### PR TITLE
Refine contract schemas for LLM-friendly structure and slimmer serialization

### DIFF
--- a/cli/commands/destination.py
+++ b/cli/commands/destination.py
@@ -29,7 +29,7 @@ def destination_csv(
         contract = generate_destination_contract(destination_id=destination_id, config=None)
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except ValueError as e:
@@ -84,7 +84,7 @@ def destination_database(
         )
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except ValueError as e:
@@ -138,7 +138,7 @@ def generate_api_contract(
         )
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except ValueError as e:

--- a/cli/commands/source.py
+++ b/cli/commands/source.py
@@ -65,7 +65,7 @@ def source_csv(
         contract = generate_source_contract(source_path=str(path.absolute()), source_id=source_id, config=config_dict)
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except FileNotFoundError as e:
@@ -125,7 +125,7 @@ def source_json(
         contract = generate_source_contract(source_path=str(path.absolute()), source_id=source_id, config=config_dict)
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except FileNotFoundError as e:

--- a/mcp_server/handlers.py
+++ b/mcp_server/handlers.py
@@ -63,7 +63,7 @@ def save_contract(contract: Contract, contract_path: str) -> bool:
         path = Path(contract_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as file:
-            file.write(contract.model_dump_json(indent=2, exclude_none=False, by_alias=True))
+            file.write(contract.model_dump_json(indent=2, exclude_none=True, by_alias=True))
             return True
     except (OSError, TypeError):
         return False
@@ -112,7 +112,7 @@ class ContractHandler:
 
         try:
             contract = generate_source_contract(str(source_full_path), source_id, config)
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
         except (ValueError, OSError, ValidationError) as e:
             return json.dumps({"error": f"Failed to generate source contract: {e!s}"}, indent=2)
 
@@ -134,7 +134,7 @@ class ContractHandler:
         """
         try:
             contract = generate_destination_contract(destination_id, schema, config)
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
         except (ValueError, TypeError, ValidationError) as e:
             return json.dumps({"error": f"Failed to generate destination contract: {e!s}"}, indent=2)
 
@@ -158,7 +158,7 @@ class ContractHandler:
         """
         try:
             contract = generate_transformation_contract(transformation_id, source_ref, destination_ref, config)
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
         except (ValueError, TypeError, ValidationError) as e:
             return json.dumps({"error": f"Failed to generate transformation contract: {e!s}"}, indent=2)
 
@@ -209,7 +209,7 @@ class ContractHandler:
 
             # Note: We don't include the connection string in the contract for security
             # It should be managed externally
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
 
         except ValueError as e:
             return json.dumps({"error": f"Validation error: {e!s}"}, indent=2)
@@ -294,7 +294,7 @@ class ContractHandler:
 
             # Convert to JSON-serializable format
             contracts_data = [
-                contract.model_dump(mode="json", by_alias=True, exclude_none=False) for contract in contracts
+                contract.model_dump(mode="json", by_alias=True, exclude_none=True) for contract in contracts
             ]
 
             return json.dumps({"contracts": contracts_data, "count": len(contracts)}, indent=2)

--- a/tests/cli/test_destination_api.py
+++ b/tests/cli/test_destination_api.py
@@ -68,17 +68,31 @@ def test_destination_api_cli_with_openapi_schema(tmp_path: Path) -> None:
 
     expected_contract = {
         "contract_type": "destination",
-        "contract_version": "1.0",
+        "contract_version": "2.0",
         "destination_id": "users_api",
         "schema": {
-            "fields": ["name", "email", "age", "active"],
-            "types": ["text", "email", "integer", "boolean"],
-            "constraints": {
-                "name": ["REQUIRED", "MIN_LENGTH: 1", "MAX_LENGTH: 100"],
-                "email": ["REQUIRED"],
-                "age": ["REQUIRED", "MIN: 0", "MAX: 150"],
-                "active": ["REQUIRED"],
-            },
+            "fields": [
+                {
+                    "name": "name",
+                    "type": "text",
+                    "constraints": ["REQUIRED", "MIN_LENGTH: 1", "MAX_LENGTH: 100"],
+                },
+                {
+                    "name": "email",
+                    "type": "email",
+                    "constraints": ["REQUIRED"],
+                },
+                {
+                    "name": "age",
+                    "type": "integer",
+                    "constraints": ["REQUIRED", "MIN: 0", "MAX: 150"],
+                },
+                {
+                    "name": "active",
+                    "type": "boolean",
+                    "constraints": ["REQUIRED"],
+                },
+            ],
         },
         "metadata": {
             "destination_type": "api",
@@ -86,12 +100,7 @@ def test_destination_api_cli_with_openapi_schema(tmp_path: Path) -> None:
             "http_method": "POST",
             "schema_file": str(schema_file),
         },
-        "validation_rules": {
-            "required_fields": [],
-            "unique_constraints": [],
-            "format_validation": {},
-            "data_range_checks": {},
-        },
+        "validation_rules": {"rules": []},
     }
 
     assert contract == expected_contract
@@ -146,12 +155,19 @@ paths:
 
     expected_contract = {
         "contract_type": "destination",
-        "contract_version": "1.0",
+        "contract_version": "2.0",
         "destination_id": "data_api",
         "schema": {
-            "fields": ["id", "value"],
-            "types": ["uuid", "float"],
-            "constraints": {},
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "uuid",
+                },
+                {
+                    "name": "value",
+                    "type": "float",
+                },
+            ],
         },
         "metadata": {
             "destination_type": "api",
@@ -159,12 +175,7 @@ paths:
             "http_method": "POST",
             "schema_file": str(schema_file),
         },
-        "validation_rules": {
-            "required_fields": [],
-            "unique_constraints": [],
-            "format_validation": {},
-            "data_range_checks": {},
-        },
+        "validation_rules": {"rules": []},
     }
 
     assert contract == expected_contract

--- a/tests/core/sources/database/test_analyzer.py
+++ b/tests/core/sources/database/test_analyzer.py
@@ -173,18 +173,20 @@ def test_generate_database_source_contract_from_table(sqlite_db: str) -> None:
 
     # Check schema
     schema = contract.data_schema
-    assert "id" in schema.fields
-    assert "username" in schema.fields
-    assert "email" in schema.fields
-    assert "age" in schema.fields
-    assert "balance" in schema.fields
+    field_names = {field.name for field in schema.fields}
+    assert "id" in field_names
+    assert "username" in field_names
+    assert "email" in field_names
+    assert "age" in field_names
+    assert "balance" in field_names
 
     # Check that types are mapped correctly
-    assert len(schema.fields) == len(schema.data_types)
+    assert len(schema.fields) == len(field_names)
 
     # Check quality metrics
-    assert contract.quality_metrics.total_rows == 3
-    assert len(contract.quality_metrics.sample_data) <= 10
+    assert contract.quality_metrics.observed is not None
+    assert contract.quality_metrics.observed.total_rows == 3
+    assert len(contract.quality_metrics.observed.sample_data) <= 10
 
     # Check metadata
     assert contract.metadata.get("database_type") == "sqlite"
@@ -214,10 +216,11 @@ def test_generate_database_source_contract_from_query(sqlite_db: str) -> None:
 
     # Check schema - should only have selected columns
     schema = contract.data_schema
-    assert set(schema.fields) == {"username", "email", "age"}
+    assert {field.name for field in schema.fields} == {"username", "email", "age"}
 
     # Check quality metrics - should only have active users
-    assert contract.quality_metrics.total_rows == 2
+    assert contract.quality_metrics.observed is not None
+    assert contract.quality_metrics.observed.total_rows == 2
 
 
 def test_generate_database_source_contract_with_sample_size(sqlite_db: str) -> None:
@@ -232,8 +235,9 @@ def test_generate_database_source_contract_with_sample_size(sqlite_db: str) -> N
     )
 
     # Should limit sample data but not affect total count
-    assert contract.quality_metrics.total_rows == 3
-    assert len(contract.quality_metrics.sample_data) <= 10  # We always limit display to 10
+    assert contract.quality_metrics.observed is not None
+    assert contract.quality_metrics.observed.total_rows == 3
+    assert len(contract.quality_metrics.observed.sample_data) <= 10  # We always limit display to 10
     assert contract.metadata.get("sample_size") == 1
 
 

--- a/tests/core/test_contract_generator.py
+++ b/tests/core/test_contract_generator.py
@@ -111,7 +111,7 @@ class TestSourceContractGeneration:
             source_path=str(sample_csv_path), source_id="test_transactions", config={"note": "test"}
         )
 
-        assert contract.contract_version == "1.0"
+        assert contract.contract_version == "2.0"
         assert contract.contract_type == "source"
         assert contract.source_id == "test_transactions"
         assert contract.source_path == str(sample_csv_path)
@@ -122,13 +122,13 @@ class TestSourceContractGeneration:
 
         # Check schema
         assert contract.data_schema.fields is not None
-        assert contract.data_schema.data_types is not None
         assert len(contract.data_schema.fields) == 5
 
         # Check quality metrics
-        assert contract.quality_metrics.total_rows == 11  # Includes blank line at end of file
-        assert isinstance(contract.quality_metrics.sample_data, list)
-        assert contract.quality_metrics.issues == []
+        assert contract.quality_metrics.observed is not None
+        assert contract.quality_metrics.observed.total_rows == 11  # Includes blank line at end of file
+        assert isinstance(contract.quality_metrics.observed.sample_data, list)
+        assert contract.quality_metrics.observed.issues == []
 
         # Check metadata
         assert contract.metadata == {"note": "test"}
@@ -186,13 +186,13 @@ class TestDestinationContractGeneration:
             destination_id="test_dest", schema=schema, config={"database": "postgres"}
         )
 
-        assert contract.contract_version == "1.0"
+        assert contract.contract_version == "2.0"
         assert contract.contract_type == "destination"
         assert contract.destination_id == "test_dest"
-        assert contract.data_schema.fields == ["id", "date", "amount"]
-        assert contract.data_schema.types == ["uuid", "date", "decimal"]
-        assert contract.data_schema.constraints == {"id": "primary_key"}
-        assert contract.validation_rules.required_fields == []
+        assert [field.name for field in contract.data_schema.fields] == ["id", "date", "amount"]
+        assert [field.type for field in contract.data_schema.fields] == ["uuid", "date", "decimal"]
+        assert contract.data_schema.fields[0].constraints == ["primary_key"]
+        assert contract.validation_rules.rules == []
         assert contract.metadata == {"database": "postgres"}
 
     def test_generate_destination_contract_without_schema(self) -> None:
@@ -201,8 +201,6 @@ class TestDestinationContractGeneration:
 
         assert contract.contract_type == "destination"
         assert contract.data_schema.fields == []
-        assert contract.data_schema.types == []
-        assert contract.data_schema.constraints == {}
         assert contract.metadata == {}
 
 
@@ -218,16 +216,15 @@ class TestTransformationContractGeneration:
             config={"batch_size": 500, "error_threshold": 0.05},
         )
 
-        assert contract.contract_version == "1.0"
+        assert contract.contract_version == "2.0"
         assert contract.contract_type == "transformation"
         assert contract.transformation_id == "test_transform"
         assert contract.source_ref == "source_1"
         assert contract.destination_ref == "dest_1"
 
         # Check empty mappings/transformations (to be filled by agent)
-        assert contract.field_mappings == {}
-        assert contract.transformations == {}
-        assert contract.enrichment == {}
+        assert contract.mapping == []
+        assert contract.transformations == []
         assert contract.business_rules == []
 
         # Check execution plan with custom config

--- a/tests/core/test_contract_generator_data_quality.py
+++ b/tests/core/test_contract_generator_data_quality.py
@@ -40,12 +40,13 @@ class TestBOMHandling:
         contract = generate_source_contract(str(csv_file), "test_bom")
 
         # Check that BOM is not in the schema fields
-        assert contract.data_schema.fields[0] == "Datum"
-        assert "\ufeff" not in contract.data_schema.fields[0]
+        assert contract.data_schema.fields[0].name == "Datum"
+        assert "\ufeff" not in contract.data_schema.fields[0].name
 
         # Check that BOM presence is noted in quality issues
-        assert len(contract.quality_metrics.issues) > 0
-        assert any("BOM" in issue for issue in contract.quality_metrics.issues)
+        assert contract.quality_metrics.observed is not None
+        assert len(contract.quality_metrics.observed.issues) > 0
+        assert any("BOM" in issue for issue in contract.quality_metrics.observed.issues)
 
 
 class TestDataTypeDetection:
@@ -167,14 +168,14 @@ class TestAvanzaRealDataIssues:
         contract = generate_source_contract(str(csv_file), "avanza_transactions")
 
         # Test BOM is stripped
-        assert contract.data_schema.fields[0] == "Datum"
-        assert "\ufeff" not in contract.data_schema.fields[0]
+        assert contract.data_schema.fields[0].name == "Datum"
+        assert "\ufeff" not in contract.data_schema.fields[0].name
 
         # Test proper delimiter detection
         assert contract.delimiter == ";"
 
         # Test data type detection (should scan multiple rows)
-        types = contract.data_schema.data_types
+        types = [field.type for field in contract.data_schema.fields]
         assert types[0] == "date", "Datum should be date"
         assert types[1] == "text", "Konto should be text"
         assert types[4] == "numeric", "Antal should be numeric (has 190, 22)"
@@ -189,5 +190,5 @@ class TestAvanzaRealDataIssues:
         populated_columns = [0, 1, 4, 5, 6, 8, 9, 10, 11]  # Columns that have data
         for col_idx in populated_columns:
             assert types[col_idx] != "empty", (
-                f"Column {col_idx} ({contract.data_schema.fields[col_idx]}) should not be 'empty'"
+                f"Column {col_idx} ({contract.data_schema.fields[col_idx].name}) should not be 'empty'"
             )

--- a/tests/mcp/test_handlers.py
+++ b/tests/mcp/test_handlers.py
@@ -90,7 +90,7 @@ class TestContractValidation:
         """Test that Pydantic catches invalid field types"""
         from pydantic import ValidationError
 
-        from core.models import QualityMetrics, SourceSchema
+        from core.models import ObservedQuality, QualityMetrics, SourceSchema
 
         # Invalid type for total_rows (should be int >= 0)
         with pytest.raises(ValidationError):
@@ -98,8 +98,10 @@ class TestContractValidation:
                 source_id="test",
                 source_path="/path/to/file.csv",
                 file_format="csv",
-                schema=SourceSchema(fields=[], data_types=[]),
-                quality_metrics=QualityMetrics(total_rows=-1),  # Invalid: negative
+                schema=SourceSchema(fields=[]),
+                quality_metrics=QualityMetrics(
+                    observed=ObservedQuality(total_rows=-1, sample_data=[], issues=[])
+                ),  # Invalid: negative
             )
 
 


### PR DESCRIPTION
### Motivation
- Make contract payloads more explicit and LLM-friendly by eliminating parallel arrays and free-form dicts.  
- Provide per-field metadata, per-field profiling, and explicit expected vs observed quality to improve grounding and safe automation.  
- Offer typed primitives for mappings, transformations and validation rules so LLMs can reason over and generate contracts consistently.  
- Reduce noise in serialized output by omitting null/optional fields to produce compact, readable contracts.

### Description
- Replace parallel `fields`/`types` arrays with `FieldDefinition` objects and adjust `SourceSchema`/`DestinationSchema` to use `schema.fields: list[FieldDefinition]`.  
- Introduce structured quality models `ObservedQuality`, `ExpectedQuality`, and `FieldMetric`, and change `QualityMetrics` to expose `observed`/`expected` blocks.  
- Add typed primitives `ValidationRule`, `FieldMapping`, and `TransformationStep`, change transformation contract to use `mapping`/`transformations` (aliased to `field_mappings`), and bump default `contract_version` to `2.0`.  
- Update generators and database introspection to emit the new shapes, and trim serialized output by using `exclude_none=True` in CLI/MCP serialization paths so null optional fields are omitted.

### Testing
- Unit tests under `tests/` were updated to match the new schema shapes and expectations (fixtures, assertions, and API destination test payloads were adjusted).  
- Serialization calls were adjusted in CLI and MCP handlers to use `exclude_none=True`, and tests were aligned to expect the slimmer JSON.  
- No automated test suite (e.g., `pytest`) was executed as part of this change.  
- Manual review: code paths for source/destination generation and database introspection were updated to construct `FieldDefinition` instances and structured quality objects to maintain behavioral parity with prior outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948492e545c832087984ef70714cced)