### PR TITLE
Remove contract_version and exclude null values from JSON output

### DIFF
--- a/cli/commands/destination.py
+++ b/cli/commands/destination.py
@@ -29,7 +29,7 @@ def destination_csv(
         contract = generate_destination_contract(destination_id=destination_id, config=None)
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except ValueError as e:
@@ -84,7 +84,7 @@ def destination_database(
         )
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except ValueError as e:
@@ -143,7 +143,7 @@ def generate_api_contract(
         )
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except ValueError as e:

--- a/cli/commands/source.py
+++ b/cli/commands/source.py
@@ -71,7 +71,7 @@ def source_csv(
         contract = generate_source_contract(source_path=str(path.absolute()), source_id=source_id, config=config_dict)
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except FileNotFoundError:
@@ -146,7 +146,7 @@ def source_json(
         contract = generate_source_contract(source_path=str(path.absolute()), source_id=source_id, config=config_dict)
 
         # Output
-        contract_json = contract.model_dump_json(by_alias=True)
+        contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
         output_contract(contract_json, output_path=output, output_format=output_format, pretty=pretty)
 
     except FileNotFoundError:

--- a/core/models.py
+++ b/core/models.py
@@ -229,7 +229,6 @@ class QualityMetrics(BaseModel):
 class SourceContract(BaseModel):
     """Contract describing a data source"""
 
-    contract_version: str = Field(default="2.0", description="Version of the contract schema")
     contract_type: Literal["source"] = Field(default="source", description="Type of contract")
     source_id: str = Field(description="Unique identifier for this source (auto-generated if not provided)")
     # File-based sources
@@ -285,7 +284,6 @@ class ValidationRules(BaseModel):
 class DestinationContract(BaseModel):
     """Contract describing a data destination"""
 
-    contract_version: str = Field(default="2.0", description="Version of the contract schema")
     contract_type: Literal["destination"] = Field(default="destination", description="Type of contract")
     destination_id: str = Field(description="Unique identifier for this destination")
     data_schema: DestinationSchema = Field(description="Schema definition", alias="schema")
@@ -323,7 +321,6 @@ class ExecutionPlan(BaseModel):
 class TransformationContract(BaseModel):
     """Contract describing a data transformation from source to destination"""
 
-    contract_version: str = Field(default="2.0", description="Version of the contract schema")
     contract_type: Literal["transformation"] = Field(default="transformation", description="Type of contract")
     transformation_id: str = Field(description="Unique identifier for this transformation")
     source_ref: str = Field(description="Reference to source contract ID")

--- a/mcp_server/handlers.py
+++ b/mcp_server/handlers.py
@@ -63,7 +63,7 @@ def save_contract(contract: Contract, contract_path: str) -> bool:
         path = Path(contract_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as file:
-            file.write(contract.model_dump_json(indent=2, exclude_none=False, by_alias=True))
+            file.write(contract.model_dump_json(indent=2, exclude_none=True, by_alias=True))
             return True
     except (OSError, TypeError):
         return False
@@ -112,7 +112,7 @@ class ContractHandler:
 
         try:
             contract = generate_source_contract(str(source_full_path), source_id, config)
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
         except (ValueError, OSError, ValidationError) as e:
             return json.dumps({"error": f"Failed to generate source contract: {e!s}"}, indent=2)
 
@@ -134,7 +134,7 @@ class ContractHandler:
         """
         try:
             contract = generate_destination_contract(destination_id, schema, config)
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
         except (ValueError, TypeError, ValidationError) as e:
             return json.dumps({"error": f"Failed to generate destination contract: {e!s}"}, indent=2)
 
@@ -158,7 +158,7 @@ class ContractHandler:
         """
         try:
             contract = generate_transformation_contract(transformation_id, source_ref, destination_ref, config)
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
         except (ValueError, TypeError, ValidationError) as e:
             return json.dumps({"error": f"Failed to generate transformation contract: {e!s}"}, indent=2)
 
@@ -209,7 +209,7 @@ class ContractHandler:
 
             # Note: We don't include the connection string in the contract for security
             # It should be managed externally
-            return contract.model_dump_json(indent=2, exclude_none=False, by_alias=True)
+            return contract.model_dump_json(indent=2, exclude_none=True, by_alias=True)
 
         except ValueError as e:
             return json.dumps({"error": f"Validation error: {e!s}"}, indent=2)
@@ -294,7 +294,7 @@ class ContractHandler:
 
             # Convert to JSON-serializable format
             contracts_data = [
-                contract.model_dump(mode="json", by_alias=True, exclude_none=False) for contract in contracts
+                contract.model_dump(mode="json", by_alias=True, exclude_none=True) for contract in contracts
             ]
 
             return json.dumps({"contracts": contracts_data, "count": len(contracts)}, indent=2)
@@ -356,7 +356,6 @@ class ContractHandler:
         result = {
             "valid": len(issues) == 0,
             "contract_path": contract_path,
-            "contract_version": contract.contract_version,
             "contract_type": contract.contract_type,
         }
 

--- a/tests/cli/test_destination_api.py
+++ b/tests/cli/test_destination_api.py
@@ -65,7 +65,6 @@ def test_destination_api_cli_with_openapi_schema(tmp_path: Path) -> None:
     assert output_file.exists()
 
     contract = json.loads(output_file.read_text())
-    assert contract["contract_version"] == "2.0"
     assert contract["destination_id"] == "users_api"
 
     fields = contract["schema"]["fields"]
@@ -148,7 +147,6 @@ paths:
     assert output_file.exists()
 
     contract = json.loads(output_file.read_text())
-    assert contract["contract_version"] == "2.0"
 
     field_names = [f["name"] for f in contract["schema"]["fields"]]
     assert "id" in field_names

--- a/tests/core/test_contract_generator.py
+++ b/tests/core/test_contract_generator.py
@@ -111,7 +111,6 @@ class TestSourceContractGeneration:
             source_path=str(sample_csv_path), source_id="test_transactions", config={"note": "test"}
         )
 
-        assert contract.contract_version == "2.0"
         assert contract.contract_type == "source"
         assert contract.source_id == "test_transactions"
         assert contract.source_path == str(sample_csv_path)
@@ -187,7 +186,6 @@ class TestDestinationContractGeneration:
             destination_id="test_dest", schema=schema, config={"database": "postgres"}
         )
 
-        assert contract.contract_version == "2.0"
         assert contract.contract_type == "destination"
         assert contract.destination_id == "test_dest"
         assert len(contract.data_schema.fields) == 3
@@ -217,7 +215,6 @@ class TestTransformationContractGeneration:
             config={"batch_size": 500, "error_threshold": 0.05},
         )
 
-        assert contract.contract_version == "2.0"
         assert contract.contract_type == "transformation"
         assert contract.transformation_id == "test_transform"
         assert contract.source_ref == "source_1"


### PR DESCRIPTION
## Problem

Contract JSON output contains unnecessary noise that makes contracts harder to read:
1. **contract_version field** appears in every contract but adds no value since version is tracked in the codebase
2. **Null fields** clutter the output with inapplicable fields (e.g., `database_type: null` for CSV files, `source_type: null` for files)

## Solution

### Remove contract_version field
- Removed from all contract models: SourceContract, DestinationContract, TransformationContract
- Version is managed in the codebase, not needed in each contract instance
- Updated all tests to remove contract_version assertions

### Exclude null values from output
- Set `exclude_none=True` for all JSON serialization in CLI commands
- Set `exclude_none=True` for all MCP server handlers
- Only relevant fields are now included in output

## Result

**Before:**
```json
{
  "contract_version": "2.0",        // ❌ Removed (unnecessary)
  "contract_type": "source",
  "source_id": "...",
  "file_format": "csv",
  "delimiter": ";",
  "database_type": null,            // ❌ Clutter (not applicable)
  "source_type": null,              // ❌ Clutter
  "source_name": null,              // ❌ Clutter
  "database_schema": null,          // ❌ Clutter
  ...
}
```

**After:**
```json
{
  "contract_type": "source",        // ✓ Clean
  "source_id": "...",
  "file_format": "csv",
  "encoding": "utf-8",
  "delimiter": ";",                 // ✓ Only relevant fields
  "has_header": true,
  ...
}
```

## Testing
- All 161 tests pass
- Linting and type checking clean
- Verified output with real CSV file