### PR TITLE
Refactor: Eliminate redundant file type discovery in source contract generation

### DIFF
--- a/cli/commands/source.py
+++ b/cli/commands/source.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import typer
 
 from cli.output import error_message, handle_permission_error, output_contract
-from core.contract_generator import generate_source_contract
+from core.contract_generator import (
+    generate_csv_source_contract,
+    generate_json_source_contract,
+)
 from core.models import TableInfo
 from core.sources.database.relationships import list_database_tables
 
@@ -56,19 +59,15 @@ def source_csv(
         if pretty is None:
             pretty = output_defaults.pretty
 
-        # Build config dict with sample_size for analysis
-        # delimiter and encoding will be auto-detected by the analyzer
-        config_dict: dict[str, str | int] = {"sample_size": sample_size}
-
-        # If user explicitly provided delimiter or encoding, add them to config as overrides
-        # These will be used by the analyzer instead of auto-detection
-        if delimiter is not None:
-            config_dict["delimiter"] = delimiter
-        if encoding is not None:
-            config_dict["encoding"] = encoding
-
-        # Generate contract
-        contract = generate_source_contract(source_path=str(path.absolute()), source_id=source_id, config=config_dict)
+        # Generate contract using type-specific function - no type discovery needed
+        contract = generate_csv_source_contract(
+            source_path=str(path.absolute()),
+            source_id=source_id,
+            delimiter=delimiter,
+            encoding=encoding,
+            sample_size=sample_size,
+            config=None,
+        )
 
         # Output
         contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)
@@ -133,17 +132,14 @@ def source_json(
         if pretty is None:
             pretty = output_defaults.pretty
 
-        # Build config dict with sample_size for analysis
-        # encoding will be auto-detected by the analyzer
-        config_dict: dict[str, str | int] = {"sample_size": sample_size}
-
-        # If user explicitly provided encoding, add it to config as an override
-        # This will be used by the analyzer instead of auto-detection
-        if encoding is not None:
-            config_dict["encoding"] = encoding
-
-        # Generate contract
-        contract = generate_source_contract(source_path=str(path.absolute()), source_id=source_id, config=config_dict)
+        # Generate contract using type-specific function - no type discovery needed
+        contract = generate_json_source_contract(
+            source_path=str(path.absolute()),
+            source_id=source_id,
+            encoding=encoding,
+            sample_size=sample_size,
+            config=None,
+        )
 
         # Output
         contract_json = contract.model_dump_json(by_alias=True, exclude_none=True)

--- a/core/README.md
+++ b/core/README.md
@@ -38,20 +38,28 @@ To use these tools with Cursor, add to `.cursor/mcp.json`:
 
 ### Contract Generation
 
-1. **generate_source_contract** - Generate a source contract from a data file
-   - Automatically analyzes file format, encoding, schema, and quality
-   - Returns: JSON contract with `contract_type: "source"`
+1. **generate_csv_source_contract** - Generate a source contract from a CSV file
+   - Analyzes CSV format, encoding, delimiter, schema, and quality
+   - Returns: CSVSourceContract
 
-2. **generate_database_source_contract** - Generate a source contract from a database table or query
+2. **generate_json_source_contract** - Generate a source contract from a JSON/NDJSON file
+   - Analyzes JSON format, encoding, schema, and quality
+   - Returns: JSONSourceContract
+
+3. **generate_source_analysis** - Analyze a file to determine its type and extract metadata
+   - Content-based file type detection
+   - Returns: SourceAnalysisResult with file_type, schema, and quality metrics
+
+4. **generate_database_source_contract** - Generate a source contract from a database table or query
    - Supports PostgreSQL, MySQL, and SQLite
    - Analyzes schema, types, and samples data
    - Returns: JSON contract with `contract_type: "source"`
 
-3. **generate_destination_contract** - Generate a destination contract
+5. **generate_destination_contract** - Generate a destination contract
    - Define target schema, validation rules, and constraints
    - Returns: JSON contract with `contract_type: "destination"`
 
-4. **generate_transformation_contract** - Generate a transformation contract
+6. **generate_transformation_contract** - Generate a transformation contract
    - Maps source to destination with transformation rules
    - Returns: JSON contract with `contract_type: "transformation"`
 
@@ -124,10 +132,16 @@ contract = generate_database_source_contract(
 
 ```python
 # 1. Generate source contract from CSV file
-source_contract = generate_source_contract(
+source_contract = generate_csv_source_contract(
     source_path="/path/to/data.csv",
     source_id="swedish_bank_csv"
 )
+
+# Or for JSON files:
+# source_contract = generate_json_source_contract(
+#     source_path="/path/to/data.json",
+#     source_id="swedish_bank_json"
+# )
 
 # 2. Generate destination contract
 dest_contract = generate_destination_contract(

--- a/tests/core/test_contract_generator.py
+++ b/tests/core/test_contract_generator.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import pytest
 
 from core.contract_generator import (
+    generate_csv_source_contract,
     generate_destination_contract,
     generate_source_analysis,
-    generate_source_contract,
     generate_transformation_contract,
 )
 from core.models import CSVSourceContract
@@ -108,7 +108,7 @@ class TestSourceContractGeneration:
 
     def test_generate_source_contract(self, sample_csv_path: Path) -> None:
         """Test source contract generation from CSV file"""
-        contract = generate_source_contract(
+        contract = generate_csv_source_contract(
             source_path=str(sample_csv_path), source_id="test_transactions", config={"note": "test"}
         )
 
@@ -138,13 +138,13 @@ class TestSourceContractGeneration:
 
     def test_generate_source_contract_no_config(self, sample_csv_path: Path) -> None:
         """Test source contract generation without config"""
-        contract = generate_source_contract(source_path=str(sample_csv_path), source_id="test_source")
+        contract = generate_csv_source_contract(source_path=str(sample_csv_path), source_id="test_source")
 
         assert contract.metadata == {}
 
     def test_generate_source_contract_auto_generated_id(self, sample_csv_path: Path) -> None:
         """Test source contract generation with auto-generated source_id"""
-        contract = generate_source_contract(source_path=str(sample_csv_path))
+        contract = generate_csv_source_contract(source_path=str(sample_csv_path))
 
         # The sample_transactions.csv file should generate "sample_transactions" as source_id
         assert contract.source_id == "sample_transactions"
@@ -160,7 +160,7 @@ class TestSourceContractGeneration:
         test_file = tmp_path / "my test file.csv"
         test_file.write_text("col1,col2\nval1,val2\n")
 
-        contract = generate_source_contract(source_path=str(test_file))
+        contract = generate_csv_source_contract(source_path=str(test_file))
 
         # Spaces should be converted to underscores
         assert contract.source_id == "my_test_file"
@@ -171,7 +171,7 @@ class TestSourceContractGeneration:
         test_file = tmp_path / "my-test-file.csv"
         test_file.write_text("col1,col2\nval1,val2\n")
 
-        contract = generate_source_contract(source_path=str(test_file))
+        contract = generate_csv_source_contract(source_path=str(test_file))
 
         # Hyphens should be converted to underscores
         assert contract.source_id == "my_test_file"

--- a/tests/core/test_contract_generator_data_quality.py
+++ b/tests/core/test_contract_generator_data_quality.py
@@ -10,8 +10,8 @@ These tests ensure proper handling of:
 from pathlib import Path
 
 from core.contract_generator import (
+    generate_csv_source_contract,
     generate_source_analysis,
-    generate_source_contract,
 )
 from core.models import CSVSourceContract
 from core.sources.utils import detect_data_types
@@ -38,7 +38,7 @@ class TestBOMHandling:
         csv_file = tmp_path / "bom_contract.csv"
         csv_file.write_text(csv_content, encoding="utf-8")
 
-        contract = generate_source_contract(str(csv_file), "test_bom")
+        contract = generate_csv_source_contract(str(csv_file), "test_bom")
 
         # Check that BOM is not in the schema fields
         assert contract.data_schema.fields[0].name == "Datum"
@@ -165,7 +165,7 @@ class TestAvanzaRealDataIssues:
         csv_file = tmp_path / "avanza.csv"
         csv_file.write_text(csv_content, encoding="utf-8")
 
-        contract = generate_source_contract(str(csv_file), "avanza_transactions")
+        contract = generate_csv_source_contract(str(csv_file), "avanza_transactions")
 
         # Test BOM is stripped
         assert contract.data_schema.fields[0].name == "Datum"


### PR DESCRIPTION
## Summary

This PR implements Option A from issue #48: creating type-specific functions for CSV and JSON source contract generation to eliminate redundant file type discovery.

## Changes

- **Created type-specific functions** in `core/contract_generator.py`:
  - `generate_csv_source_contract()` - directly calls `analyze_csv_file()` without type discovery
  - `generate_json_source_contract()` - directly calls `analyze_json_file()` without type discovery
  - Removed `generate_source_contract()` - replaced by above

- **Updated CLI commands** (`cli/commands/source.py`):
  - CSV command now calls `generate_csv_source_contract()` directly
  - JSON command now calls `generate_json_source_contract()` directly
  - Eliminates redundant type discovery when user explicitly specifies type via subcommand

## Benefits

- ✅ No redundant type discovery when type is known (CLI subcommands)
- ✅ Better type safety with specific return types (`CSVSourceContract` vs `CSVSourceContract | JSONSourceContract`)
- ✅ Consistent with database source pattern (`generate_database_source_contract()`)
- ✅ Easier to add type-specific parameters in the future

Closes #48