### PR TITLE
Read decimal-comma values as decimals in numeric ranges

### DIFF
--- a/csvcontract/analyze_test.go
+++ b/csvcontract/analyze_test.go
@@ -670,6 +670,33 @@ func TestAnalyzeContractJSON(t *testing.T) {
 	}
 }
 
+func TestAnalyzeSemicolonDecimalCommaCSV(t *testing.T) {
+	// Issue #79 reproduction: a semicolon-delimited Swedish export with
+	// decimal commas. Price must classify as numeric with the range
+	// compared numerically (2.75 < 9.25 < 10.5), not as if "10,5" were
+	// the US thousands form 105. Raw spellings are preserved in min/max.
+	data := []byte("Product;Price\nCoffee;10,5\nTea;9,25\nWater;2,75\n")
+	contract, err := AnalyzeReader(ctx, bytes.NewReader(data), nil)
+	if err != nil {
+		t.Fatalf("AnalyzeReader: %v", err)
+	}
+
+	if contract.Delimiter != ";" {
+		t.Errorf("delimiter = %q, want \";\"", contract.Delimiter)
+	}
+
+	price := contract.Fields[1]
+	if price.DataType != profile.TypeNumeric {
+		t.Errorf("Price data_type = %q, want %q", price.DataType, profile.TypeNumeric)
+	}
+	if price.Profile.MinValue == nil || *price.Profile.MinValue != "2,75" {
+		t.Errorf("Price min_value = %v, want \"2,75\"", price.Profile.MinValue)
+	}
+	if price.Profile.MaxValue == nil || *price.Profile.MaxValue != "10,5" {
+		t.Errorf("Price max_value = %v, want \"10,5\"", price.Profile.MaxValue)
+	}
+}
+
 func TestAnalyzeDistinctCapSurfacedInJSON(t *testing.T) {
 	// The ID column has 5 distinct values, crossing MaxTracked=3, so its
 	// distinct count is a floor and must be flagged. The Status column

--- a/profile/classify.go
+++ b/profile/classify.go
@@ -85,12 +85,14 @@ func IsNumeric(s string) bool {
 	case hasComma && hasDot:
 		return IsUSFormatNumber(s) || IsEuropeanFormatNumber(s)
 	case hasComma && !hasDot:
-		// Ambiguous: "1,234" could be US thousands (1234) or European
-		// decimal (1.234). We accept both as numeric. Downstream in
-		// ParseNumeric, comma-only values are parsed by removing commas
-		// (US interpretation). This is a known limitation -- it affects
-		// min/max profiling in files that use European decimal format
-		// without a dot.
+		// Comma-only values are ambiguous without file context. We accept
+		// both the US thousands shape (1,234) and the European decimal
+		// shape (10,5). ParseNumeric resolves the same two shapes the same
+		// way: a well-formed thousands pattern keeps US semantics, any
+		// other single-comma form is a decimal comma. "1,234" alone
+		// therefore stays one thousand two hundred thirty-four even in a
+		// European file; that residual ambiguity is unavoidable at the
+		// value level.
 		return IsUSThousandsOnly(s) || IsEuropeanDecimalOnly(s)
 	default:
 		// No comma, maybe a dot decimal or plain integer.

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -191,6 +191,19 @@ func IsNull(v string) bool {
 
 // ParseNumeric attempts to parse a string as a float64, handling both
 // US (1,234.56) and European (1.234,56) number formats.
+//
+// Comma-only values (commas, no dots) are disambiguated by shape, since
+// the profiler has no file-level context such as the delimiter:
+//   - A well-formed thousands pattern (1,234 or 1,234,567) keeps US
+//     thousands semantics, so "1,234" alone stays 1234.
+//   - Any other single-comma form (10,5 / 9,25) is treated as a decimal
+//     comma, the common European spelling, so "10,5" is 10.5.
+//
+// The residual ambiguity is real: "1,234" in a Swedish file is still
+// read as one thousand two hundred thirty-four, and a column mixing
+// both conventions keeps whatever each individual value says. IsNumeric
+// accepts exactly the same comma-only forms, so classification and
+// range tracking agree.
 func ParseNumeric(s string) (float64, bool) {
 	s = strings.TrimSpace(s)
 	s = strings.Trim(s, "\"")
@@ -237,12 +250,21 @@ func ParseNumeric(s string) (float64, bool) {
 			}
 		}
 	case hasComma:
-		// Could be US thousands (1,234) or European decimal (1,5).
-		// Remove commas and parse.
-		cleaned := strings.ReplaceAll(core, ",", "")
-		if f, err := strconv.ParseFloat(cleaned, 64); err == nil {
-			result = f
-			parsed = true
+		switch {
+		case IsUSThousandsOnly(core):
+			// Well-formed US thousands: 1,234 or 1,234,567.
+			cleaned := strings.ReplaceAll(core, ",", "")
+			if f, err := strconv.ParseFloat(cleaned, 64); err == nil {
+				result = f
+				parsed = true
+			}
+		case IsEuropeanDecimalOnly(core):
+			// Decimal comma: 10,5 means 10.5.
+			cleaned := strings.Replace(core, ",", ".", 1)
+			if f, err := strconv.ParseFloat(cleaned, 64); err == nil {
+				result = f
+				parsed = true
+			}
 		}
 	}
 

--- a/profile/profiler_test.go
+++ b/profile/profiler_test.go
@@ -265,6 +265,13 @@ func TestParseNumeric(t *testing.T) {
 		{"1,234.56", 1234.56, true},
 		{"1.234,56", 1234.56, true},
 		{"1,234", 1234, true},
+		{"1,234,567", 1234567, true},
+		{"10,5", 10.5, true},
+		{"9,25", 9.25, true},
+		{"2,75", 2.75, true},
+		{"-10,5", -10.5, true},
+		{"1,2345", 1.2345, true},
+		{"1,23,456", 0, false},
 		{"abc", 0, false},
 		{"", 0, false},
 		{"  ", 0, false},
@@ -284,6 +291,55 @@ func TestParseNumeric(t *testing.T) {
 		if ok && got != tt.want {
 			t.Errorf("ParseNumeric(%q) = %f, want %f", tt.input, got, tt.want)
 		}
+	}
+}
+
+// TestParseNumericAgreesWithIsNumeric pins that classification and
+// parsing accept the same comma forms, so a column classified numeric
+// never contains values the range tracker cannot parse (full
+// reconciliation across all forms is issue #80).
+func TestParseNumericAgreesWithIsNumeric(t *testing.T) {
+	inputs := []string{
+		"10,5", "9,25", "2,75", "-10,5", "12,34", "1,2345",
+		"1,234", "1,234,567", "1,23,456", "1,234.56", "5,", ",5",
+	}
+	for _, in := range inputs {
+		_, parseOK := ParseNumeric(in)
+		classifyOK := IsNumeric(in)
+		if parseOK != classifyOK {
+			t.Errorf("disagreement on %q: ParseNumeric ok = %v, IsNumeric = %v", in, parseOK, classifyOK)
+		}
+	}
+}
+
+func TestRangeTrackerEuropeanDecimalComma(t *testing.T) {
+	// Issue #79 reproduction: Swedish prices with decimal commas. The
+	// raw spellings are preserved while comparison is numeric, so the
+	// range no longer inverts (10,5 must not parse as 105).
+	var tracker RangeTracker
+	for _, v := range []string{"10,5", "9,25", "2,75"} {
+		tracker.Observe(v)
+	}
+	if tracker.Min() != "2,75" {
+		t.Errorf("min = %q, want \"2,75\"", tracker.Min())
+	}
+	if tracker.Max() != "10,5" {
+		t.Errorf("max = %q, want \"10,5\"", tracker.Max())
+	}
+}
+
+func TestRangeTrackerMixedCommaConventions(t *testing.T) {
+	// A column mixing conventions keeps whatever each value says:
+	// "10,5" reads as 10.5 (decimal comma) while "1,234" reads as 1234
+	// (well-formed US thousands), so 1,234 is the maximum.
+	var tracker RangeTracker
+	tracker.Observe("10,5")
+	tracker.Observe("1,234")
+	if tracker.Min() != "10,5" {
+		t.Errorf("min = %q, want \"10,5\"", tracker.Min())
+	}
+	if tracker.Max() != "1,234" {
+		t.Errorf("max = %q, want \"1,234\"", tracker.Max())
 	}
 }
 


### PR DESCRIPTION
## Why

The canonical Swedish export, semicolon-delimited with comma decimals, produced numerically inverted ranges: prices 10,5 / 9,25 / 2,75 classified as numeric but reported min 10,5 and max 9,25, because every comma was stripped as a US thousands separator and 10,5 became 105. Consumers of the contract got wrong bounds for the most common European number spelling.

## What

Comma-only values are now disambiguated by shape at the value level, since the profiler has no file context such as the delimiter: a well-formed thousands pattern (1,234 or 1,234,567) keeps US semantics, any other single-comma form (10,5) reads as a decimal comma. Values containing both dots and commas behave as before. The residual ambiguity is documented rather than hidden: 1,234 alone still reads as one thousand two hundred thirty-four, and a column mixing conventions keeps whatever each value says.

The issue suggested using the semicolon delimiter as a signal, but the profile package never sees the file, so the value-level rule is the conservative fix without new configuration.

IsNumeric and ParseNumeric now accept the same comma-only forms, so a column classified numeric never feeds the range tracker an unparseable value; full reconciliation of the two is tracked in #80.

Closes #79