### PR TITLE
Make source_id optional for CSV and JSON sources

### DIFF
--- a/cli/commands/source.py
+++ b/cli/commands/source.py
@@ -16,7 +16,9 @@ app.add_typer(database_app, name="database")
 @app.command("csv")
 def source_csv(
     path: Path = typer.Argument(..., help="Path to CSV file", exists=True, dir_okay=False, resolve_path=True),
-    source_id: str = typer.Option(..., "--id", help="Unique identifier for this source"),
+    source_id: str | None = typer.Option(
+        None, "--id", help="Unique identifier for this source (default: derived from file name)"
+    ),
     output: Path | None = typer.Option(
         None, "--output", "-o", help="Output file path (default: stdout)", dir_okay=False, resolve_path=True
     ),
@@ -29,6 +31,7 @@ def source_csv(
     """Generate source contract from CSV file.
 
     Example:
+        contract-gen source csv data/transactions.csv --output contracts/source.json --pretty
         contract-gen source csv data/transactions.csv --id transactions --output contracts/source.json --pretty
     """
     try:
@@ -78,7 +81,9 @@ def source_csv(
 @app.command("json")
 def source_json(
     path: Path = typer.Argument(..., help="Path to JSON/NDJSON file", exists=True, dir_okay=False, resolve_path=True),
-    source_id: str = typer.Option(..., "--id", help="Unique identifier for this source"),
+    source_id: str | None = typer.Option(
+        None, "--id", help="Unique identifier for this source (default: derived from file name)"
+    ),
     output: Path | None = typer.Option(
         None, "--output", "-o", help="Output file path (default: stdout)", dir_okay=False, resolve_path=True
     ),
@@ -90,6 +95,7 @@ def source_json(
     """Generate source contract from JSON or NDJSON file.
 
     Example:
+        contract-gen source json data/users.json --output contracts/source.json
         contract-gen source json data/users.json --id users --output contracts/source.json
     """
     try:

--- a/core/contract_generator.py
+++ b/core/contract_generator.py
@@ -43,18 +43,27 @@ def generate_source_analysis(source_path: str) -> dict[str, Any]:
     return analyze_csv_file(source_file)
 
 
-def generate_source_contract(source_path: str, source_id: str, config: dict[str, Any] | None = None) -> SourceContract:
+def generate_source_contract(
+    source_path: str, source_id: str | None = None, config: dict[str, Any] | None = None
+) -> SourceContract:
     """Generate a source contract describing a data source
 
     Args:
         source_path: Path to source data file
-        source_id: Unique identifier for this source (e.g., 'swedish_bank_csv')
+        source_id: Unique identifier for this source (e.g., 'swedish_bank_csv').
+                   If not provided, will be auto-generated from the file name.
         config: Optional configuration dictionary
 
     Returns:
         Source contract model
     """
     source_analysis = generate_source_analysis(source_path)
+
+    # Auto-generate source_id from file name if not provided
+    if source_id is None:
+        source_file = Path(source_path)
+        # Use stem (filename without extension) and sanitize it
+        source_id = source_file.stem.lower().replace(" ", "_").replace("-", "_")
 
     return SourceContract(
         source_id=source_id,

--- a/core/models.py
+++ b/core/models.py
@@ -29,7 +29,7 @@ class SourceContract(BaseModel):
 
     contract_version: str = Field(default="1.0", description="Version of the contract schema")
     contract_type: Literal["source"] = Field(default="source", description="Type of contract")
-    source_id: str = Field(description="Unique identifier for this source")
+    source_id: str = Field(description="Unique identifier for this source (auto-generated if not provided)")
     # File-based sources
     source_path: str | None = Field(default=None, description="Path to the source data file")
     file_format: str | None = Field(default=None, description="File format (csv, json, parquet, etc.)")

--- a/mcp_server/handlers.py
+++ b/mcp_server/handlers.py
@@ -89,14 +89,15 @@ class ContractHandler:
     def generate_source_contract(
         self,
         source_path: str,
-        source_id: str,
+        source_id: str | None = None,
         config: dict[str, object] | None = None,
     ) -> str:
         """Generate a source contract describing a data source
 
         Args:
             source_path: Absolute path to the source data file
-            source_id: Unique identifier for this source (e.g., 'swedish_bank_csv')
+            source_id: Unique identifier for this source (e.g., 'swedish_bank_csv').
+                       If not provided, will be auto-generated from the file name.
             config: Optional configuration dictionary
 
         Returns:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -43,14 +43,14 @@ async def list_tools() -> list[Tool]:
                     },
                     "source_id": {
                         "type": "string",
-                        "description": "Unique identifier for this source (e.g., 'swedish_bank_csv')",
+                        "description": "Unique identifier for this source (e.g., 'swedish_bank_csv'). If not provided, will be auto-generated from the file name.",
                     },
                     "config": {
                         "type": "object",
                         "description": "Optional configuration/metadata dictionary",
                     },
                 },
-                "required": ["source_path", "source_id"],
+                "required": ["source_path"],
             },
         ),
         Tool(

--- a/tests/core/test_contract_generator.py
+++ b/tests/core/test_contract_generator.py
@@ -115,6 +115,37 @@ class TestSourceContractGeneration:
 
         assert contract.metadata == {}
 
+    def test_generate_source_contract_auto_generated_id(self, sample_csv_path: Path) -> None:
+        """Test source contract generation with auto-generated source_id"""
+        contract = generate_source_contract(source_path=str(sample_csv_path))
+
+        # The sample_transactions.csv file should generate "sample_transactions" as source_id
+        assert contract.source_id == "sample_transactions"
+        assert contract.source_path == str(sample_csv_path)
+        assert contract.contract_type == "source"
+
+    def test_generate_source_contract_auto_generated_id_with_spaces(self, tmp_path: Path) -> None:
+        """Test source contract generation with auto-generated source_id for file with spaces"""
+        # Create a temporary CSV file with spaces in the name
+        test_file = tmp_path / "my test file.csv"
+        test_file.write_text("col1,col2\nval1,val2\n")
+
+        contract = generate_source_contract(source_path=str(test_file))
+
+        # Spaces should be converted to underscores
+        assert contract.source_id == "my_test_file"
+
+    def test_generate_source_contract_auto_generated_id_with_hyphens(self, tmp_path: Path) -> None:
+        """Test source contract generation with auto-generated source_id for file with hyphens"""
+        # Create a temporary CSV file with hyphens in the name
+        test_file = tmp_path / "my-test-file.csv"
+        test_file.write_text("col1,col2\nval1,val2\n")
+
+        contract = generate_source_contract(source_path=str(test_file))
+
+        # Hyphens should be converted to underscores
+        assert contract.source_id == "my_test_file"
+
 
 class TestDestinationContractGeneration:
     """Tests for destination contract generation"""


### PR DESCRIPTION
Data sources don't always need explicit identifiers - the ingestion pipeline or destination database can generate IDs, or data may be stored without primary keys. Requiring source_id for every contract was unnecessarily rigid.

## Changes

- Made `source_id` parameter optional in `generate_source_contract()`
- Auto-generates source_id from file name when not provided (e.g., 'transactions.csv' → 'transactions')
- Sanitizes file names by converting spaces and hyphens to underscores
- Updated CLI commands (`csv` and `json`) to make `--id` flag optional
- Updated MCP server tools to make source_id optional
- Added comprehensive tests for auto-generated IDs including edge cases

## Testing

- ✅ All 145 tests pass
- ✅ Linting passes (Ruff)
- ✅ Type checking passes (mypy)

## Example Usage

**Before** (required):
```bash
contract-gen source csv data/transactions.csv --id transactions
```

**After** (optional):
```bash
# Auto-generates source_id as "transactions"
contract-gen source csv data/transactions.csv

# Or explicitly provide an ID
contract-gen source csv data/transactions.csv --id my_custom_id
```