### PR TITLE
Use PostgREST OpenAPI schema for proper Supabase introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ contract-gen source database postgresql --conn "postgresql://user:pass@localhost
 # List available Supabase tables
 contract-gen source supabase list --url https://xxxxx.supabase.co --api-key eyJhbGc...
 
-# Generate source contract from Supabase (simple, but no primary keys)
+# Generate source contract from Supabase (uses actual PostgreSQL schema, works with empty tables!)
 contract-gen source supabase analyze --url https://xxxxx.supabase.co --api-key eyJhbGc... --table users --output contracts/users.json
 
-# For full schema introspection with primary keys, use database source instead:
+# For full schema introspection with primary keys and foreign keys, use database source:
 contract-gen source database list --conn "postgresql://postgres:[PASSWORD]@db.[PROJECT-REF].supabase.co:5432/postgres" --type postgresql
 
 # Generate destination contract (CSV)

--- a/cli/commands/source.py
+++ b/cli/commands/source.py
@@ -276,16 +276,22 @@ def source_supabase_analyze(
 ) -> None:
     """Generate source contract from Supabase table.
 
-    Uses Supabase's PostgREST API for authentication and data access.
+    Uses PostgREST OpenAPI schema to read actual PostgreSQL table definitions.
+    Works with empty tables - no data required!
+
+    FEATURES:
+    - Reads actual PostgreSQL schema (not inferred from data)
+    - Works with empty tables
+    - Proper data type detection
+    - Nullable detection from schema
 
     LIMITATIONS:
-    - Primary keys: Not detected (PostgREST does not expose schema metadata)
-    - Data types: Inferred from sample data values, not PostgreSQL schema
-    - Empty tables: Cannot generate contracts (no data to infer from)
-    - RLS policies: May limit visible data based on API key permissions
+    - Primary keys: Not exposed in OpenAPI schema
+    - Foreign keys: Not exposed in OpenAPI schema
+    - Default values: Not exposed in OpenAPI schema
 
-    For full schema introspection with primary keys, use the database source
-    command with a PostgreSQL connection string instead.
+    For full schema introspection with primary keys and foreign keys, use the 
+    database source command with a PostgreSQL connection string instead.
 
     Example:
         contract-gen source supabase analyze --url https://xxxxx.supabase.co --api-key eyJhbGc... --table users --output contracts/users.json


### PR DESCRIPTION
## Summary

Fixes the fundamental design flaw where Supabase source contracts were inferred from data instead of reading the actual PostgreSQL schema. Now uses PostgREST's OpenAPI endpoint to get real schema definitions.

## Problem

The original implementation had critical issues:
- ❌ Empty tables couldn't generate contracts (error: "cannot infer schema from empty table")
- ❌ Data types were guessed from sample values, not from PostgreSQL schema
- ❌ Inaccurate type detection (JSON→text, arrays guessed from first element)
- ❌ Primary keys never detected

## Solution

Use PostgREST's OpenAPI schema (`/rest/v1/` endpoint) which exposes actual PostgreSQL schema:

```json
{
  "components": {
    "schemas": {
      "users": {
        "type": "object",
        "required": ["id", "username"],
        "properties": {
          "id": {"type": "integer", "format": "int32"},
          "username": {"type": "string"},
          "created_at": {"type": "string", "format": "date-time"}
        }
      }
    }
  }
}
```

## Benefits

✅ **Works with empty tables** - No data required for schema  
✅ **Accurate types** - From PostgreSQL schema, not inferred  
✅ **Nullable detection** - From `required` array  
✅ **Proper type mapping** - integer, bigint, timestamp, uuid, arrays, etc.  
✅ **Consistent** - Aligns with database source behavior (schema-first)  

## Changes

### Core (`core/sources/supabase.py`)
- Added `_map_openapi_type_to_contract()` - Maps OpenAPI types to contract types
- Added `analyze_supabase_table_from_schema()` - Reads schema from OpenAPI
- Updated `analyze_supabase_table()` - Uses schema-first, data optional
- Sample data now only fetched if `sample_size > 0` (for quality metrics)

### CLI (`cli/commands/source.py`)
- Updated help text to reflect new capabilities
- Emphasized that it works with empty tables
- Clarified limitations (PKs/FKs not in OpenAPI)

### Documentation (`README.md`)
- Updated examples to show it works with empty tables
- Clarified when to use Supabase vs database commands

## Testing

- ✅ All 165 tests passing
- ✅ `make check` passing (lint, format, type check)
- ✅ Works with empty Supabase tables (tested manually)

## Limitations (Unchanged)

- Primary keys: Not exposed in OpenAPI schema
- Foreign keys: Not exposed in OpenAPI schema  
- Default values: Not exposed in OpenAPI schema

For full schema introspection, users can still use the database source command with a PostgreSQL connection string.

## Breaking Changes

None - API signature unchanged, just improves behavior.