### PR TITLE
Increase sample size for CSV and JSON type detection to 1000 rows

### DIFF
--- a/core/contract_generator.py
+++ b/core/contract_generator.py
@@ -20,11 +20,12 @@ from core.sources.csv import analyze_csv_file
 from core.sources.json import analyze_json_file
 
 
-def generate_source_analysis(source_path: str) -> dict[str, Any]:
+def generate_source_analysis(source_path: str, sample_size: int = 1000) -> dict[str, Any]:
     """Generate automated source data analysis
 
     Args:
         source_path: Path to source data file
+        sample_size: Number of rows to sample for analysis (default: 1000)
 
     Returns:
         Dictionary with analysis results
@@ -37,10 +38,10 @@ def generate_source_analysis(source_path: str) -> dict[str, Any]:
     # Determine file type by extension
     suffix = source_file.suffix.lower()
     if suffix in [".json", ".jsonl", ".ndjson"]:
-        return analyze_json_file(source_file)
+        return analyze_json_file(source_file, sample_size=sample_size)
 
     # Default to CSV analysis
-    return analyze_csv_file(source_file)
+    return analyze_csv_file(source_file, sample_size=sample_size)
 
 
 def generate_source_contract(
@@ -52,12 +53,15 @@ def generate_source_contract(
         source_path: Path to source data file
         source_id: Unique identifier for this source (e.g., 'swedish_bank_csv').
                    If not provided, will be auto-generated from the file name.
-        config: Optional configuration dictionary
+        config: Optional configuration dictionary (can include 'sample_size')
 
     Returns:
         Source contract model
     """
-    source_analysis = generate_source_analysis(source_path)
+    # Extract sample_size from config, default to 1000
+    sample_size = config.get("sample_size", 1000) if config else 1000
+
+    source_analysis = generate_source_analysis(source_path, sample_size=sample_size)
 
     # Auto-generate source_id from file name if not provided
     if source_id is None:

--- a/core/sources/csv.py
+++ b/core/sources/csv.py
@@ -19,17 +19,26 @@ def detect_delimiter(file_path: str, encoding: str) -> str:
             return ","  # Default fallback
 
 
-def analyze_csv_file(source_file: Path) -> dict[str, Any]:
-    """Analyze CSV file content."""
+def analyze_csv_file(source_file: Path, sample_size: int = 1000) -> dict[str, Any]:
+    """Analyze CSV file content.
+
+    Args:
+        source_file: Path to the CSV file
+        sample_size: Number of rows to sample for type detection (default: 1000)
+
+    Returns:
+        Dictionary with analysis results
+    """
     encoding = detect_file_encoding(str(source_file))
     delimiter = detect_delimiter(str(source_file), encoding)
 
-    # Read sample rows
+    # Read sample rows (header + sample_size data rows)
     sample_rows = []
+    max_rows_to_read = sample_size + 1  # +1 for header
     with source_file.open(encoding=encoding) as f:
         reader = csv.reader(f, delimiter=delimiter)
         for i, row in enumerate(reader):
-            if i >= 10:  # Sample first 10 rows
+            if i >= max_rows_to_read:
                 break
             sample_rows.append(row)
 

--- a/core/sources/json.py
+++ b/core/sources/json.py
@@ -7,8 +7,16 @@ from typing import Any
 from core.sources.utils import detect_data_types_from_multiple_rows, detect_file_encoding
 
 
-def analyze_json_file(source_file: Path) -> dict[str, Any]:
-    """Analyze JSON or NDJSON file content."""
+def analyze_json_file(source_file: Path, sample_size: int = 1000) -> dict[str, Any]:
+    """Analyze JSON or NDJSON file content.
+
+    Args:
+        source_file: Path to the JSON/NDJSON file
+        sample_size: Number of objects to sample for type detection (default: 1000)
+
+    Returns:
+        Dictionary with analysis results
+    """
     encoding = detect_file_encoding(str(source_file))
     issues = []
 
@@ -27,7 +35,7 @@ def analyze_json_file(source_file: Path) -> dict[str, Any]:
                 try:
                     data = json.load(f)
                     if isinstance(data, list):
-                        data_objects = data[:10]  # Sample first 10
+                        data_objects = data[:sample_size]  # Sample first N objects
                         total_rows = len(data)
                     else:
                         issues.append("JSON root is not a list")
@@ -40,7 +48,7 @@ def analyze_json_file(source_file: Path) -> dict[str, Any]:
                     line = line.strip()
                     if not line:
                         continue
-                    if i < 10:
+                    if len(data_objects) < sample_size:
                         try:
                             data_objects.append(json.loads(line))
                         except json.JSONDecodeError:


### PR DESCRIPTION
## Problem

Type detection was only sampling 10 rows which caused sparse columns to be
incorrectly marked as 'empty' when their first non-null value appeared later
in the file. For example, a 'Resultat' column with values starting at row 12
would be detected as empty with only 10 rows sampled.

## Solution

Now samples 1000 rows by default (configurable via sample_size parameter)
which matches the default used by database source analysis. This ensures
more accurate type detection for columns with sparse data while maintaining
reasonable performance for typical files.

## Changes

- Updated `analyze_csv_file()` to accept `sample_size` parameter (default: 1000)
- Updated `analyze_json_file()` to accept `sample_size` parameter (default: 1000)
- Modified `generate_source_analysis()` to accept and pass through sample_size
- Updated `generate_source_contract()` to extract sample_size from config

## Testing

- ✅ All 146 tests pass
- ✅ Verified with real-world CSV file with sparse columns
- ✅ Type checking passes (mypy)
- ✅ Linting passes (Ruff)

## Example

Before (10 rows): Sparse columns detected as "empty"
After (1000 rows): Sparse columns correctly detected as "numeric"

Fixes issue where columns like "Valutakurs" and "Resultat" were incorrectly typed as empty when they had values starting at row 10+.