### PR TITLE
Detect no header when the first row matches the column value classes

### DIFF
--- a/csvcontract/analyze.go
+++ b/csvcontract/analyze.go
@@ -40,10 +40,11 @@ func AnalyzeFile(ctx context.Context, path string, opts *Options) (*SourceContra
 //
 //  1. Sniff: read the first 8KB to detect encoding and delimiter, then
 //     seek back to the start.
-//  2. Stream: single sequential pass through all rows. The first row is
-//     used for header detection. Every data row is fed to per-column
-//     profilers (type inference, null counting, frequency tracking,
-//     min/max). Up to MaxSampleRows are kept for the SampleData field.
+//  2. Stream: single sequential pass through all rows. The first row
+//     plus a bounded probe of the following rows are used for header
+//     detection. Every data row is fed to per-column profilers (type
+//     inference, null counting, frequency tracking, min/max). Up to
+//     MaxSampleRows are kept for the SampleData field.
 //
 // Peak memory is bounded by MaxTracked (default 10,000) distinct values
 // per column plus MaxSampleRows (default 5) stored rows, regardless of
@@ -123,7 +124,29 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 		return nil, fmt.Errorf("file is empty")
 	}
 
-	hasHeader := profile.DetectHeader(firstRow)
+	// Buffer a bounded probe of the following rows so header detection
+	// can compare the first row's value classes against the column
+	// value classes. A read error during the probe is remembered and
+	// surfaced after the buffered rows are processed, preserving the
+	// row number reported for parse errors.
+	var probe [][]string
+	var probeErr error
+	for len(probe) < profile.HeaderProbeRows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		record, readErr := reader.Read()
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			probeErr = readErr
+			break
+		}
+		probe = append(probe, record)
+	}
+
+	hasHeader := profile.DetectHeaderWithRows(firstRow, probe)
 
 	var fieldNames []string
 	maxSampleRows := opts.maxSampleRows()
@@ -157,16 +180,26 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 		colTypes[i] = profile.TypeEmpty
 	}
 
-	// If the first row is data, process it.
 	var sampleRows [][]string
 	totalRows := 0
 
-	if firstDataRow != nil {
+	processRow := func(record []string) {
 		totalRows++
-		observeRow(firstDataRow, profilers, colTypes, numFields)
+		observeRow(record, profilers, colTypes, numFields)
 		if len(sampleRows) < maxSampleRows {
-			sampleRows = append(sampleRows, firstDataRow)
+			sampleRows = append(sampleRows, record)
 		}
+	}
+
+	// If the first row is data, process it, then drain the probe buffer.
+	if firstDataRow != nil {
+		processRow(firstDataRow)
+	}
+	for _, record := range probe {
+		processRow(record)
+	}
+	if probeErr != nil {
+		return nil, fmt.Errorf("parse error at row %d: %w", totalRows+2, probeErr)
 	}
 
 	// Stream all remaining rows.
@@ -182,11 +215,7 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 		if readErr != nil {
 			return nil, fmt.Errorf("parse error at row %d: %w", totalRows+2, readErr)
 		}
-		totalRows++
-		observeRow(record, profilers, colTypes, numFields)
-		if len(sampleRows) < maxSampleRows {
-			sampleRows = append(sampleRows, record)
-		}
+		processRow(record)
 	}
 
 	topN := opts.topN()

--- a/csvcontract/analyze_test.go
+++ b/csvcontract/analyze_test.go
@@ -157,6 +157,120 @@ func TestAnalyzeNoHeader(t *testing.T) {
 	})
 }
 
+func TestAnalyzeHomogeneousNoHeader(t *testing.T) {
+	// Exact reproduction from issue #75: a headerless file where every
+	// row has the same value classes. The first row must be treated as
+	// data, not promoted to field names, or consumers silently drop a
+	// record.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "parts.csv")
+	content := "P-600,Kedjespannare K2,75.50,2026-06-07\n" +
+		"P-601,Drevsats 13T,189.00,2026-06-07\n" +
+		"P-602,Kedjelas X,45.25,2026-06-08\n" +
+		"P-603,Bromsok F4,320.00,2026-06-08\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	contract, err := AnalyzeFile(ctx, path, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeFile: %v", err)
+	}
+
+	assertContract(t, contract, SourceContract{
+		SourceFormat: "csv",
+		Encoding:     "utf-8",
+		Delimiter:    ",",
+		HasHeader:    false,
+		TotalRows:    4,
+		Fields: []Field{
+			{Name: "column_1", DataType: profile.TypeText, Profile: profile.FieldProfile{
+				TotalCount: 4, NullCount: 0, NullPercentage: 0,
+				MinValue: ptr("P-600"), MaxValue: ptr("P-603"),
+				TopValues: []ct.TopValue{tv("P-600", 1), tv("P-601", 1), tv("P-602", 1), tv("P-603", 1)},
+			}},
+			{Name: "column_2", DataType: profile.TypeText, Profile: profile.FieldProfile{
+				TotalCount: 4, NullCount: 0, NullPercentage: 0,
+				MinValue: ptr("Bromsok F4"), MaxValue: ptr("Kedjespannare K2"),
+				TopValues: []ct.TopValue{tv("Bromsok F4", 1), tv("Drevsats 13T", 1), tv("Kedjelas X", 1), tv("Kedjespannare K2", 1)},
+			}},
+			{Name: "column_3", DataType: profile.TypeNumeric, Profile: profile.FieldProfile{
+				TotalCount: 4, NullCount: 0, NullPercentage: 0,
+				MinValue: ptr("45.25"), MaxValue: ptr("320.00"),
+				TopValues: []ct.TopValue{tv("189.00", 1), tv("320.00", 1), tv("45.25", 1), tv("75.50", 1)},
+			}},
+			{Name: "column_4", DataType: profile.TypeDate, Profile: profile.FieldProfile{
+				TotalCount: 4, NullCount: 0, NullPercentage: 0,
+				MinValue: ptr("2026-06-07"), MaxValue: ptr("2026-06-08"),
+				TopValues: []ct.TopValue{tv("2026-06-07", 2), tv("2026-06-08", 2)},
+			}},
+		},
+		SampleData: [][]string{
+			{"P-600", "Kedjespannare K2", "75.50", "2026-06-07"},
+			{"P-601", "Drevsats 13T", "189.00", "2026-06-07"},
+			{"P-602", "Kedjelas X", "45.25", "2026-06-08"},
+			{"P-603", "Bromsok F4", "320.00", "2026-06-08"},
+		},
+		Issues: nil,
+	})
+}
+
+func TestAnalyzeNumericFirstRowNoHeader(t *testing.T) {
+	// A first row whose numeric cell sits over a numeric column is
+	// strong evidence against a header even though the row contains
+	// text.
+	r := bytes.NewReader([]byte("widget,75.50\ngadget,189.00\nsprocket,45.25\n"))
+	contract, err := AnalyzeReader(ctx, r, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeReader: %v", err)
+	}
+	if contract.HasHeader {
+		t.Error("expected no header for numeric first-row cell over numeric column")
+	}
+	if contract.TotalRows != 3 {
+		t.Errorf("total_rows = %d, want 3", contract.TotalRows)
+	}
+	if contract.Fields[0].Name != "column_1" || contract.Fields[1].Name != "column_2" {
+		t.Errorf("field names = %q, %q, want column_1, column_2",
+			contract.Fields[0].Name, contract.Fields[1].Name)
+	}
+}
+
+func TestAnalyzeTemporalFirstRowNoHeader(t *testing.T) {
+	// Same as above but with a date cell over a date column.
+	r := bytes.NewReader([]byte("widget,2026-06-07\ngadget,2026-06-08\nsprocket,2026-06-09\n"))
+	contract, err := AnalyzeReader(ctx, r, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeReader: %v", err)
+	}
+	if contract.HasHeader {
+		t.Error("expected no header for date first-row cell over date column")
+	}
+	if contract.TotalRows != 3 {
+		t.Errorf("total_rows = %d, want 3", contract.TotalRows)
+	}
+	if contract.Fields[1].DataType != profile.TypeDate {
+		t.Errorf("column_2 data_type = %q, want %q", contract.Fields[1].DataType, profile.TypeDate)
+	}
+}
+
+func TestAnalyzeAllTextAssumesHeader(t *testing.T) {
+	// All-text files are genuinely ambiguous: a text header over text
+	// columns and a headerless text file have identical value classes.
+	// The historical behavior (assume a header) is pinned here.
+	r := bytes.NewReader([]byte("alpha,beta\ngamma,delta\nepsilon,zeta\n"))
+	contract, err := AnalyzeReader(ctx, r, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeReader: %v", err)
+	}
+	if !contract.HasHeader {
+		t.Error("expected header for all-text file (documented ambiguity)")
+	}
+	if contract.TotalRows != 2 {
+		t.Errorf("total_rows = %d, want 2", contract.TotalRows)
+	}
+}
+
 func TestAnalyzeEmptyCSV(t *testing.T) {
 	contract, err := AnalyzeFile(ctx, "testdata/empty.csv", nil)
 	if err != nil {
@@ -738,6 +852,101 @@ func (r *failDuringStreamReader) Read(p []byte) (int, error) {
 func (r *failDuringStreamReader) Seek(offset int64, _ int) (int64, error) {
 	r.offset = int(offset)
 	return offset, nil
+}
+
+func TestAnalyzeReaderLateStreamParseError(t *testing.T) {
+	// A read error after the header-detection probe (32 rows) must be
+	// reported from the main streaming loop.
+	var buf bytes.Buffer
+	buf.WriteString("Name,Value\n")
+	for i := 0; i < 600; i++ {
+		fmt.Fprintf(&buf, "row%d,%d\n", i, i)
+	}
+	r := &failAtEndReader{data: buf.Bytes()}
+	_, err := AnalyzeReader(ctx, r, nil)
+	if err == nil {
+		t.Fatal("expected error for late stream read failure")
+	}
+	if !strings.Contains(err.Error(), "injected late stream error") {
+		t.Errorf("error = %q, want to contain 'injected late stream error'", err)
+	}
+}
+
+// failAtEndReader serves its data normally but, once the analyzer has
+// seeked back to the start, replaces the final EOF with an error.
+type failAtEndReader struct {
+	data   []byte
+	offset int
+	seeked bool
+}
+
+func (r *failAtEndReader) Read(p []byte) (int, error) {
+	if r.offset >= len(r.data) {
+		if r.seeked {
+			return 0, fmt.Errorf("injected late stream error")
+		}
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.offset:])
+	r.offset += n
+	return n, nil
+}
+
+func (r *failAtEndReader) Seek(offset int64, _ int) (int64, error) {
+	r.offset = int(offset)
+	r.seeked = true
+	return offset, nil
+}
+
+func TestAnalyzeReaderCancelAfterProbe(t *testing.T) {
+	// Cancellation that happens after the header-detection probe must be
+	// caught by the main streaming loop.
+	var buf bytes.Buffer
+	buf.WriteString("Name,Value\n")
+	for i := 0; i < 2000; i++ {
+		fmt.Fprintf(&buf, "row%d,%d\n", i, i)
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	r := &cancelOnSecondFillReader{
+		ReadSeeker: bytes.NewReader(buf.Bytes()),
+		cancel:     cancel,
+	}
+
+	_, err := AnalyzeReader(cancelCtx, r, nil)
+	if err == nil {
+		t.Fatal("expected error for context cancelled after probe")
+	}
+}
+
+// cancelOnSecondFillReader cancels the context on the second buffered
+// read after the analyzer has seeked back to the start. By then the
+// header-detection probe has long been satisfied from the first buffer
+// fill, so the cancellation lands in the main streaming loop.
+type cancelOnSecondFillReader struct {
+	io.ReadSeeker
+	cancel func()
+	seeked bool
+	fills  int
+}
+
+func (r *cancelOnSecondFillReader) Read(p []byte) (int, error) {
+	n, err := r.ReadSeeker.Read(p)
+	if r.seeked {
+		r.fills++
+		if r.fills >= 2 {
+			r.cancel()
+		}
+	}
+	return n, err
+}
+
+func (r *cancelOnSecondFillReader) Seek(offset int64, whence int) (int64, error) {
+	n, err := r.ReadSeeker.Seek(offset, whence)
+	if whence == io.SeekStart && offset == 0 {
+		r.seeked = true
+	}
+	return n, err
 }
 
 func TestAnalyzeRowShorterThanHeader(t *testing.T) {

--- a/excelcontract/analyze.go
+++ b/excelcontract/analyze.go
@@ -87,9 +87,12 @@ func analyzeSheet(f *excelize.File, sheet string, opts *Options) (*contract.Sche
 		return nil, nil
 	}
 
-	// Determine field names from the header row.
+	// Determine field names from the header row. A bounded probe of the
+	// rows below it lets the detector compare the candidate header's
+	// value classes against the column value classes, so a homogeneous
+	// headerless sheet is not mistaken for one with a header.
 	headerRow := rows[region.headerRow]
-	hasHeader := profile.DetectHeader(headerRow)
+	hasHeader := profile.DetectHeaderWithRows(headerRow, probeRows(rows, region.headerRow+1))
 
 	var fieldNames []string
 	if hasHeader {
@@ -180,6 +183,19 @@ func analyzeSheet(f *excelize.File, sheet string, opts *Options) (*contract.Sche
 			RequiredFields: requiredFields(fields),
 		},
 	}, nil
+}
+
+// probeRows collects up to profile.HeaderProbeRows non-empty rows
+// starting at the given index, for header detection.
+func probeRows(rows [][]string, start int) [][]string {
+	var probe [][]string
+	for i := start; i < len(rows) && len(probe) < profile.HeaderProbeRows; i++ {
+		if isEmptyRow(rows[i]) {
+			continue
+		}
+		probe = append(probe, rows[i])
+	}
+	return probe
 }
 
 // requiredFields returns field names where all values are non-null.

--- a/excelcontract/analyze_test.go
+++ b/excelcontract/analyze_test.go
@@ -396,6 +396,46 @@ func TestAnalyzeHeaderOnlySheet(t *testing.T) {
 	}
 }
 
+func TestAnalyzeHomogeneousSheetNoHeader(t *testing.T) {
+	// Same shape as the CSV reproduction in issue #75: every row has
+	// identical value classes, so the first row is data, not a header.
+	f := excelize.NewFile()
+	defer func() { _ = f.Close() }()
+	// Row 3 is left blank: blank rows are skipped both by the header
+	// probe and by profiling.
+	_ = f.SetSheetRow("Sheet1", "A1", &[]any{"P-600", "Kedjespannare K2", "75.50", "2026-06-07"})
+	_ = f.SetSheetRow("Sheet1", "A2", &[]any{"P-601", "Drevsats 13T", "189.00", "2026-06-07"})
+	_ = f.SetSheetRow("Sheet1", "A4", &[]any{"P-602", "Kedjelas X", "45.25", "2026-06-08"})
+	_ = f.SetSheetRow("Sheet1", "A5", &[]any{"P-603", "Bromsok F4", "320.00", "2026-06-08"})
+
+	buf, err := f.WriteToBuffer()
+	if err != nil {
+		t.Fatalf("WriteToBuffer: %v", err)
+	}
+
+	dc, err := AnalyzeReader(ctx, bytes.NewReader(buf.Bytes()), nil)
+	if err != nil {
+		t.Fatalf("AnalyzeReader: %v", err)
+	}
+
+	sc := dc.Schemas[0]
+	if sc.RowCount == nil || *sc.RowCount != 4 {
+		t.Errorf("row_count = %v, want 4", sc.RowCount)
+	}
+	if len(sc.Fields) != 4 {
+		t.Fatalf("fields count = %d, want 4", len(sc.Fields))
+	}
+	wantNames := []string{"column_1", "column_2", "column_3", "column_4"}
+	for i, want := range wantNames {
+		if sc.Fields[i].Name != want {
+			t.Errorf("fields[%d].Name = %q, want %q", i, sc.Fields[i].Name, want)
+		}
+	}
+	if len(sc.SampleData) == 0 || sc.SampleData[0][0] != "P-600" {
+		t.Errorf("sample_data[0] = %v, want first row preserved as data", sc.SampleData)
+	}
+}
+
 func TestAnalyzeAllEmptySheets(t *testing.T) {
 	// Create a workbook with only empty sheets.
 	f := excelize.NewFile()

--- a/profile/header.go
+++ b/profile/header.go
@@ -5,10 +5,20 @@ import (
 	"strings"
 )
 
+// HeaderProbeRows is the recommended number of data rows to collect and
+// pass to DetectHeaderWithRows. It is large enough to establish stable
+// column value classes and small enough to keep memory bounded for
+// streaming analyzers.
+const HeaderProbeRows = 32
+
 // DetectHeader returns true if the first row looks like a header rather
-// than data. The heuristic: if every non-empty cell in the first row is
-// numeric, it is probably data. If at least one cell is non-numeric and
-// non-empty, it is probably a header.
+// than data, judging by the first row alone. The heuristic: if every
+// non-empty cell in the first row is numeric, it is probably data. If at
+// least one cell is non-numeric and non-empty, it is probably a header.
+//
+// When subsequent rows are available, prefer DetectHeaderWithRows, which
+// also compares the first row against the column value classes and
+// catches headerless files whose first row contains text.
 //
 // This uses the same IsNumeric function as type inference to ensure
 // consistent behavior.
@@ -26,6 +36,59 @@ func DetectHeader(firstRow []string) bool {
 		}
 	}
 	return false
+}
+
+// DetectHeaderWithRows returns true if the first row looks like a header
+// rather than data, using the rows that follow it as evidence.
+//
+// It starts from the single-row heuristic (DetectHeader): an all-numeric
+// first row is data. When the first row contains text it then compares
+// each first-row cell against the value class of its column in dataRows.
+// A first-row cell that parses as numeric or date in a column whose
+// remaining values are also numeric or date is strong evidence against a
+// header: real headers are names, not numbers or dates. One such column
+// is enough to conclude the file has no header, because a homogeneous
+// first row would otherwise be promoted to field names and consumers
+// would silently drop the first record.
+//
+// All-text files are genuinely ambiguous: a text header over text
+// columns and a headerless text file produce identical value classes.
+// For those we keep the historical behavior and report a header, since
+// no column-class evidence can distinguish the two cases.
+//
+// dataRows should be a bounded probe of the rows after the first one;
+// HeaderProbeRows is a sensible size. Passing no rows degrades to
+// DetectHeader.
+func DetectHeaderWithRows(firstRow []string, dataRows [][]string) bool {
+	if !DetectHeader(firstRow) {
+		return false
+	}
+	for col, cell := range firstRow {
+		first := ClassifyCell(cell)
+		if first != TypeNumeric && first != TypeDate {
+			continue
+		}
+		colClass := columnClass(dataRows, col)
+		if colClass == TypeNumeric || colClass == TypeDate {
+			return false
+		}
+	}
+	return true
+}
+
+// columnClass merges the cell classes of one column across rows, using
+// the same priority order as type inference (text > date > numeric >
+// empty). Rows shorter than col contribute an empty cell.
+func columnClass(rows [][]string, col int) DataType {
+	class := TypeEmpty
+	for _, row := range rows {
+		var value string
+		if col < len(row) {
+			value = row[col]
+		}
+		class = MergeTypes(class, ClassifyCell(value))
+	}
+	return class
 }
 
 // GenerateFieldNames returns column names for a headerless file by

--- a/profile/header_test.go
+++ b/profile/header_test.go
@@ -24,6 +24,116 @@ func TestDetectHeader(t *testing.T) {
 	}
 }
 
+func TestDetectHeaderWithRows(t *testing.T) {
+	tests := []struct {
+		name     string
+		firstRow []string
+		dataRows [][]string
+		want     bool
+	}{
+		{
+			// Exact reproduction from issue #75: every row has the same
+			// value classes (identifier, text, numeric, date), so the
+			// first row is data, not a header.
+			name:     "homogeneous headerless rows",
+			firstRow: []string{"P-600", "Kedjespannare K2", "75.50", "2026-06-07"},
+			dataRows: [][]string{
+				{"P-601", "Drevsats 13T", "189.00", "2026-06-07"},
+				{"P-602", "Kedjelas X", "45.25", "2026-06-08"},
+				{"P-603", "Bromsok F4", "320.00", "2026-06-08"},
+			},
+			want: false,
+		},
+		{
+			name:     "numeric first-row cell in numeric column",
+			firstRow: []string{"widget", "75.50"},
+			dataRows: [][]string{
+				{"gadget", "189.00"},
+				{"sprocket", "45.25"},
+			},
+			want: false,
+		},
+		{
+			name:     "temporal first-row cell in temporal column",
+			firstRow: []string{"widget", "2026-06-07"},
+			dataRows: [][]string{
+				{"gadget", "2026-06-08"},
+				{"sprocket", "2026-06-09"},
+			},
+			want: false,
+		},
+		{
+			// Regression: a classic text header over numeric data must
+			// still be detected as a header.
+			name:     "text header over numeric columns",
+			firstRow: []string{"Name", "Age", "Score"},
+			dataRows: [][]string{
+				{"Alice", "30", "95.5"},
+				{"Bob", "25", "87.3"},
+			},
+			want: true,
+		},
+		{
+			// All-text files are genuinely ambiguous: a text header over
+			// text columns and a headerless text file have identical
+			// value classes. The historical behavior (header) is pinned.
+			name:     "all-text rows stay ambiguous, header assumed",
+			firstRow: []string{"alpha", "beta"},
+			dataRows: [][]string{
+				{"gamma", "delta"},
+				{"epsilon", "zeta"},
+			},
+			want: true,
+		},
+		{
+			// A numeric first-row cell over a text column is not
+			// evidence against a header: the column class disagrees.
+			name:     "numeric first-row cell over text column",
+			firstRow: []string{"Name", "42"},
+			dataRows: [][]string{
+				{"Alice", "forty"},
+				{"Bob", "fifty"},
+			},
+			want: true,
+		},
+		{
+			// A numeric first-row cell over an all-empty column gives no
+			// evidence either way; keep the single-row verdict.
+			name:     "numeric first-row cell over empty column",
+			firstRow: []string{"Name", "42"},
+			dataRows: [][]string{
+				{"Alice", ""},
+				{"Bob"},
+			},
+			want: true,
+		},
+		{
+			name:     "all numeric first row is data regardless of rows",
+			firstRow: []string{"1", "2"},
+			dataRows: [][]string{{"3", "4"}},
+			want:     false,
+		},
+		{
+			name:     "no data rows falls back to single-row heuristic",
+			firstRow: []string{"Name", "Age"},
+			dataRows: nil,
+			want:     true,
+		},
+		{
+			name:     "empty first row",
+			firstRow: []string{},
+			dataRows: [][]string{{"1", "2"}},
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		got := DetectHeaderWithRows(tt.firstRow, tt.dataRows)
+		if got != tt.want {
+			t.Errorf("DetectHeaderWithRows(%s) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestGenerateFieldNames(t *testing.T) {
 	names := GenerateFieldNames(3)
 	want := []string{"column_1", "column_2", "column_3"}


### PR DESCRIPTION
Header detection judged the first row in isolation, so a homogeneous headerless CSV (identifier, name, price, date on every row) was reported with has_header true. The first DATA row got promoted to field names, and any consumer trusting the parse profile silently dropped that record. In the ingestion platform the loss was only avoided because the authoring agent noticed the contradiction and re-parsed row 0 as data.

The detector now compares the first row's value classes against the column value classes of a bounded probe of the following rows. A first-row cell that parses as numeric or temporal in a column whose other values are numeric or temporal is treated as strong evidence against a header, since real headers are names, not numbers or dates. One such column concludes no header, and field names are synthesized positionally.

All-text files remain genuinely ambiguous (a text header over text columns and a headerless text file have identical value classes), so the historical header-assumed behavior is kept there and documented. Text headers over numeric columns are detected exactly as before. The same row-aware detection is applied to both the CSV and the Excel analyzers, which shared the single-row heuristic.

Closes #75