### PR TITLE
Surface the distinct-count tracking cap in field profiles

### DIFF
--- a/csvcontract/analyze_test.go
+++ b/csvcontract/analyze_test.go
@@ -543,6 +543,49 @@ func TestAnalyzeContractJSON(t *testing.T) {
 	}
 }
 
+func TestAnalyzeDistinctCapSurfacedInJSON(t *testing.T) {
+	// The ID column has 5 distinct values, crossing MaxTracked=3, so its
+	// distinct count is a floor and must be flagged. The Status column
+	// stays under the cap and must not be flagged.
+	data := []byte("ID,Status\n1,ok\n2,ok\n3,ok\n4,ok\n5,ok\n")
+	contract, err := AnalyzeReader(ctx, bytes.NewReader(data), &Options{MaxTracked: 3})
+	if err != nil {
+		t.Fatalf("AnalyzeReader: %v", err)
+	}
+
+	id := contract.Fields[0].Profile
+	if !id.DistinctCountCapped {
+		t.Error("ID distinct_count_capped = false, want true")
+	}
+	if id.DistinctCount != 3 {
+		t.Errorf("ID distinct_count = %d, want floor 3", id.DistinctCount)
+	}
+
+	status := contract.Fields[1].Profile
+	if status.DistinctCountCapped {
+		t.Error("Status distinct_count_capped = true, want false")
+	}
+	if status.DistinctCount != 1 {
+		t.Errorf("Status distinct_count = %d, want 1", status.DistinctCount)
+	}
+
+	// The orchestrator consumes the marshalled contract, so the new key
+	// must be present in the JSON output for capped and uncapped fields.
+	out, err := json.Marshal(contract)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if n := strings.Count(string(out), `"distinct_count_capped":`); n != 2 {
+		t.Errorf("distinct_count_capped key count = %d, want 2 (json: %s)", n, out)
+	}
+	if !strings.Contains(string(out), `"distinct_count_capped":true`) {
+		t.Errorf("expected a capped field in json: %s", out)
+	}
+	if !strings.Contains(string(out), `"distinct_count_capped":false`) {
+		t.Errorf("expected an uncapped field in json: %s", out)
+	}
+}
+
 func TestAnalyzeSingleRowNoHeader(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "single.csv")
@@ -1050,6 +1093,9 @@ func assertProfile(t *testing.T, prefix string, got, want profile.FieldProfile) 
 	}
 	if got.NullPercentage != want.NullPercentage {
 		t.Errorf("%s: null_percentage = %f, want %f", prefix, got.NullPercentage, want.NullPercentage)
+	}
+	if got.DistinctCountCapped != want.DistinctCountCapped {
+		t.Errorf("%s: distinct_count_capped = %v, want %v", prefix, got.DistinctCountCapped, want.DistinctCountCapped)
 	}
 	assertStringPtr(t, prefix+": min_value", got.MinValue, want.MinValue)
 	assertStringPtr(t, prefix+": max_value", got.MaxValue, want.MaxValue)

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -68,14 +68,15 @@ func (p *ColumnProfiler) Finish(topN int) FieldProfile {
 	}
 
 	return FieldProfile{
-		TotalCount:     p.totalCount,
-		NullCount:      p.nullCount,
-		NullPercentage: nullPct,
-		DistinctCount:  len(p.freqs),
-		MinValue:       minVal,
-		MaxValue:       maxVal,
-		TopValues:      p.topValues(topN),
-		Shape:          p.shape.signature(),
+		TotalCount:          p.totalCount,
+		NullCount:           p.nullCount,
+		NullPercentage:      nullPct,
+		DistinctCount:       len(p.freqs),
+		DistinctCountCapped: p.capped,
+		MinValue:            minVal,
+		MaxValue:            maxVal,
+		TopValues:           p.topValues(topN),
+		Shape:               p.shape.signature(),
 	}
 }
 

--- a/profile/profiler_test.go
+++ b/profile/profiler_test.go
@@ -124,6 +124,10 @@ func TestColumnProfilerCapped(t *testing.T) {
 	if result.DistinctCount != 3 {
 		t.Errorf("distinct_count = %d, want 3", result.DistinctCount)
 	}
+	// Crossing the cap is surfaced: distinct_count is a floor, not exact.
+	if !result.DistinctCountCapped {
+		t.Error("distinct_count_capped = false, want true after crossing the cap")
+	}
 	// "a" should have count 2, "b" and "c" have count 1.
 	// "d" should not appear.
 	found := map[string]int{}
@@ -135,6 +139,22 @@ func TestColumnProfilerCapped(t *testing.T) {
 	}
 	if _, ok := found["d"]; ok {
 		t.Error("d should not be tracked")
+	}
+}
+
+func TestColumnProfilerNotCapped(t *testing.T) {
+	// Exactly maxTracked distinct values: every value was tracked, so the
+	// distinct count is exact and the capped flag stays false.
+	p := NewColumnProfiler(3)
+	for _, v := range []string{"a", "b", "c", "a"} {
+		p.Observe(v)
+	}
+	result := p.Finish(10)
+	if result.DistinctCount != 3 {
+		t.Errorf("distinct_count = %d, want 3", result.DistinctCount)
+	}
+	if result.DistinctCountCapped {
+		t.Error("distinct_count_capped = true, want false when the cap was never exceeded")
 	}
 }
 

--- a/profile/types.go
+++ b/profile/types.go
@@ -19,14 +19,29 @@ const (
 // TotalCount tracks the number of rows observed (used internally by
 // profilers). Callers map this to contract.FieldProfile.SampleSize.
 type FieldProfile struct {
-	TotalCount     int                 `json:"total_count"`
-	NullCount      int                 `json:"null_count"`
-	NullPercentage float64             `json:"null_percentage"`
-	DistinctCount  int                 `json:"distinct_count"`
-	MinValue       *string             `json:"min_value"`
-	MaxValue       *string             `json:"max_value"`
-	TopValues      []contract.TopValue `json:"top_values"`
-	Shape          ShapeSignature      `json:"shape"`
+	TotalCount     int     `json:"total_count"`
+	NullCount      int     `json:"null_count"`
+	NullPercentage float64 `json:"null_percentage"`
+
+	// DistinctCount is the number of distinct non-null values tracked.
+	// When DistinctCountCapped is true, tracking stopped at the
+	// MaxTracked limit and DistinctCount means "at least this many".
+	DistinctCount int `json:"distinct_count"`
+
+	// DistinctCountCapped is true when the column had more distinct
+	// values than MaxTracked, so DistinctCount is a floor rather than
+	// an exact count.
+	DistinctCountCapped bool    `json:"distinct_count_capped"`
+	MinValue            *string `json:"min_value"`
+	MaxValue            *string `json:"max_value"`
+
+	// TopValues lists the most frequent tracked values. When
+	// DistinctCountCapped is true these can be stale: values first seen
+	// after the cap was reached are never counted, so a genuinely
+	// frequent late-arriving value may be missing and the reported
+	// counts only cover tracked values.
+	TopValues []contract.TopValue `json:"top_values"`
+	Shape     ShapeSignature      `json:"shape"`
 }
 
 // Options controls the analysis behavior. A nil Options uses defaults.


### PR DESCRIPTION
## Why

On large files the profiler stops tracking new distinct values at MaxTracked (default 10,000) but the contract gives no signal. A 50,000-row column of unique order ids reports distinct_count 10000, so a consumer concludes the column is not a unique key and designs deduplication wrong. The profiler already knew it had saturated; the contract just never said so.

## What

Field profiles now carry distinct_count_capped. When true, distinct_count means at least this many rather than an exact count, and the doc comments state honestly that top_values can be stale once capped, because values first seen after the cap are never counted. The key is new and no existing keys change, so orchestrator consumers of this JSON stay compatible.

MaxTracked is already configurable through the csvcontract Options, so no new option plumbing was needed.

Known follow-up: excelcontract maps profiles into the shared contract.FieldProfile type, which does not carry the flag yet, so Excel contracts still drop it. Extending the shared type is a separate decision.

Closes #78