### PR TITLE
Add per-field value-shape signatures with a drift tripwire

### DIFF
--- a/csvcontract/analyze_shape_test.go
+++ b/csvcontract/analyze_shape_test.go
@@ -1,0 +1,39 @@
+package csvcontract
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAnalyzeFieldShape pins the serialized shape signature end to
+// end: the platform stores this JSON at authoring time and compares
+// landed files against it, so the exact wire shape is contract.
+func TestAnalyzeFieldShape(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "products.csv")
+	content := "sku,name\nP-600,Kedjespannare K2\nP-601,Drevsats K13\nP-602,Styrlager konisk\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sc, err := AnalyzeFile(context.Background(), path, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeFile() = %v, want nil", err)
+	}
+	if len(sc.Fields) != 2 {
+		t.Fatalf("fields = %d, want 2", len(sc.Fields))
+	}
+	got, err := json.Marshal(sc.Fields[0].Profile.Shape)
+	if err != nil {
+		t.Fatalf("marshal shape: %v", err)
+	}
+	want := `{"masks":[{"mask":"A-9","count":3}],"dominant_share":1,"length_min":5,"length_max":5}`
+	if string(got) != want {
+		t.Errorf("sku shape = %s, want %s", got, want)
+	}
+	name := sc.Fields[1].Profile.Shape
+	if name.Masks[0].Mask != "A_A9" || name.DominantShare != 0.67 {
+		t.Errorf("name shape = %+v, want dominant A_A9 at 0.67", name)
+	}
+}

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -19,6 +19,7 @@ type ColumnProfiler struct {
 	maxTracked int
 	capped     bool
 	tracker    RangeTracker
+	shape      shapeTracker
 }
 
 // NewColumnProfiler creates a profiler that tracks up to maxTracked
@@ -40,6 +41,7 @@ func (p *ColumnProfiler) Observe(value string) {
 	}
 
 	p.tracker.Observe(value)
+	p.shape.observe(value)
 
 	if count, exists := p.freqs[value]; exists {
 		p.freqs[value] = count + 1
@@ -73,6 +75,7 @@ func (p *ColumnProfiler) Finish(topN int) FieldProfile {
 		MinValue:       minVal,
 		MaxValue:       maxVal,
 		TopValues:      p.topValues(topN),
+		Shape:          p.shape.signature(),
 	}
 }
 

--- a/profile/shape.go
+++ b/profile/shape.go
@@ -1,0 +1,192 @@
+package profile
+
+import (
+	"math"
+	"slices"
+	"strings"
+	"unicode"
+)
+
+// maxTrackedMasks bounds the per-column mask map so adversarial data
+// cannot bloat it; once exceeded, further unseen masks land in the
+// overflowMask bucket.
+const maxTrackedMasks = 32
+
+// overflowMask is the bucket that absorbs mask classes beyond the
+// tracked bound. It never participates in dominance decisions: an
+// overflowing column has no clear dominant by definition.
+const overflowMask = "..."
+
+// dominantShareFloor is the share a mask class needs before the
+// comparator treats it as the column's clear dominant. Below it the
+// column is too mixed for a swap verdict, and DriftsFrom stays quiet.
+const dominantShareFloor = 0.6
+
+// MaskCount is one coarse format mask and how many values matched it.
+type MaskCount struct {
+	Mask  string `json:"mask"`
+	Count int    `json:"count"`
+}
+
+// ShapeSignature is a column's value-shape evidence: the distribution
+// of coarse format masks over its non-null values, the share of the
+// most common mask, and the observed length range. It serves two
+// consumers at once: an authoring agent reading the contract gets
+// explicit shape evidence beside the samples, and the ingestion
+// platform compares a landed file's signatures against the ones
+// recorded when the pipeline was authored, to catch files whose
+// columns swapped meaning under an unchanged schema.
+type ShapeSignature struct {
+	// Masks holds the mask classes seen, sorted by count descending
+	// then mask ascending, so identical input always serializes
+	// identically.
+	Masks []MaskCount `json:"masks"`
+
+	// DominantShare is the fraction of non-null values matching the
+	// most common mask, rounded to two decimals for JSON stability.
+	// Zero when the column had no non-null values.
+	DominantShare float64 `json:"dominant_share"`
+
+	// LengthMin and LengthMax bound the rune lengths of non-null
+	// values. Both zero when the column had no non-null values.
+	LengthMin int `json:"length_min"`
+	LengthMax int `json:"length_max"`
+}
+
+// FormatMask compresses a value into its coarse shape: runs of letters
+// become "A", runs of digits become "9", runs of whitespace become
+// "_", and any other rune is kept verbatim with identical neighbours
+// collapsed. "P-600" masks to "A-9", "Kedjespannare K2" to "A_A9",
+// "75.50" to "9.9", "2026-06-07" to "9-9-9".
+func FormatMask(value string) string {
+	var b strings.Builder
+	var last rune
+	hasLast := false
+	for _, r := range value {
+		var class rune
+		switch {
+		case unicode.IsLetter(r):
+			class = 'A'
+		case unicode.IsDigit(r):
+			class = '9'
+		case unicode.IsSpace(r):
+			class = '_'
+		default:
+			class = r
+		}
+		if hasLast && class == last {
+			continue
+		}
+		b.WriteRune(class)
+		last = class
+		hasLast = true
+	}
+	return b.String()
+}
+
+// shapeTracker accumulates mask statistics inside ColumnProfiler's
+// existing single pass.
+type shapeTracker struct {
+	masks    map[string]int
+	total    int
+	lenMin   int
+	lenMax   int
+	seenAny  bool
+	overflow int
+}
+
+// observe records one non-null value's mask and length.
+func (t *shapeTracker) observe(value string) {
+	if t.masks == nil {
+		t.masks = make(map[string]int)
+	}
+	t.total++
+	length := len([]rune(value))
+	if !t.seenAny || length < t.lenMin {
+		t.lenMin = length
+	}
+	if !t.seenAny || length > t.lenMax {
+		t.lenMax = length
+	}
+	t.seenAny = true
+
+	mask := FormatMask(value)
+	if _, exists := t.masks[mask]; exists {
+		t.masks[mask]++
+		return
+	}
+	if len(t.masks) < maxTrackedMasks {
+		t.masks[mask] = 1
+		return
+	}
+	t.overflow++
+}
+
+// signature renders the accumulated state deterministically.
+func (t *shapeTracker) signature() ShapeSignature {
+	masks := make([]MaskCount, 0, len(t.masks)+1)
+	for m, c := range t.masks {
+		masks = append(masks, MaskCount{Mask: m, Count: c})
+	}
+	if t.overflow > 0 {
+		masks = append(masks, MaskCount{Mask: overflowMask, Count: t.overflow})
+	}
+	slices.SortFunc(masks, func(a, b MaskCount) int {
+		if a.Count != b.Count {
+			return b.Count - a.Count
+		}
+		return strings.Compare(a.Mask, b.Mask)
+	})
+
+	share := 0.0
+	if t.total > 0 && len(masks) > 0 && masks[0].Mask != overflowMask {
+		share = math.Round(float64(masks[0].Count)/float64(t.total)*100) / 100
+	}
+	return ShapeSignature{
+		Masks:         masks,
+		DominantShare: share,
+		LengthMin:     t.lenMin,
+		LengthMax:     t.lenMax,
+	}
+}
+
+// dominant returns the signature's clear dominant mask, or false when
+// the column has none: no values, an overflow bucket on top, or a
+// share below the floor.
+func (s ShapeSignature) dominant() (string, bool) {
+	if len(s.Masks) == 0 || s.Masks[0].Mask == overflowMask || s.DominantShare < dominantShareFloor {
+		return "", false
+	}
+	return s.Masks[0].Mask, true
+}
+
+// DriftsFrom reports whether the observed signature s has drifted from
+// a baseline recorded earlier for the same column. It is a TRIPWIRE
+// for wholesale semantic swaps (a column of "A-9" identifiers turning
+// into free text), not a statistical drift detector: it fires only
+// when both signatures have a clear dominant mask and the dominants
+// differ, or when the observed dominant never appeared in the baseline
+// at all. Rare new masks, length shifts, and share wobble stay quiet
+// on purpose; a false positive parks a run and erodes trust in the
+// signal.
+func (s ShapeSignature) DriftsFrom(baseline ShapeSignature) bool {
+	observed, ok := s.dominant()
+	if !ok {
+		return false
+	}
+	baselineDominant, baseOK := baseline.dominant()
+	if baseOK && observed != baselineDominant {
+		return true
+	}
+	if baseOK {
+		return false
+	}
+	// The baseline has no clear dominant: only an observed dominant the
+	// baseline NEVER saw counts as drift.
+	for _, m := range baseline.Masks {
+		if m.Mask == observed {
+			return false
+		}
+	}
+	return len(baseline.Masks) > 0
+}

--- a/profile/shape_test.go
+++ b/profile/shape_test.go
@@ -1,0 +1,170 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestFormatMask(t *testing.T) {
+	cases := []struct{ value, want string }{
+		{"P-600", "A-9"},
+		{"Kedjespannare K2", "A_A9"},
+		{"75.50", "9.9"},
+		{"2026-06-07", "9-9-9"},
+		{"Åsa Öberg", "A_A"},
+		{"  spaced  out  ", "_A_A_"},
+		{"!!??!!", "!?!"},
+		{"", ""},
+		{"42", "9"},
+		{"a1b2", "A9A9"},
+		{"SE45 5000 0000", "A9_9_9"},
+	}
+	for _, c := range cases {
+		if got := FormatMask(c.value); got != c.want {
+			t.Errorf("FormatMask(%q) = %q, want %q", c.value, got, c.want)
+		}
+	}
+}
+
+// observeAll runs values through a fresh tracker and returns its
+// signature.
+func observeAll(values ...string) ShapeSignature {
+	var tr shapeTracker
+	for _, v := range values {
+		tr.observe(v)
+	}
+	return tr.signature()
+}
+
+func TestShapeSignature(t *testing.T) {
+	sig := observeAll("P-600", "P-601", "Kedjespannare K2", "P-700")
+	if len(sig.Masks) != 2 || sig.Masks[0].Mask != "A-9" || sig.Masks[0].Count != 3 {
+		t.Fatalf("Masks = %+v, want A-9 x3 first", sig.Masks)
+	}
+	if sig.DominantShare != 0.75 {
+		t.Errorf("DominantShare = %v, want 0.75", sig.DominantShare)
+	}
+	if sig.LengthMin != 5 || sig.LengthMax != 16 {
+		t.Errorf("(LengthMin, LengthMax) = (%d, %d), want (5, 16)", sig.LengthMin, sig.LengthMax)
+	}
+
+	empty := observeAll()
+	if len(empty.Masks) != 0 || empty.DominantShare != 0 || empty.LengthMin != 0 || empty.LengthMax != 0 {
+		t.Errorf("empty signature = %+v, want zero values", empty)
+	}
+}
+
+// TestShapeSignatureRuneLengths: lengths count runes, not bytes, so
+// Swedish text measures honestly.
+func TestShapeSignatureRuneLengths(t *testing.T) {
+	sig := observeAll("Åäö")
+	if sig.LengthMin != 3 || sig.LengthMax != 3 {
+		t.Errorf("(LengthMin, LengthMax) = (%d, %d), want (3, 3)", sig.LengthMin, sig.LengthMax)
+	}
+}
+
+func TestShapeSignatureOverflowBucket(t *testing.T) {
+	var tr shapeTracker
+	// 32 distinct masks fill the table; two more land in the bucket.
+	for i := 0; i < maxTrackedMasks; i++ {
+		// Distinct run patterns: "9", "9-9", "9-9-9", ... give unique masks.
+		v := "1"
+		for j := 0; j < i; j++ {
+			v += "-" + fmt.Sprint(j%10)
+		}
+		tr.observe(v)
+	}
+	tr.observe("!@#$%^")
+	tr.observe("([{}])")
+	sig := tr.signature()
+	var overflow *MaskCount
+	for i := range sig.Masks {
+		if sig.Masks[i].Mask == overflowMask {
+			overflow = &sig.Masks[i]
+		}
+	}
+	if overflow == nil || overflow.Count != 2 {
+		t.Fatalf("overflow bucket = %+v, want count 2", overflow)
+	}
+
+	// A signature whose top entry is the overflow bucket has no clear
+	// dominant and never drifts.
+	var flooded shapeTracker
+	for i := 0; i < maxTrackedMasks; i++ {
+		v := "1"
+		for j := 0; j < i; j++ {
+			v += "-" + fmt.Sprint(j%10)
+		}
+		flooded.observe(v)
+	}
+	for i := 0; i < 50; i++ {
+		flooded.observe("!@#$%^")
+	}
+	fsig := flooded.signature()
+	if fsig.Masks[0].Mask != overflowMask {
+		t.Fatalf("flooded top mask = %q, want the overflow bucket", fsig.Masks[0].Mask)
+	}
+	if fsig.DominantShare != 0 {
+		t.Errorf("flooded DominantShare = %v, want 0 (no dominance from the bucket)", fsig.DominantShare)
+	}
+	if fsig.DriftsFrom(observeAll("P-1", "P-2")) {
+		t.Error("a signature without a clear dominant must never report drift")
+	}
+}
+
+func TestShapeSignatureDeterminism(t *testing.T) {
+	values := []string{"P-600", "Kedjespannare K2", "75.50", "P-601", "2026-06-07", "P-602"}
+	a, _ := json.Marshal(observeAll(values...))
+	b, _ := json.Marshal(observeAll(values...))
+	if string(a) != string(b) {
+		t.Errorf("signature JSON differs across runs:\n%s\n%s", a, b)
+	}
+}
+
+func TestDriftsFrom(t *testing.T) {
+	ids := observeAll("P-600", "P-601", "P-602", "P-603")              // dominant A-9
+	names := observeAll("Kullager djupspar", "Drivrem bred", "Axel x") // dominant A_A
+	cases := []struct {
+		name               string
+		observed, baseline ShapeSignature
+		want               bool
+	}{
+		{"identifiers swapped to names", names, ids, true},
+		{"names swapped to identifiers", ids, names, true},
+		{"identical stays quiet", ids, observeAll("P-700", "P-701", "P-702"), false},
+		{"rare new masks stay quiet", observeAll("P-1", "P-2", "P-3", "P-4", "P-5", "P-6", "P-7", "free text here"), ids, false},
+		{"observed too mixed stays quiet", observeAll("P-1", "alpha beta", "9.9", "x-1", "yy zz", "7.5"), ids, false},
+		{
+			"baseline too mixed, observed dominant present, stays quiet",
+			ids, observeAll("P-1", "alpha beta", "9.9", "P-2", "yy zz", "7.5"), false,
+		},
+		{
+			"baseline too mixed, observed dominant absent, drifts",
+			names, observeAll("P-1", "alpha", "9.9", "P-2", "01/02", "7.5"), true,
+		},
+		{"empty baseline never drifts", ids, observeAll(), false},
+		{"empty observed never drifts", observeAll(), ids, false},
+	}
+	for _, c := range cases {
+		if got := c.observed.DriftsFrom(c.baseline); got != c.want {
+			t.Errorf("%s: DriftsFrom = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestDriftShareFloorBothSides pins the dominance floor: at exactly
+// the floor dominance holds; just below it the comparator stays quiet.
+func TestDriftShareFloorBothSides(t *testing.T) {
+	ids := observeAll("P-600", "P-601", "P-602")
+	// 3 of 5 = 0.6: exactly at the floor, dominance holds, drift fires.
+	atFloor := observeAll("alpha beta", "gamma d", "epsilon z", "P-1", "9.9")
+	if !atFloor.DriftsFrom(ids) {
+		t.Error("dominance at exactly the floor must count")
+	}
+	// 3 of 6 = 0.5: below the floor, no clear dominant, no drift.
+	belowFloor := observeAll("alpha beta", "gamma d", "epsilon z", "P-1", "9.9", "1-2")
+	if belowFloor.DriftsFrom(ids) {
+		t.Error("no drift verdict without a clear dominant")
+	}
+}

--- a/profile/types.go
+++ b/profile/types.go
@@ -26,6 +26,7 @@ type FieldProfile struct {
 	MinValue       *string             `json:"min_value"`
 	MaxValue       *string             `json:"max_value"`
 	TopValues      []contract.TopValue `json:"top_values"`
+	Shape          ShapeSignature      `json:"shape"`
 }
 
 // Options controls the analysis behavior. A nil Options uses defaults.


### PR DESCRIPTION
The enforcement half of JacobJNilsson/orchestrator#29 needs value-level shape evidence the structural fingerprint deliberately does not carry: a column-swapped file with identical headers cache-hit a pipeline authored from sample values and delivered names into the sku column as committed success.

Column profiles now carry a shape signature computed in the existing single pass (capped coarse-mask distribution, dominant share, rune-length range), surfaced through csvcontract field profiles. The DriftsFrom comparator is a conservative tripwire: only a clear dominant-mask change (or an observed dominant the baseline never saw) fires, so natural variation cannot false-positive a park. Authoring agents get the same evidence in their instructions for free.

jsoncontract and excelcontract are deliberately untouched; their divergence from the shared core is tracked in #82. Closes #83.