### PR TITLE
Add structural fingerprint package for the pipeline cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
           echo "csvcontract: ${COVERAGE}%"
           awk "BEGIN {if ($COVERAGE < 100) {print \"FAIL\"; exit 1}}"
 
+      - name: Test fingerprint (100%)
+        run: |
+          go test -race -coverprofile=coverage.out ./fingerprint/...
+          COVERAGE=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | sed 's/%//')
+          echo "fingerprint: ${COVERAGE}%"
+          awk "BEGIN {if ($COVERAGE < 100) {print \"FAIL\"; exit 1}}"
+
       - name: Test jsoncontract (95%)
         run: |
           go test -race -coverprofile=coverage.out ./jsoncontract/...

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ test: db-start
 	go test -race -coverprofile=coverage.out ./csvcontract/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 100) {printf "FAIL csvcontract %.1f%% < 100%%\n", $$1; exit 1} else {printf "csvcontract: %.1f%%\n", $$1}}'
+	go test -race -coverprofile=coverage.out ./fingerprint/...
+	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
+		awk '{if ($$1+0 < 100) {printf "FAIL fingerprint %.1f%% < 100%%\n", $$1; exit 1} else {printf "fingerprint: %.1f%%\n", $$1}}'
 	go test -race -coverprofile=coverage.out ./jsoncontract/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 95) {printf "FAIL jsoncontract %.1f%% < 95%%\n", $$1; exit 1} else {printf "jsoncontract: %.1f%%\n", $$1}}'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ go get github.com/JacobJNilsson/data-contract-generator@latest
 | [`supacontract`](supacontract/) | Analyze Supabase projects via PostgREST OpenAPI (no direct DB connection needed) |
 | [`verify`](verify/) | Validate contracts for structural correctness and semantic coherence |
 | [`transform`](transform/) | Generate transformation contracts with field mapping suggestions |
+| [`fingerprint`](fingerprint/) | Structural fingerprints: canonical schema identity, hashing, and near-neighbour ranking for the pipeline cache |
 
 ## Quick start
 
@@ -66,6 +67,7 @@ The pre-commit hook runs `make check` which enforces:
 | transform | 100% |
 | supacontract | 95% |
 | pgcontract | 85% (tested against real Postgres) |
+| fingerprint | 100% |
 
 ## Architecture
 
@@ -78,6 +80,7 @@ pgcontract/      ← PostgreSQL analysis
 supacontract/    ← Supabase analysis
 verify/          ← contract validation
 transform/       ← field mapping suggestions
+fingerprint/     ← structural identity for the pipeline cache
 ```
 
 No circular dependencies. No type aliases. Each analyzer imports `contract/` for shared types and stdlib for everything else (except `pgcontract` which uses `pgx`).

--- a/fingerprint/distance.go
+++ b/fingerprint/distance.go
@@ -19,14 +19,20 @@ type Distance struct {
 	AddedRemoved      int
 }
 
-// Compare computes the structural distance between two objects.
+// Compare computes the structural distance between two objects. It is
+// deliberately AlgoVersion-agnostic: distance is advice for reference
+// selection, never an auto-match, and the re-fingerprint migration that
+// accompanies an algo bump recomputes objects under the new rules.
 func Compare(a, b Object) Distance {
+	return compare(fieldTypes(a.Fields), a, b)
+}
+
+func compare(aTypes map[string]CanonicalType, a, b Object) Distance {
 	if a.Format != b.Format {
 		return Distance{Disqualified: true}
 	}
 	d := Distance{ParseProfileDiffs: parseProfileDiffs(a.ParseProfile, b.ParseProfile)}
 
-	aTypes := fieldTypes(a.Fields)
 	bTypes := fieldTypes(b.Fields)
 	shared := 0
 	for name, aType := range aTypes {
@@ -77,9 +83,10 @@ func Rank(target Object, candidates []Object) []int {
 		index    int
 		distance Distance
 	}
+	targetTypes := fieldTypes(target.Fields)
 	rankedCandidates := make([]ranked, 0, len(candidates))
 	for i, candidate := range candidates {
-		d := Compare(target, candidate)
+		d := compare(targetTypes, target, candidate)
 		if d.Disqualified {
 			continue
 		}
@@ -118,6 +125,9 @@ func parseProfileDiffs(a, b *ParseProfile) int {
 	return diffs
 }
 
+// fieldTypes keys fields by name. Canonical field names are unique by
+// construction (canonicalFields disambiguates duplicates), so no entry is
+// ever silently overwritten.
 func fieldTypes(fields []Field) map[string]CanonicalType {
 	types := make(map[string]CanonicalType, len(fields))
 	for _, f := range fields {

--- a/fingerprint/distance.go
+++ b/fingerprint/distance.go
@@ -1,0 +1,127 @@
+package fingerprint
+
+import "sort"
+
+// Distance is the deterministic structural distance between two fingerprint
+// objects, used to rank near-neighbour pipelines as authoring references on
+// a cache miss. It is advice for the authoring agent, never an auto-match:
+// only exact identity (hash + Match) dispatches a pipeline.
+//
+// Components are compared lexicographically in declaration order, mirroring
+// the spec's priority: format mismatch disqualifies, then parse-profile
+// diffs, then field-set Jaccard distance, then per-field type changes, then
+// added/removed field count.
+type Distance struct {
+	Disqualified      bool
+	ParseProfileDiffs int
+	Jaccard           float64
+	TypeChanges       int
+	AddedRemoved      int
+}
+
+// Compare computes the structural distance between two objects.
+func Compare(a, b Object) Distance {
+	if a.Format != b.Format {
+		return Distance{Disqualified: true}
+	}
+	d := Distance{ParseProfileDiffs: parseProfileDiffs(a.ParseProfile, b.ParseProfile)}
+
+	aTypes := fieldTypes(a.Fields)
+	bTypes := fieldTypes(b.Fields)
+	shared := 0
+	for name, aType := range aTypes {
+		bType, ok := bTypes[name]
+		if !ok {
+			continue
+		}
+		shared++
+		if aType != bType {
+			d.TypeChanges++
+		}
+	}
+	union := len(aTypes) + len(bTypes) - shared
+	d.AddedRemoved = union - shared
+	if union > 0 {
+		d.Jaccard = 1 - float64(shared)/float64(union)
+	}
+	return d
+}
+
+// Less reports whether d is strictly closer than other, comparing components
+// in priority order. Disqualified distances are never closer than anything.
+func (d Distance) Less(other Distance) bool {
+	if d.Disqualified != other.Disqualified {
+		return !d.Disqualified
+	}
+	if d.Disqualified {
+		return false
+	}
+	if d.ParseProfileDiffs != other.ParseProfileDiffs {
+		return d.ParseProfileDiffs < other.ParseProfileDiffs
+	}
+	if d.Jaccard != other.Jaccard {
+		return d.Jaccard < other.Jaccard
+	}
+	if d.TypeChanges != other.TypeChanges {
+		return d.TypeChanges < other.TypeChanges
+	}
+	return d.AddedRemoved < other.AddedRemoved
+}
+
+// Rank orders candidates by distance to target, closest first, and returns
+// their indices into the candidates slice. Format-mismatched candidates are
+// disqualified and excluded. Ties preserve candidate order, so the ranking
+// is fully deterministic and order-stable.
+func Rank(target Object, candidates []Object) []int {
+	type ranked struct {
+		index    int
+		distance Distance
+	}
+	rankedCandidates := make([]ranked, 0, len(candidates))
+	for i, candidate := range candidates {
+		d := Compare(target, candidate)
+		if d.Disqualified {
+			continue
+		}
+		rankedCandidates = append(rankedCandidates, ranked{index: i, distance: d})
+	}
+	sort.SliceStable(rankedCandidates, func(i, j int) bool {
+		return rankedCandidates[i].distance.Less(rankedCandidates[j].distance)
+	})
+	indices := make([]int, len(rankedCandidates))
+	for i, r := range rankedCandidates {
+		indices[i] = r.index
+	}
+	return indices
+}
+
+func parseProfileDiffs(a, b *ParseProfile) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		a = &ParseProfile{}
+	}
+	if b == nil {
+		b = &ParseProfile{}
+	}
+	diffs := 0
+	if !strPtrEqual(a.Delimiter, b.Delimiter) {
+		diffs++
+	}
+	if !strPtrEqual(a.Encoding, b.Encoding) {
+		diffs++
+	}
+	if !boolPtrEqual(a.HasHeader, b.HasHeader) {
+		diffs++
+	}
+	return diffs
+}
+
+func fieldTypes(fields []Field) map[string]CanonicalType {
+	types := make(map[string]CanonicalType, len(fields))
+	for _, f := range fields {
+		types[f.Name] = f.Type
+	}
+	return types
+}

--- a/fingerprint/distance_test.go
+++ b/fingerprint/distance_test.go
@@ -1,0 +1,177 @@
+package fingerprint
+
+import (
+	"testing"
+)
+
+func object(format Format, profile *ParseProfile, fields ...Field) Object {
+	return Object{AlgoVersion: AlgoVersion, Format: format, ParseProfile: profile, Fields: fields}
+}
+
+func csvProfile(delimiter string, hasHeader bool) *ParseProfile {
+	encoding := "utf-8"
+	return &ParseProfile{Delimiter: &delimiter, Encoding: &encoding, HasHeader: &hasHeader}
+}
+
+func TestCompareFormatMismatchDisqualifies(t *testing.T) {
+	a := object(FormatCSV, csvProfile(",", true), Field{Name: "a", Type: TypeString})
+	b := object(FormatJSON, nil, Field{Name: "a", Type: TypeString})
+	if d := Compare(a, b); !d.Disqualified {
+		t.Errorf("format mismatch did not disqualify")
+	}
+}
+
+func TestCompareComponents(t *testing.T) {
+	base := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+		Field{Name: "c", Type: TypeTemporal},
+	)
+
+	identical := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+		Field{Name: "c", Type: TypeTemporal},
+	)
+	d := Compare(base, identical)
+	if d.Disqualified || d.ParseProfileDiffs != 0 || d.Jaccard != 0 || d.TypeChanges != 0 || d.AddedRemoved != 0 {
+		t.Errorf("identical objects have nonzero distance: %+v", d)
+	}
+
+	differentDelimiter := object(FormatCSV, csvProfile(";", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+		Field{Name: "c", Type: TypeTemporal},
+	)
+	if d := Compare(base, differentDelimiter); d.ParseProfileDiffs != 1 {
+		t.Errorf("delimiter diff: ParseProfileDiffs = %d, want 1", d.ParseProfileDiffs)
+	}
+
+	typeChanged := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeString},
+		Field{Name: "c", Type: TypeTemporal},
+	)
+	if d := Compare(base, typeChanged); d.TypeChanges != 1 || d.AddedRemoved != 0 {
+		t.Errorf("type change: %+v, want TypeChanges=1 AddedRemoved=0", d)
+	}
+
+	fieldAdded := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+		Field{Name: "c", Type: TypeTemporal},
+		Field{Name: "d", Type: TypeString},
+	)
+	d = Compare(base, fieldAdded)
+	if d.AddedRemoved != 1 {
+		t.Errorf("added field: AddedRemoved = %d, want 1", d.AddedRemoved)
+	}
+	if want := 1 - 3.0/4.0; d.Jaccard != want {
+		t.Errorf("added field: Jaccard = %v, want %v", d.Jaccard, want)
+	}
+
+	nilVsProfile := Compare(
+		object(FormatXLSX, nil, Field{Name: "a", Type: TypeString}),
+		object(FormatXLSX, csvProfile(",", true), Field{Name: "a", Type: TypeString}),
+	)
+	if nilVsProfile.ParseProfileDiffs != 3 {
+		t.Errorf("nil vs full profile: ParseProfileDiffs = %d, want 3", nilVsProfile.ParseProfileDiffs)
+	}
+
+	profileVsNil := Compare(
+		object(FormatXLSX, csvProfile(",", true), Field{Name: "a", Type: TypeString}),
+		object(FormatXLSX, nil, Field{Name: "a", Type: TypeString}),
+	)
+	if profileVsNil.ParseProfileDiffs != 3 {
+		t.Errorf("full profile vs nil: ParseProfileDiffs = %d, want 3", profileVsNil.ParseProfileDiffs)
+	}
+
+	empty := Compare(
+		object(FormatXLSX, nil),
+		object(FormatXLSX, nil),
+	)
+	if empty.Jaccard != 0 {
+		t.Errorf("empty field sets: Jaccard = %v, want 0", empty.Jaccard)
+	}
+}
+
+func TestDistanceLessPriorityOrder(t *testing.T) {
+	cases := []struct {
+		name    string
+		closer  Distance
+		farther Distance
+	}{
+		{"qualified beats disqualified", Distance{Jaccard: 0.9}, Distance{Disqualified: true}},
+		{"parse profile beats jaccard", Distance{ParseProfileDiffs: 0, Jaccard: 0.9}, Distance{ParseProfileDiffs: 1, Jaccard: 0.1}},
+		{"jaccard beats type changes", Distance{Jaccard: 0.1, TypeChanges: 5}, Distance{Jaccard: 0.2, TypeChanges: 0}},
+		{"type changes beat added/removed", Distance{TypeChanges: 1, AddedRemoved: 5}, Distance{TypeChanges: 2, AddedRemoved: 0}},
+		{"added/removed last", Distance{AddedRemoved: 1}, Distance{AddedRemoved: 2}},
+	}
+	for _, tc := range cases {
+		if !tc.closer.Less(tc.farther) {
+			t.Errorf("%s: closer not Less than farther", tc.name)
+		}
+		if tc.farther.Less(tc.closer) {
+			t.Errorf("%s: farther Less than closer", tc.name)
+		}
+	}
+
+	equal := Distance{Jaccard: 0.5}
+	if equal.Less(equal) {
+		t.Errorf("equal distances compare Less")
+	}
+	bothDisqualified := Distance{Disqualified: true}
+	if bothDisqualified.Less(Distance{Disqualified: true}) {
+		t.Errorf("disqualified compares Less than disqualified")
+	}
+}
+
+// Acceptance: the near-neighbour ranking is deterministic and order-stable.
+func TestNearNeighbourOrder(t *testing.T) {
+	target := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+	)
+	exact := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+	)
+	near := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+		Field{Name: "c", Type: TypeString},
+	)
+	far := object(FormatCSV, csvProfile(";", false),
+		Field{Name: "x", Type: TypeString},
+	)
+	wrongFormat := object(FormatJSON, nil,
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+	)
+	tieWithNear := object(FormatCSV, csvProfile(",", true),
+		Field{Name: "a", Type: TypeString},
+		Field{Name: "b", Type: TypeNumber},
+		Field{Name: "d", Type: TypeString},
+	)
+
+	candidates := []Object{far, near, wrongFormat, exact, tieWithNear}
+	got := Rank(target, candidates)
+	want := []int{3, 1, 4, 0} // exact, near, tie (original order), far; wrongFormat excluded
+	if len(got) != len(want) {
+		t.Fatalf("Rank returned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Rank returned %v, want %v", got, want)
+		}
+	}
+
+	for range 10 {
+		again := Rank(target, candidates)
+		for i := range want {
+			if again[i] != want[i] {
+				t.Fatalf("Rank not deterministic: %v then %v", got, again)
+			}
+		}
+	}
+}

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -1,0 +1,252 @@
+// Package fingerprint computes structural fingerprints of analyzed sources:
+// a deterministic projection of analyzer output into a canonical structural
+// schema, hashed into the pipeline cache key. A fingerprint match must
+// guarantee the matched pipeline can process the file, so identity errs
+// toward specificity: any structural change produces a different hash, while
+// observation-unstable signals (nullability, profiling) are excluded.
+package fingerprint
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/JacobJNilsson/data-contract-generator/contract"
+	"github.com/JacobJNilsson/data-contract-generator/csvcontract"
+	"github.com/JacobJNilsson/data-contract-generator/jsoncontract"
+	"golang.org/x/text/unicode/norm"
+)
+
+// AlgoVersion identifies the canonicalisation rules used to build and hash
+// fingerprint objects. Any change to those rules must bump it; old hashes are
+// never reinterpreted under new rules.
+const AlgoVersion = "fp1"
+
+// CanonicalType is the coarse type lattice used for identity. The analyzer
+// vocabulary is already coarse, so strict equality on these tokens is stable
+// across files of the same shape.
+type CanonicalType string
+
+// The canonical type tokens. STRING, NUMBER, TEMPORAL, BOOLEAN, OBJECT, and
+// ARRAY cover every observable analyzer type.
+const (
+	TypeString   CanonicalType = "STRING"
+	TypeNumber   CanonicalType = "NUMBER"
+	TypeTemporal CanonicalType = "TEMPORAL"
+	TypeBoolean  CanonicalType = "BOOLEAN"
+	TypeObject   CanonicalType = "OBJECT"
+	TypeArray    CanonicalType = "ARRAY"
+	// TypeUnknown marks columns whose type could not be observed (all-null or
+	// empty). When a later file resolves the type, the hash changes: a
+	// documented cache miss, not a silent re-route.
+	TypeUnknown CanonicalType = "UNKNOWN"
+)
+
+// Format is the source format kind. Different formats use different
+// analyzers and parsers, so format is always identity-bearing.
+type Format string
+
+// The supported source format kinds.
+const (
+	FormatCSV    Format = "csv"
+	FormatJSON   Format = "json"
+	FormatNDJSON Format = "ndjson"
+	FormatXLSX   Format = "xlsx"
+	FormatAPI    Format = "api"
+)
+
+// ParseProfile holds the parse-level settings that change how bytes become
+// records. Fields that do not apply to a format are nil and serialize as
+// null, so absence is itself canonical.
+type ParseProfile struct {
+	Delimiter *string `json:"delimiter"`
+	Encoding  *string `json:"encoding"`
+	HasHeader *bool   `json:"has_header"`
+}
+
+// Field is one named, canonically typed column of the structural schema.
+// Names are NFC-normalised and trimmed with case preserved; volatile
+// per-field data (nullability, profiling) is deliberately absent.
+type Field struct {
+	Name string        `json:"name"`
+	Type CanonicalType `json:"type"`
+}
+
+// Object is the canonical, inspectable fingerprint: everything that goes
+// into identity and nothing that does not. Hash() derives the cache-key hash
+// from its canonical serialization; the object itself is stored beside the
+// hash as the collision guard.
+type Object struct {
+	AlgoVersion  string        `json:"algo_version"`
+	Format       Format        `json:"format"`
+	ParseProfile *ParseProfile `json:"parse_profile"`
+	Fields       []Field       `json:"fields"`
+}
+
+// Unit is one structural unit of a multi-schema source: the schema locator
+// (sheet name, "METHOD /path" endpoint) plus its fingerprint. The locator
+// extends the intake channel into the cache key's channel_path so units
+// within one file do not collide.
+type Unit struct {
+	Locator string
+	Object  Object
+}
+
+// FromCSV fingerprints a CSV analysis. Delimiter, header presence, and
+// encoding are identity-bearing parts of the parse profile.
+func FromCSV(sc *csvcontract.SourceContract) (Object, error) {
+	if sc == nil {
+		return Object{}, errors.New("fingerprint: nil CSV contract")
+	}
+	fields, err := canonicalFields(len(sc.Fields), func(i int) (string, string) {
+		return sc.Fields[i].Name, string(sc.Fields[i].DataType)
+	})
+	if err != nil {
+		return Object{}, err
+	}
+	delimiter, encoding, hasHeader := sc.Delimiter, sc.Encoding, sc.HasHeader
+	return Object{
+		AlgoVersion:  AlgoVersion,
+		Format:       FormatCSV,
+		ParseProfile: &ParseProfile{Delimiter: &delimiter, Encoding: &encoding, HasHeader: &hasHeader},
+		Fields:       fields,
+	}, nil
+}
+
+// FromJSON fingerprints a JSON or NDJSON analysis. The two formats parse
+// differently, so the contract's source format is identity-bearing.
+func FromJSON(sc *jsoncontract.SourceContract) (Object, error) {
+	if sc == nil {
+		return Object{}, errors.New("fingerprint: nil JSON contract")
+	}
+	var format Format
+	switch sc.SourceFormat {
+	case "json":
+		format = FormatJSON
+	case "ndjson":
+		format = FormatNDJSON
+	default:
+		return Object{}, fmt.Errorf("fingerprint: unsupported JSON source format %q", sc.SourceFormat)
+	}
+	fields, err := canonicalFields(len(sc.Fields), func(i int) (string, string) {
+		return sc.Fields[i].Name, string(sc.Fields[i].DataType)
+	})
+	if err != nil {
+		return Object{}, err
+	}
+	encoding := sc.Encoding
+	return Object{
+		AlgoVersion:  AlgoVersion,
+		Format:       format,
+		ParseProfile: &ParseProfile{Encoding: &encoding},
+		Fields:       fields,
+	}, nil
+}
+
+// FromDataContract fans a multi-schema contract (Excel workbook, API spec)
+// out into one structural unit per schema, each fingerprinted independently.
+// The schema name becomes the unit's channel-path locator.
+func FromDataContract(dc *contract.DataContract) ([]Unit, error) {
+	if dc == nil {
+		return nil, errors.New("fingerprint: nil data contract")
+	}
+	format, err := dataContractFormat(dc)
+	if err != nil {
+		return nil, err
+	}
+	if len(dc.Schemas) == 0 {
+		return nil, errors.New("fingerprint: data contract has no schemas")
+	}
+	units := make([]Unit, 0, len(dc.Schemas))
+	for _, schema := range dc.Schemas {
+		fields, err := canonicalFields(len(schema.Fields), func(i int) (string, string) {
+			return schema.Fields[i].Name, schema.Fields[i].DataType
+		})
+		if err != nil {
+			return nil, fmt.Errorf("schema %q: %w", schema.Name, err)
+		}
+		units = append(units, Unit{
+			Locator: schema.Name,
+			Object: Object{
+				AlgoVersion: AlgoVersion,
+				Format:      format,
+				Fields:      fields,
+			},
+		})
+	}
+	return units, nil
+}
+
+// dataContractFormat determines the source format kind from contract
+// metadata. Unrecognized contracts are an error, never a guess: an unknown
+// format must not silently share identity space with a known one.
+func dataContractFormat(dc *contract.DataContract) (Format, error) {
+	if sf, ok := dc.Metadata["source_format"].(string); ok && sf == "xlsx" {
+		return FormatXLSX, nil
+	}
+	if src, ok := dc.Metadata["source"].(string); ok && src == "openapi" {
+		return FormatAPI, nil
+	}
+	return "", errors.New("fingerprint: cannot determine source format from data contract metadata")
+}
+
+// canonicalFields normalizes, maps, and sorts a schema's fields into
+// canonical form. Named fields sort by name so column reordering does not
+// change identity; headerless CSV columns carry synthesized positional
+// names, which keeps their order intrinsic to identity.
+func canonicalFields(n int, at func(i int) (name, dataType string)) ([]Field, error) {
+	if n == 0 {
+		return nil, errors.New("fingerprint: schema has no fields")
+	}
+	fields := make([]Field, 0, n)
+	for i := range n {
+		name, dataType := at(i)
+		canonical, err := mapDataType(dataType)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", name, err)
+		}
+		fields = append(fields, Field{Name: canonicalName(name), Type: canonical})
+	}
+	sort.SliceStable(fields, func(i, j int) bool {
+		if fields[i].Name != fields[j].Name {
+			return fields[i].Name < fields[j].Name
+		}
+		return fields[i].Type < fields[j].Type
+	})
+	return fields, nil
+}
+
+// canonicalName normalizes a field name for identity: Unicode NFC plus
+// surrounding-whitespace trim, case preserved. Anything beyond that (a
+// rename) is a real structural change and must miss.
+func canonicalName(name string) string {
+	return norm.NFC.String(strings.TrimSpace(name))
+}
+
+// mapDataType projects an analyzer type token onto the canonical lattice.
+// The mapping is strict: a token outside the known analyzer vocabularies is
+// an error, because silently coercing it could let two different shapes
+// share a fingerprint.
+func mapDataType(dataType string) (CanonicalType, error) {
+	switch dataType {
+	case "text", "uuid", "bytea":
+		return TypeString, nil
+	case "numeric", "integer":
+		return TypeNumber, nil
+	case "date", "timestamptz":
+		return TypeTemporal, nil
+	case "boolean":
+		return TypeBoolean, nil
+	case "object", "jsonb":
+		return TypeObject, nil
+	case "array":
+		return TypeArray, nil
+	case "null", "empty":
+		return TypeUnknown, nil
+	}
+	if strings.HasPrefix(dataType, "array[") && strings.HasSuffix(dataType, "]") {
+		return TypeArray, nil
+	}
+	return "", fmt.Errorf("fingerprint: unmapped analyzer type %q", dataType)
+}

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -7,9 +7,11 @@
 package fingerprint
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/JacobJNilsson/data-contract-generator/contract"
@@ -36,7 +38,15 @@ const (
 	TypeTemporal CanonicalType = "TEMPORAL"
 	TypeBoolean  CanonicalType = "BOOLEAN"
 	TypeObject   CanonicalType = "OBJECT"
-	TypeArray    CanonicalType = "ARRAY"
+	// TypeBinary marks declared binary payloads (OpenAPI byte/binary). Binary
+	// vs text changes how bytes become records, so it never collapses into
+	// STRING.
+	TypeBinary CanonicalType = "BINARY"
+	// TypeArray is the element-opaque array token, used when the analyzer
+	// does not expose the element type (JSON sources). When it does (API
+	// specs), the element is preserved as ARRAY<inner>, e.g. ARRAY<NUMBER>:
+	// identity is as fine as the analyzer exposes, never coarser.
+	TypeArray CanonicalType = "ARRAY"
 	// TypeUnknown marks columns whose type could not be observed (all-null or
 	// empty). When a later file resolves the type, the hash changes: a
 	// documented cache miss, not a silent re-route.
@@ -77,11 +87,19 @@ type Field struct {
 // into identity and nothing that does not. Hash() derives the cache-key hash
 // from its canonical serialization; the object itself is stored beside the
 // hash as the collision guard.
+//
+// Struct fields are declared in canonical (alphabetical JSON key) order:
+// CanonicalBytes serializes them in declaration order, and the golden test
+// pins the resulting byte layout.
 type Object struct {
-	AlgoVersion  string        `json:"algo_version"`
-	Format       Format        `json:"format"`
-	ParseProfile *ParseProfile `json:"parse_profile"`
-	Fields       []Field       `json:"fields"`
+	AlgoVersion string  `json:"algo_version"`
+	Fields      []Field `json:"fields"`
+	Format      Format  `json:"format"`
+	// Nesting carries recursive structure when a future analyzer exposes it
+	// (spec limitation L1). Always null under fp1; present so the stored
+	// collision-guard object represents every key the hash covers.
+	Nesting      json.RawMessage `json:"nesting"`
+	ParseProfile *ParseProfile   `json:"parse_profile"`
 }
 
 // Unit is one structural unit of a multi-schema source: the schema locator
@@ -144,27 +162,37 @@ func FromJSON(sc *jsoncontract.SourceContract) (Object, error) {
 	}, nil
 }
 
+// SkippedSchema records one schema of a multi-schema contract that could not
+// be fingerprinted, so a single bad sheet or endpoint never costs the other
+// units their cache identity (per-unit blast-radius isolation).
+type SkippedSchema struct {
+	Locator string
+	Err     error
+}
+
 // FromDataContract fans a multi-schema contract (Excel workbook, API spec)
 // out into one structural unit per schema, each fingerprinted independently.
-// The schema name becomes the unit's channel-path locator.
-func FromDataContract(dc *contract.DataContract) ([]Unit, error) {
+// The schema name becomes the unit's channel-path locator. Schemas that fail
+// to fingerprint are returned in skipped rather than failing the fanout; the
+// error is reserved for contract-level problems.
+func FromDataContract(dc *contract.DataContract) (units []Unit, skipped []SkippedSchema, err error) {
 	if dc == nil {
-		return nil, errors.New("fingerprint: nil data contract")
+		return nil, nil, errors.New("fingerprint: nil data contract")
 	}
 	format, err := dataContractFormat(dc)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(dc.Schemas) == 0 {
-		return nil, errors.New("fingerprint: data contract has no schemas")
+		return nil, nil, errors.New("fingerprint: data contract has no schemas")
 	}
-	units := make([]Unit, 0, len(dc.Schemas))
 	for _, schema := range dc.Schemas {
-		fields, err := canonicalFields(len(schema.Fields), func(i int) (string, string) {
+		fields, fieldErr := canonicalFields(len(schema.Fields), func(i int) (string, string) {
 			return schema.Fields[i].Name, schema.Fields[i].DataType
 		})
-		if err != nil {
-			return nil, fmt.Errorf("schema %q: %w", schema.Name, err)
+		if fieldErr != nil {
+			skipped = append(skipped, SkippedSchema{Locator: schema.Name, Err: fieldErr})
+			continue
 		}
 		units = append(units, Unit{
 			Locator: schema.Name,
@@ -175,13 +203,22 @@ func FromDataContract(dc *contract.DataContract) ([]Unit, error) {
 			},
 		})
 	}
-	return units, nil
+	return units, skipped, nil
 }
 
 // dataContractFormat determines the source format kind from contract
 // metadata. Unrecognized contracts are an error, never a guess: an unknown
 // format must not silently share identity space with a known one.
+//
+// Identity limitation, mirroring spec L1: Excel header detection is per
+// sheet and not exposed on the contract, so a sheet whose literal header row
+// happens to equal the synthesized positional names of a headerless sheet
+// would collide. Resolving it needs the analyzer to expose the detection
+// outcome — a future algo_version, flagged rather than hidden.
 func dataContractFormat(dc *contract.DataContract) (Format, error) {
+	if dc.ContractType == "destination" {
+		return "", errors.New("fingerprint: destination contracts are not fingerprinted")
+	}
 	if sf, ok := dc.Metadata["source_format"].(string); ok && sf == "xlsx" {
 		return FormatXLSX, nil
 	}
@@ -191,10 +228,10 @@ func dataContractFormat(dc *contract.DataContract) (Format, error) {
 	return "", errors.New("fingerprint: cannot determine source format from data contract metadata")
 }
 
-// canonicalFields normalizes, maps, and sorts a schema's fields into
-// canonical form. Named fields sort by name so column reordering does not
-// change identity; headerless CSV columns carry synthesized positional
-// names, which keeps their order intrinsic to identity.
+// canonicalFields normalizes, maps, disambiguates, and sorts a schema's
+// fields into canonical form. Named fields sort by name so column reordering
+// does not change identity; headerless CSV columns carry synthesized
+// positional names, which keeps their order intrinsic to identity.
 func canonicalFields(n int, at func(i int) (name, dataType string)) ([]Field, error) {
 	if n == 0 {
 		return nil, errors.New("fingerprint: schema has no fields")
@@ -208,30 +245,63 @@ func canonicalFields(n int, at func(i int) (name, dataType string)) ([]Field, er
 		}
 		fields = append(fields, Field{Name: canonicalName(name), Type: canonical})
 	}
-	sort.SliceStable(fields, func(i, j int) bool {
-		if fields[i].Name != fields[j].Name {
-			return fields[i].Name < fields[j].Name
-		}
-		return fields[i].Type < fields[j].Type
+	disambiguateDuplicates(fields)
+	// Names are unique after disambiguation, so name order is total.
+	sort.Slice(fields, func(i, j int) bool {
+		return fields[i].Name < fields[j].Name
 	})
 	return fields, nil
 }
 
-// canonicalName normalizes a field name for identity: Unicode NFC plus
-// surrounding-whitespace trim, case preserved. Anything beyond that (a
-// rename) is a real structural change and must miss.
+// disambiguateDuplicates makes canonical names unique by suffixing duplicate
+// occurrences with their column-order ordinal ("id" → "id#1", "id#2").
+// Without this, sorting would erase which duplicate-named column carries
+// which type, letting two files with swapped column types share a
+// fingerprint — a catastrophic false positive. Ambiguous names degrade to
+// positional identity instead, so reordering duplicate-named columns is a
+// miss, exactly like headerless CSV. canonicalName escapes literal '#' as
+// '##' in every name, so a real header can never collide with a synthesized
+// suffix.
+func disambiguateDuplicates(fields []Field) {
+	counts := make(map[string]int, len(fields))
+	for _, f := range fields {
+		counts[f.Name]++
+	}
+	seen := make(map[string]int, len(fields))
+	for i, f := range fields {
+		if counts[f.Name] < 2 {
+			continue
+		}
+		seen[f.Name]++
+		fields[i].Name = f.Name + "#" + strconv.Itoa(seen[f.Name])
+	}
+}
+
+// canonicalName normalizes a field name for identity: invalid UTF-8 replaced
+// deterministically, Unicode NFC, surrounding-whitespace trim, case
+// preserved, and literal '#' escaped as '##' to keep the namespace of
+// disambiguation suffixes private. The UTF-8 replacement keeps the stored
+// object consistent with its serialized form, so encoding garbage cannot
+// manufacture hash-equal-but-object-unequal collision alerts. Anything
+// beyond that (a rename) is a real structural change and must miss.
 func canonicalName(name string) string {
-	return norm.NFC.String(strings.TrimSpace(name))
+	canonical := norm.NFC.String(strings.TrimSpace(strings.ToValidUTF8(name, "�")))
+	return strings.ReplaceAll(canonical, "#", "##")
 }
 
 // mapDataType projects an analyzer type token onto the canonical lattice.
-// The mapping is strict: a token outside the known analyzer vocabularies is
-// an error, because silently coercing it could let two different shapes
-// share a fingerprint.
+// The mapping is strict in both directions: a token outside the known
+// analyzer vocabularies is an error (silent coercion could let two shapes
+// share a fingerprint), and a distinction the analyzer exposes is preserved
+// (array element types, binary vs text) rather than coarsened. Only the
+// spec's deliberate collapses apply: int/float to NUMBER, date/timestamp to
+// TEMPORAL, uuid to STRING, jsonb to OBJECT.
 func mapDataType(dataType string) (CanonicalType, error) {
 	switch dataType {
-	case "text", "uuid", "bytea":
+	case "text", "uuid":
 		return TypeString, nil
+	case "bytea":
+		return TypeBinary, nil
 	case "numeric", "integer":
 		return TypeNumber, nil
 	case "date", "timestamptz":
@@ -245,8 +315,12 @@ func mapDataType(dataType string) (CanonicalType, error) {
 	case "null", "empty":
 		return TypeUnknown, nil
 	}
-	if strings.HasPrefix(dataType, "array[") && strings.HasSuffix(dataType, "]") {
-		return TypeArray, nil
+	if inner, ok := strings.CutPrefix(dataType, "array["); ok && strings.HasSuffix(inner, "]") {
+		element, err := mapDataType(strings.TrimSuffix(inner, "]"))
+		if err != nil {
+			return "", err
+		}
+		return CanonicalType("ARRAY<" + string(element) + ">"), nil
 	}
 	return "", fmt.Errorf("fingerprint: unmapped analyzer type %q", dataType)
 }

--- a/fingerprint/fingerprint_test.go
+++ b/fingerprint/fingerprint_test.go
@@ -1,6 +1,7 @@
 package fingerprint
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -276,6 +277,25 @@ func TestCollisionGuardMatch(t *testing.T) {
 	if !Match(noProfile, noProfile) {
 		t.Errorf("nil parse profiles do not Match themselves")
 	}
+
+	withNesting := same
+	withNesting.Nesting = json.RawMessage(`{"depth":1}`)
+	if Match(base, withNesting) {
+		t.Errorf("differing nesting still Matches")
+	}
+}
+
+// The canonical form is plain RFC 8259 JSON: no Go-specific HTML escaping,
+// so the hash is reproducible by any JSON implementation.
+func TestCanonicalBytesPlainJSON(t *testing.T) {
+	o := mustCSV(t, csvContract(csvField("a<b&c>", profile.TypeText)))
+	canonical := string(o.CanonicalBytes())
+	if strings.Contains(canonical, `\u003c`) || strings.Contains(canonical, `\u0026`) {
+		t.Errorf("canonical bytes use Go HTML escaping: %s", canonical)
+	}
+	if !strings.Contains(canonical, `"a<b&c>"`) {
+		t.Errorf("canonical bytes missing plain-JSON name: %s", canonical)
+	}
 }
 
 // Acceptance: a 3-schema contract fans out into 3 units with 3 fingerprints.
@@ -289,9 +309,12 @@ func TestMultiSchemaFanout(t *testing.T) {
 			{Name: "Items", Fields: []contract.FieldDefinition{{Name: "sku", DataType: "text"}, {Name: "qty", DataType: "numeric"}}},
 		},
 	}
-	units, err := FromDataContract(dc)
+	units, skipped, err := FromDataContract(dc)
 	if err != nil {
 		t.Fatalf("FromDataContract: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("unexpected skipped schemas: %v", skipped)
 	}
 	if len(units) != 3 {
 		t.Fatalf("expected 3 units, got %d", len(units))
@@ -329,17 +352,20 @@ func TestFromDataContractAPI(t *testing.T) {
 			}},
 		},
 	}
-	units, err := FromDataContract(dc)
+	units, skipped, err := FromDataContract(dc)
 	if err != nil {
 		t.Fatalf("FromDataContract: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("unexpected skipped schemas: %v", skipped)
 	}
 	if units[0].Object.Format != FormatAPI {
 		t.Errorf("format = %q, want api", units[0].Object.Format)
 	}
 	want := map[string]CanonicalType{
 		"id": TypeNumber, "email": TypeString, "created_at": TypeTemporal,
-		"active": TypeBoolean, "tags": TypeArray, "settings": TypeObject,
-		"ref": TypeString, "blob": TypeString,
+		"active": TypeBoolean, "tags": "ARRAY<STRING>", "settings": TypeObject,
+		"ref": TypeString, "blob": TypeBinary,
 	}
 	for _, f := range units[0].Object.Fields {
 		if want[f.Name] != f.Type {
@@ -391,19 +417,55 @@ func TestNameCanonicalisation(t *testing.T) {
 	}
 }
 
-// Duplicate canonical names keep a deterministic order via the type
-// tie-break, so even degenerate schemas fingerprint stably.
-func TestDuplicateNameDeterminism(t *testing.T) {
-	first := mustCSV(t, csvContract(
+// Duplicate canonical names degrade to positional identity: the name→type
+// pairing stays in the hash, so two files with swapped column types can
+// never share a fingerprint (the catastrophic false positive), and
+// reordering ambiguous columns is a miss, like headerless CSV.
+func TestDuplicateNamePositionalIdentity(t *testing.T) {
+	textFirst := mustCSV(t, csvContract(
 		csvField("a", profile.TypeText),
 		csvField("a ", profile.TypeNumeric),
 	))
-	second := mustCSV(t, csvContract(
-		csvField("a ", profile.TypeNumeric),
+	rebuilt := mustCSV(t, csvContract(
 		csvField("a", profile.TypeText),
+		csvField("a ", profile.TypeNumeric),
 	))
-	if first.Hash() != second.Hash() {
-		t.Errorf("duplicate-name ordering is not deterministic")
+	if textFirst.Hash() != rebuilt.Hash() {
+		t.Errorf("duplicate-name fingerprint is not deterministic")
+	}
+
+	typesSwapped := mustCSV(t, csvContract(
+		csvField("a", profile.TypeNumeric),
+		csvField("a ", profile.TypeText),
+	))
+	if typesSwapped.Hash() == textFirst.Hash() {
+		t.Errorf("swapped types behind duplicate names share a hash: false positive")
+	}
+	if Match(textFirst, typesSwapped) {
+		t.Errorf("swapped types behind duplicate names still Match")
+	}
+
+	wantNames := []string{"a#1", "a#2"}
+	for i, f := range textFirst.Fields {
+		if f.Name != wantNames[i] {
+			t.Errorf("field %d name = %q, want %q", i, f.Name, wantNames[i])
+		}
+	}
+}
+
+// Literal '#' in headers is escaped, so a real header can never collide
+// with a synthesized disambiguation suffix.
+func TestHashSuffixNamespaceIsPrivate(t *testing.T) {
+	literal := mustCSV(t, csvContract(
+		csvField("x#1", profile.TypeText),
+		csvField("x#2", profile.TypeNumeric),
+	))
+	synthesized := mustCSV(t, csvContract(
+		csvField("x", profile.TypeText),
+		csvField("x", profile.TypeNumeric),
+	))
+	if literal.Hash() == synthesized.Hash() {
+		t.Errorf("literal #-headers collide with synthesized duplicate suffixes")
 	}
 }
 
@@ -414,7 +476,7 @@ func TestErrors(t *testing.T) {
 	if _, err := FromJSON(nil); err == nil {
 		t.Errorf("nil JSON contract: expected error")
 	}
-	if _, err := FromDataContract(nil); err == nil {
+	if _, _, err := FromDataContract(nil); err == nil {
 		t.Errorf("nil data contract: expected error")
 	}
 	if _, err := FromCSV(csvContract()); err == nil {
@@ -429,20 +491,86 @@ func TestErrors(t *testing.T) {
 	if _, err := FromCSV(csvContract(csvField("a", profile.DataType("mystery")))); err == nil {
 		t.Errorf("unmapped type: expected error")
 	}
-	if _, err := FromDataContract(&contract.DataContract{Metadata: map[string]any{}}); err == nil {
+	if _, _, err := FromDataContract(&contract.DataContract{Metadata: map[string]any{}}); err == nil {
 		t.Errorf("undetectable format: expected error")
 	}
-	if _, err := FromDataContract(&contract.DataContract{Metadata: map[string]any{"source_format": "xlsx"}}); err == nil {
+	if _, _, err := FromDataContract(&contract.DataContract{Metadata: map[string]any{"source_format": "xlsx"}}); err == nil {
 		t.Errorf("no schemas: expected error")
 	}
-	badSchema := &contract.DataContract{
-		Metadata: map[string]any{"source_format": "xlsx"},
-		Schemas:  []contract.SchemaContract{{Name: "Bad", Fields: []contract.FieldDefinition{{Name: "x", DataType: "mystery"}}}},
+	destination := &contract.DataContract{
+		ContractType: "destination",
+		Metadata:     map[string]any{"source": "openapi"},
+		Schemas:      []contract.SchemaContract{{Name: "t", Fields: []contract.FieldDefinition{{Name: "x", DataType: "text"}}}},
 	}
-	if _, err := FromDataContract(badSchema); err == nil || !strings.Contains(err.Error(), `"Bad"`) {
-		t.Errorf("schema error not wrapped with schema name: %v", err)
+	if _, _, err := FromDataContract(destination); err == nil {
+		t.Errorf("destination contract: expected error")
 	}
 	if _, err := FromCSV(csvContract(csvField("a", "array[text"))); err == nil {
 		t.Errorf("malformed array type: expected error")
+	}
+	if _, err := FromCSV(csvContract(csvField("a", "array[]"))); err == nil {
+		t.Errorf("empty array element: expected error")
+	}
+	if _, err := FromCSV(csvContract(csvField("a", "array[mystery]"))); err == nil {
+		t.Errorf("unmapped array element: expected error")
+	}
+}
+
+// One bad schema must not cost the other units their fingerprints: the
+// failing sheet/endpoint is reported as skipped, the rest fan out normally.
+func TestFanoutIsolatesBadSchemas(t *testing.T) {
+	dc := &contract.DataContract{
+		Metadata: map[string]any{"source": "openapi"},
+		Schemas: []contract.SchemaContract{
+			{Name: "GET /good", Fields: []contract.FieldDefinition{{Name: "id", DataType: "integer"}}},
+			{Name: "GET /bad", Fields: []contract.FieldDefinition{{Name: "avatar", DataType: "file"}}},
+			{Name: "GET /also-good", Fields: []contract.FieldDefinition{{Name: "name", DataType: "text"}}},
+		},
+	}
+	units, skipped, err := FromDataContract(dc)
+	if err != nil {
+		t.Fatalf("FromDataContract: %v", err)
+	}
+	if len(units) != 2 {
+		t.Fatalf("expected 2 units, got %d", len(units))
+	}
+	if len(skipped) != 1 || skipped[0].Locator != "GET /bad" || skipped[0].Err == nil {
+		t.Fatalf("expected GET /bad skipped with error, got %+v", skipped)
+	}
+}
+
+// Nested array element types stay identity-bearing as far as the analyzer
+// exposes them.
+func TestNestedArrayTypes(t *testing.T) {
+	dc := &contract.DataContract{
+		Metadata: map[string]any{"source": "openapi"},
+		Schemas: []contract.SchemaContract{
+			{Name: "GET /matrix", Fields: []contract.FieldDefinition{{Name: "grid", DataType: "array[array[integer]]"}}},
+		},
+	}
+	units, skipped, err := FromDataContract(dc)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("FromDataContract: err=%v skipped=%v", err, skipped)
+	}
+	if got := units[0].Object.Fields[0].Type; got != "ARRAY<ARRAY<NUMBER>>" {
+		t.Errorf("nested array type = %q, want ARRAY<ARRAY<NUMBER>>", got)
+	}
+
+	stringArrays := &contract.DataContract{
+		Metadata: map[string]any{"source": "openapi"},
+		Schemas: []contract.SchemaContract{
+			{Name: "GET /tags", Fields: []contract.FieldDefinition{{Name: "tags", DataType: "array[text]"}}},
+		},
+	}
+	intArrays := &contract.DataContract{
+		Metadata: map[string]any{"source": "openapi"},
+		Schemas: []contract.SchemaContract{
+			{Name: "GET /tags", Fields: []contract.FieldDefinition{{Name: "tags", DataType: "array[integer]"}}},
+		},
+	}
+	su, _, _ := FromDataContract(stringArrays)
+	iu, _, _ := FromDataContract(intArrays)
+	if su[0].Object.Hash() == iu[0].Object.Hash() {
+		t.Errorf("array element type change did not change hash")
 	}
 }

--- a/fingerprint/fingerprint_test.go
+++ b/fingerprint/fingerprint_test.go
@@ -1,0 +1,448 @@
+package fingerprint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/contract"
+	"github.com/JacobJNilsson/data-contract-generator/csvcontract"
+	"github.com/JacobJNilsson/data-contract-generator/jsoncontract"
+	"github.com/JacobJNilsson/data-contract-generator/profile"
+)
+
+func csvContract(fields ...csvcontract.Field) *csvcontract.SourceContract {
+	return &csvcontract.SourceContract{
+		SourceFormat: "csv",
+		Encoding:     "utf-8",
+		Delimiter:    ",",
+		HasHeader:    true,
+		TotalRows:    100,
+		Fields:       fields,
+	}
+}
+
+func csvField(name string, dataType profile.DataType) csvcontract.Field {
+	return csvcontract.Field{Name: name, DataType: dataType}
+}
+
+func jsonContract(sourceFormat string, fields ...jsoncontract.Field) *jsoncontract.SourceContract {
+	return &jsoncontract.SourceContract{
+		SourceFormat: sourceFormat,
+		Encoding:     "utf-8",
+		TotalRows:    50,
+		Fields:       fields,
+	}
+}
+
+func jsonField(name string, dataType jsoncontract.DataType) jsoncontract.Field {
+	return jsoncontract.Field{Name: name, DataType: dataType}
+}
+
+func mustCSV(t *testing.T, sc *csvcontract.SourceContract) Object {
+	t.Helper()
+	o, err := FromCSV(sc)
+	if err != nil {
+		t.Fatalf("FromCSV: %v", err)
+	}
+	return o
+}
+
+func mustJSON(t *testing.T, sc *jsoncontract.SourceContract) Object {
+	t.Helper()
+	o, err := FromJSON(sc)
+	if err != nil {
+		t.Fatalf("FromJSON: %v", err)
+	}
+	return o
+}
+
+// Acceptance: same file hashed twice yields the identical hash. Platform
+// independence holds by construction: canonicalisation never consults map
+// order, locale, time, or environment.
+func TestDeterminism(t *testing.T) {
+	build := func() Object {
+		return mustCSV(t, csvContract(
+			csvField("order_id", profile.TypeText),
+			csvField("amount", profile.TypeNumeric),
+			csvField("placed_at", profile.TypeDate),
+		))
+	}
+	first, second := build(), build()
+	if first.Hash() != second.Hash() {
+		t.Errorf("hashes differ across builds: %s vs %s", first.Hash(), second.Hash())
+	}
+	repeat := first.Hash()
+	if repeat != first.Hash() {
+		t.Errorf("hash is not stable on repeat calls")
+	}
+	if !Match(first, second) {
+		t.Errorf("identical objects do not Match")
+	}
+}
+
+// Acceptance: reordered named columns, more rows, and a different sample of
+// the same shape all yield the identical hash.
+func TestStability(t *testing.T) {
+	base := mustCSV(t, csvContract(
+		csvField("a", profile.TypeText),
+		csvField("b", profile.TypeNumeric),
+	))
+
+	reordered := csvContract(
+		csvField("b", profile.TypeNumeric),
+		csvField("a", profile.TypeText),
+	)
+	if got := mustCSV(t, reordered).Hash(); got != base.Hash() {
+		t.Errorf("reordered named columns changed hash: %s vs %s", got, base.Hash())
+	}
+
+	bigger := csvContract(
+		csvField("a", profile.TypeText),
+		csvField("b", profile.TypeNumeric),
+	)
+	bigger.TotalRows = 1_000_000
+	bigger.SampleData = [][]string{{"x", "1"}}
+	bigger.Fields[0].Profile = profile.FieldProfile{TotalCount: 1_000_000, DistinctCount: 999}
+	if got := mustCSV(t, bigger).Hash(); got != base.Hash() {
+		t.Errorf("row count / sample / profiling changed hash: %s vs %s", got, base.Hash())
+	}
+}
+
+// Acceptance: added field, removed field, type change, delimiter change, and
+// header toggle each yield a different hash.
+func TestSensitivity(t *testing.T) {
+	base := mustCSV(t, csvContract(
+		csvField("a", profile.TypeText),
+		csvField("b", profile.TypeNumeric),
+	))
+
+	variants := map[string]*csvcontract.SourceContract{
+		"added field": csvContract(
+			csvField("a", profile.TypeText),
+			csvField("b", profile.TypeNumeric),
+			csvField("c", profile.TypeText),
+		),
+		"removed field": csvContract(
+			csvField("a", profile.TypeText),
+		),
+		"type change": csvContract(
+			csvField("a", profile.TypeText),
+			csvField("b", profile.TypeText),
+		),
+		"renamed field": csvContract(
+			csvField("a", profile.TypeText),
+			csvField("B", profile.TypeNumeric),
+		),
+	}
+	delimiterChanged := csvContract(
+		csvField("a", profile.TypeText),
+		csvField("b", profile.TypeNumeric),
+	)
+	delimiterChanged.Delimiter = ";"
+	variants["delimiter change"] = delimiterChanged
+
+	headerToggled := csvContract(
+		csvField("a", profile.TypeText),
+		csvField("b", profile.TypeNumeric),
+	)
+	headerToggled.HasHeader = false
+	variants["header toggle"] = headerToggled
+
+	encodingChanged := csvContract(
+		csvField("a", profile.TypeText),
+		csvField("b", profile.TypeNumeric),
+	)
+	encodingChanged.Encoding = "latin-1"
+	variants["encoding change"] = encodingChanged
+
+	for name, variant := range variants {
+		got := mustCSV(t, variant)
+		if got.Hash() == base.Hash() {
+			t.Errorf("%s: hash unchanged", name)
+		}
+		if Match(base, got) {
+			t.Errorf("%s: objects still Match", name)
+		}
+	}
+}
+
+// Acceptance: a numeric column with and without decimals maps to the same
+// coarse NUMBER token, so profiling differences never reach identity.
+func TestTypeStability(t *testing.T) {
+	min1, max1 := "1", "9"
+	withInts := csvContract(csvField("amount", profile.TypeNumeric))
+	withInts.Fields[0].Profile = profile.FieldProfile{MinValue: &min1, MaxValue: &max1}
+
+	min2, max2 := "0.25", "99.99"
+	withDecimals := csvContract(csvField("amount", profile.TypeNumeric))
+	withDecimals.Fields[0].Profile = profile.FieldProfile{MinValue: &min2, MaxValue: &max2}
+
+	if mustCSV(t, withInts).Hash() != mustCSV(t, withDecimals).Hash() {
+		t.Errorf("decimal vs integer numeric profiles changed hash")
+	}
+}
+
+// Acceptance: a column null in one file and valued in another, type
+// otherwise known, yields the identical hash — nullability is excluded.
+func TestNullStability(t *testing.T) {
+	noNulls := jsonContract("json", jsonField("name", jsoncontract.TypeText))
+	noNulls.Fields[0].Profile = jsoncontract.FieldProfile{TotalCount: 50, NullCount: 0}
+
+	someNulls := jsonContract("json", jsonField("name", jsoncontract.TypeText))
+	someNulls.Fields[0].Profile = jsoncontract.FieldProfile{TotalCount: 50, NullCount: 20}
+
+	if mustJSON(t, noNulls).Hash() != mustJSON(t, someNulls).Hash() {
+		t.Errorf("null counts changed hash")
+	}
+}
+
+// Acceptance: an all-null column later resolving to a real type yields a
+// different hash — a documented miss, not a silent re-route.
+// Every remaining analyzer token maps onto the lattice.
+func TestTypeLattice(t *testing.T) {
+	o := mustJSON(t, jsonContract("json",
+		jsonField("nested", jsoncontract.TypeObject),
+		jsonField("list", jsoncontract.TypeArray),
+		jsonField("blank", jsoncontract.TypeEmpty),
+		jsonField("flag", jsoncontract.TypeBoolean),
+		jsonField("when", jsoncontract.TypeDate),
+	))
+	want := map[string]CanonicalType{
+		"nested": TypeObject, "list": TypeArray, "blank": TypeUnknown,
+		"flag": TypeBoolean, "when": TypeTemporal,
+	}
+	for _, f := range o.Fields {
+		if want[f.Name] != f.Type {
+			t.Errorf("field %q mapped to %q, want %q", f.Name, f.Type, want[f.Name])
+		}
+	}
+}
+
+func TestUnknownResolution(t *testing.T) {
+	allNull := mustJSON(t, jsonContract("json", jsonField("status", jsoncontract.TypeNull)))
+	resolved := mustJSON(t, jsonContract("json", jsonField("status", jsoncontract.TypeText)))
+	if allNull.Hash() == resolved.Hash() {
+		t.Errorf("UNKNOWN resolving to STRING did not change hash")
+	}
+}
+
+// Acceptance (collision guard): a cache hit requires hash equality AND
+// object deep-equality, so structurally different objects must never Match,
+// and every structural facet participates in the comparison.
+func TestCollisionGuardMatch(t *testing.T) {
+	base := mustCSV(t, csvContract(csvField("a", profile.TypeText)))
+
+	same := mustCSV(t, csvContract(csvField("a", profile.TypeText)))
+	if !Match(base, same) {
+		t.Fatalf("structurally identical objects do not Match")
+	}
+
+	differentVersion := same
+	differentVersion.AlgoVersion = "fp2"
+	if Match(base, differentVersion) {
+		t.Errorf("differing algo_version still Matches")
+	}
+
+	differentFormat := same
+	differentFormat.Format = FormatJSON
+	if Match(base, differentFormat) {
+		t.Errorf("differing format still Matches")
+	}
+
+	differentFieldCount := mustCSV(t, csvContract(
+		csvField("a", profile.TypeText),
+		csvField("b", profile.TypeText),
+	))
+	if Match(base, differentFieldCount) {
+		t.Errorf("differing field count still Matches")
+	}
+
+	differentField := mustCSV(t, csvContract(csvField("a", profile.TypeNumeric)))
+	if Match(base, differentField) {
+		t.Errorf("differing field type still Matches")
+	}
+
+	differentProfile := mustCSV(t, csvContract(csvField("a", profile.TypeText)))
+	differentProfile.ParseProfile.HasHeader = nil
+	if Match(base, differentProfile) {
+		t.Errorf("differing parse profile still Matches")
+	}
+
+	noProfile := same
+	noProfile.ParseProfile = nil
+	if Match(base, noProfile) {
+		t.Errorf("nil vs non-nil parse profile still Matches")
+	}
+	if !Match(noProfile, noProfile) {
+		t.Errorf("nil parse profiles do not Match themselves")
+	}
+}
+
+// Acceptance: a 3-schema contract fans out into 3 units with 3 fingerprints.
+func TestMultiSchemaFanout(t *testing.T) {
+	dc := &contract.DataContract{
+		ContractType: "source",
+		Metadata:     map[string]any{"source_format": "xlsx"},
+		Schemas: []contract.SchemaContract{
+			{Name: "Orders", Fields: []contract.FieldDefinition{{Name: "id", DataType: "text"}}},
+			{Name: "Customers", Fields: []contract.FieldDefinition{{Name: "id", DataType: "numeric"}}},
+			{Name: "Items", Fields: []contract.FieldDefinition{{Name: "sku", DataType: "text"}, {Name: "qty", DataType: "numeric"}}},
+		},
+	}
+	units, err := FromDataContract(dc)
+	if err != nil {
+		t.Fatalf("FromDataContract: %v", err)
+	}
+	if len(units) != 3 {
+		t.Fatalf("expected 3 units, got %d", len(units))
+	}
+	hashes := map[string]bool{}
+	locators := map[string]bool{}
+	for _, u := range units {
+		hashes[u.Object.Hash()] = true
+		locators[u.Locator] = true
+		if u.Object.Format != FormatXLSX {
+			t.Errorf("unit %q format = %q, want xlsx", u.Locator, u.Object.Format)
+		}
+	}
+	if len(hashes) != 3 {
+		t.Errorf("expected 3 distinct fingerprints, got %d", len(hashes))
+	}
+	if !locators["Orders"] || !locators["Customers"] || !locators["Items"] {
+		t.Errorf("locators not taken from sheet names: %v", locators)
+	}
+}
+
+func TestFromDataContractAPI(t *testing.T) {
+	dc := &contract.DataContract{
+		Metadata: map[string]any{"source": "openapi"},
+		Schemas: []contract.SchemaContract{
+			{Name: "GET /users", Fields: []contract.FieldDefinition{
+				{Name: "id", DataType: "integer"},
+				{Name: "email", DataType: "text"},
+				{Name: "created_at", DataType: "timestamptz"},
+				{Name: "active", DataType: "boolean"},
+				{Name: "tags", DataType: "array[text]"},
+				{Name: "settings", DataType: "jsonb"},
+				{Name: "ref", DataType: "uuid"},
+				{Name: "blob", DataType: "bytea"},
+			}},
+		},
+	}
+	units, err := FromDataContract(dc)
+	if err != nil {
+		t.Fatalf("FromDataContract: %v", err)
+	}
+	if units[0].Object.Format != FormatAPI {
+		t.Errorf("format = %q, want api", units[0].Object.Format)
+	}
+	want := map[string]CanonicalType{
+		"id": TypeNumber, "email": TypeString, "created_at": TypeTemporal,
+		"active": TypeBoolean, "tags": TypeArray, "settings": TypeObject,
+		"ref": TypeString, "blob": TypeString,
+	}
+	for _, f := range units[0].Object.Fields {
+		if want[f.Name] != f.Type {
+			t.Errorf("field %q mapped to %q, want %q", f.Name, f.Type, want[f.Name])
+		}
+	}
+}
+
+// The canonical form is pinned: this is the documented serialization other
+// components (and future algo versions) are measured against.
+func TestCanonicalBytesGolden(t *testing.T) {
+	o := mustCSV(t, csvContract(
+		csvField("amount", profile.TypeNumeric),
+		csvField("order_id", profile.TypeText),
+	))
+	want := `{"algo_version":"fp1","fields":[{"name":"amount","type":"NUMBER"},{"name":"order_id","type":"STRING"}],"format":"csv","nesting":null,"parse_profile":{"delimiter":",","encoding":"utf-8","has_header":true}}`
+	if got := string(o.CanonicalBytes()); got != want {
+		t.Errorf("canonical bytes:\n got %s\nwant %s", got, want)
+	}
+	if !strings.HasPrefix(o.Hash(), "fp1:") {
+		t.Errorf("hash %q lacks algo version prefix", o.Hash())
+	}
+
+	jsonObject := mustJSON(t, jsonContract("ndjson", jsonField("a", jsoncontract.TypeText)))
+	wantJSON := `{"algo_version":"fp1","fields":[{"name":"a","type":"STRING"}],"format":"ndjson","nesting":null,"parse_profile":{"delimiter":null,"encoding":"utf-8","has_header":null}}`
+	if got := string(jsonObject.CanonicalBytes()); got != wantJSON {
+		t.Errorf("ndjson canonical bytes:\n got %s\nwant %s", got, wantJSON)
+	}
+
+	bare := Object{AlgoVersion: AlgoVersion, Format: FormatXLSX, Fields: []Field{{Name: "x", Type: TypeString}}}
+	wantBare := `{"algo_version":"fp1","fields":[{"name":"x","type":"STRING"}],"format":"xlsx","nesting":null,"parse_profile":null}`
+	if got := string(bare.CanonicalBytes()); got != wantBare {
+		t.Errorf("bare canonical bytes:\n got %s\nwant %s", got, wantBare)
+	}
+}
+
+// Field names normalize to NFC with surrounding whitespace trimmed, so
+// byte-level encoding noise is absorbed while real renames still miss.
+func TestNameCanonicalisation(t *testing.T) {
+	nfd := mustCSV(t, csvContract(csvField("café ", profile.TypeText)))
+	nfc := mustCSV(t, csvContract(csvField("café", profile.TypeText)))
+	if nfd.Hash() != nfc.Hash() {
+		t.Errorf("NFC/trim noise changed hash")
+	}
+
+	upper := mustCSV(t, csvContract(csvField("CAFÉ", profile.TypeText)))
+	if upper.Hash() == nfc.Hash() {
+		t.Errorf("case change did not change hash; case must be preserved")
+	}
+}
+
+// Duplicate canonical names keep a deterministic order via the type
+// tie-break, so even degenerate schemas fingerprint stably.
+func TestDuplicateNameDeterminism(t *testing.T) {
+	first := mustCSV(t, csvContract(
+		csvField("a", profile.TypeText),
+		csvField("a ", profile.TypeNumeric),
+	))
+	second := mustCSV(t, csvContract(
+		csvField("a ", profile.TypeNumeric),
+		csvField("a", profile.TypeText),
+	))
+	if first.Hash() != second.Hash() {
+		t.Errorf("duplicate-name ordering is not deterministic")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := FromCSV(nil); err == nil {
+		t.Errorf("nil CSV contract: expected error")
+	}
+	if _, err := FromJSON(nil); err == nil {
+		t.Errorf("nil JSON contract: expected error")
+	}
+	if _, err := FromDataContract(nil); err == nil {
+		t.Errorf("nil data contract: expected error")
+	}
+	if _, err := FromCSV(csvContract()); err == nil {
+		t.Errorf("zero fields: expected error")
+	}
+	if _, err := FromJSON(jsonContract("xml", jsonField("a", jsoncontract.TypeText))); err == nil {
+		t.Errorf("unsupported JSON source format: expected error")
+	}
+	if _, err := FromJSON(jsonContract("json")); err == nil {
+		t.Errorf("JSON zero fields: expected error")
+	}
+	if _, err := FromCSV(csvContract(csvField("a", profile.DataType("mystery")))); err == nil {
+		t.Errorf("unmapped type: expected error")
+	}
+	if _, err := FromDataContract(&contract.DataContract{Metadata: map[string]any{}}); err == nil {
+		t.Errorf("undetectable format: expected error")
+	}
+	if _, err := FromDataContract(&contract.DataContract{Metadata: map[string]any{"source_format": "xlsx"}}); err == nil {
+		t.Errorf("no schemas: expected error")
+	}
+	badSchema := &contract.DataContract{
+		Metadata: map[string]any{"source_format": "xlsx"},
+		Schemas:  []contract.SchemaContract{{Name: "Bad", Fields: []contract.FieldDefinition{{Name: "x", DataType: "mystery"}}}},
+	}
+	if _, err := FromDataContract(badSchema); err == nil || !strings.Contains(err.Error(), `"Bad"`) {
+		t.Errorf("schema error not wrapped with schema name: %v", err)
+	}
+	if _, err := FromCSV(csvContract(csvField("a", "array[text"))); err == nil {
+		t.Errorf("malformed array type: expected error")
+	}
+}

--- a/fingerprint/hash.go
+++ b/fingerprint/hash.go
@@ -5,34 +5,21 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"strconv"
 )
 
-// CanonicalBytes serializes the object into its canonical JSON form: keys
-// sorted, fields pre-sorted by name, fixed type tokens, UTF-8, no
-// insignificant whitespace, absent values as explicit nulls. Same object ⇒
-// same bytes, with no dependence on map order, locale, or platform.
+// CanonicalBytes serializes the object into its canonical JSON form: keys in
+// fixed (alphabetical) order via struct declaration order, fields pre-sorted
+// by name, fixed type tokens, UTF-8, no insignificant whitespace, absent
+// values as explicit nulls, and no HTML escaping so the byte form is plain
+// RFC 8259 JSON reproducible outside Go. Same object ⇒ same bytes, with no
+// dependence on map order, locale, or platform.
 func (o Object) CanonicalBytes() []byte {
 	var b bytes.Buffer
-	b.WriteString(`{"algo_version":`)
-	writeString(&b, o.AlgoVersion)
-	b.WriteString(`,"fields":[`)
-	for i, f := range o.Fields {
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		b.WriteString(`{"name":`)
-		writeString(&b, f.Name)
-		b.WriteString(`,"type":`)
-		writeString(&b, string(f.Type))
-		b.WriteByte('}')
-	}
-	b.WriteString(`],"format":`)
-	writeString(&b, string(o.Format))
-	b.WriteString(`,"nesting":null,"parse_profile":`)
-	writeParseProfile(&b, o.ParseProfile)
-	b.WriteByte('}')
-	return b.Bytes()
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	// Encoding a struct of strings, bools, and slices cannot fail.
+	_ = enc.Encode(o)
+	return bytes.TrimSuffix(b.Bytes(), []byte("\n"))
 }
 
 // Hash returns the cache-key hash: the algorithm version prefixing a SHA-256
@@ -48,6 +35,9 @@ func (o Object) Hash() string {
 // guard, so even a SHA-256 collision cannot silently mis-route a file.
 func Match(a, b Object) bool {
 	if a.AlgoVersion != b.AlgoVersion || a.Format != b.Format {
+		return false
+	}
+	if !bytes.Equal(a.Nesting, b.Nesting) {
 		return false
 	}
 	if !parseProfileEqual(a.ParseProfile, b.ParseProfile) {
@@ -85,37 +75,4 @@ func boolPtrEqual(a, b *bool) bool {
 		return a == b
 	}
 	return *a == *b
-}
-
-func writeParseProfile(b *bytes.Buffer, p *ParseProfile) {
-	if p == nil {
-		b.WriteString("null")
-		return
-	}
-	b.WriteString(`{"delimiter":`)
-	writeStringPtr(b, p.Delimiter)
-	b.WriteString(`,"encoding":`)
-	writeStringPtr(b, p.Encoding)
-	b.WriteString(`,"has_header":`)
-	if p.HasHeader == nil {
-		b.WriteString("null")
-	} else {
-		b.WriteString(strconv.FormatBool(*p.HasHeader))
-	}
-	b.WriteByte('}')
-}
-
-func writeStringPtr(b *bytes.Buffer, s *string) {
-	if s == nil {
-		b.WriteString("null")
-		return
-	}
-	writeString(b, *s)
-}
-
-// writeString writes a JSON string literal. encoding/json string encoding is
-// deterministic, and a plain string value cannot fail to marshal.
-func writeString(b *bytes.Buffer, s string) {
-	encoded, _ := json.Marshal(s)
-	b.Write(encoded)
 }

--- a/fingerprint/hash.go
+++ b/fingerprint/hash.go
@@ -1,0 +1,121 @@
+package fingerprint
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+)
+
+// CanonicalBytes serializes the object into its canonical JSON form: keys
+// sorted, fields pre-sorted by name, fixed type tokens, UTF-8, no
+// insignificant whitespace, absent values as explicit nulls. Same object ⇒
+// same bytes, with no dependence on map order, locale, or platform.
+func (o Object) CanonicalBytes() []byte {
+	var b bytes.Buffer
+	b.WriteString(`{"algo_version":`)
+	writeString(&b, o.AlgoVersion)
+	b.WriteString(`,"fields":[`)
+	for i, f := range o.Fields {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"name":`)
+		writeString(&b, f.Name)
+		b.WriteString(`,"type":`)
+		writeString(&b, string(f.Type))
+		b.WriteByte('}')
+	}
+	b.WriteString(`],"format":`)
+	writeString(&b, string(o.Format))
+	b.WriteString(`,"nesting":null,"parse_profile":`)
+	writeParseProfile(&b, o.ParseProfile)
+	b.WriteByte('}')
+	return b.Bytes()
+}
+
+// Hash returns the cache-key hash: the algorithm version prefixing a SHA-256
+// of the canonical bytes, e.g. "fp1:9f2c…". The version prefix guarantees an
+// old hash is never reinterpreted under new canonicalisation rules.
+func (o Object) Hash() string {
+	sum := sha256.Sum256(o.CanonicalBytes())
+	return o.AlgoVersion + ":" + hex.EncodeToString(sum[:])
+}
+
+// Match reports whether two objects are structurally identical. A cache hit
+// requires hash equality AND Match: the stored object is the collision
+// guard, so even a SHA-256 collision cannot silently mis-route a file.
+func Match(a, b Object) bool {
+	if a.AlgoVersion != b.AlgoVersion || a.Format != b.Format {
+		return false
+	}
+	if !parseProfileEqual(a.ParseProfile, b.ParseProfile) {
+		return false
+	}
+	if len(a.Fields) != len(b.Fields) {
+		return false
+	}
+	for i := range a.Fields {
+		if a.Fields[i] != b.Fields[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func parseProfileEqual(a, b *ParseProfile) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return strPtrEqual(a.Delimiter, b.Delimiter) &&
+		strPtrEqual(a.Encoding, b.Encoding) &&
+		boolPtrEqual(a.HasHeader, b.HasHeader)
+}
+
+func strPtrEqual(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func writeParseProfile(b *bytes.Buffer, p *ParseProfile) {
+	if p == nil {
+		b.WriteString("null")
+		return
+	}
+	b.WriteString(`{"delimiter":`)
+	writeStringPtr(b, p.Delimiter)
+	b.WriteString(`,"encoding":`)
+	writeStringPtr(b, p.Encoding)
+	b.WriteString(`,"has_header":`)
+	if p.HasHeader == nil {
+		b.WriteString("null")
+	} else {
+		b.WriteString(strconv.FormatBool(*p.HasHeader))
+	}
+	b.WriteByte('}')
+}
+
+func writeStringPtr(b *bytes.Buffer, s *string) {
+	if s == nil {
+		b.WriteString("null")
+		return
+	}
+	writeString(b, *s)
+}
+
+// writeString writes a JSON string literal. encoding/json string encoding is
+// deterministic, and a plain string value cannot fail to marshal.
+func writeString(b *bytes.Buffer, s string) {
+	encoded, _ := json.Marshal(s)
+	b.Write(encoded)
+}


### PR DESCRIPTION
First build slice of the autonomous ingestion platform (implementation-plan Phase 0.1, closes #73).

The platform's JIT-compiler model needs a cache key: a deterministic identity for the structural shape of incoming data, so a known shape runs its pinned pipeline with no LLM involved and an unknown shape triggers authoring. A wrong match means a file silently flows through the wrong pipeline, so identity errs toward specificity per the spec — strict on format, parse profile, names, and coarse types; deliberately blind to nullability and profiling so same-shape files always hit.

Adds the `fingerprint` package: canonical object + versioned hash, deep-equality collision guard, multi-schema fanout (Excel sheets / API endpoints), and the deterministic near-neighbour ranking that supplies reference pipelines to cache-miss authoring. All nine acceptance criteria from the spec's §10 table are implemented as named tests; the package joins the 100% coverage gate in `make check`.

One mapping decision worth review: the analyzer vocabularies are wider than the spec's lattice table (apicontract emits `integer`, `timestamptz`, `uuid`, `bytea`, `jsonb`, `array[...]`), so those are mapped onto the coarse lattice explicitly, and any token outside the known vocabularies is an error rather than a silent coercion — strictness over availability, per the spec's one rule.