### PR TITLE
Populate the issues channel where the contract is silently wrong

### DIFF
--- a/csvcontract/analyze.go
+++ b/csvcontract/analyze.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	csvstd "encoding/csv"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/JacobJNilsson/data-contract-generator/profile"
@@ -119,7 +122,9 @@ func AnalyzeReader(ctx context.Context, rs io.ReadSeeker, opts *Options) (*Sourc
 	result.SourceFormat = "csv"
 	result.Encoding = encoding
 	result.Delimiter = string(delimiter)
-	result.Issues = issues
+	// Encoding issues lead, then the data-quality issues collected
+	// during the streaming pass, already in deterministic order.
+	result.Issues = append(issues, result.Issues...)
 
 	return result, nil
 }
@@ -134,10 +139,15 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 	reader.LazyQuotes = true
 	reader.FieldsPerRecord = -1
 
-	// Read the first row to determine header/field names.
+	// Read the first row to determine header/field names. An empty file
+	// and a failing read are different facts (issue #81): only a clean
+	// EOF means the file is empty, anything else carries the real error.
 	firstRow, err := reader.Read()
-	if err != nil {
+	if errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("file is empty")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read first row: %w", err)
 	}
 
 	// Buffer a bounded probe of the following rows so header detection
@@ -162,7 +172,7 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 		probe = append(probe, record)
 	}
 
-	hasHeader := profile.DetectHeaderWithRows(firstRow, probe)
+	hasHeader, headerGuessed := profile.DetectHeaderWithRowsConfidence(firstRow, probe)
 
 	var fieldNames []string
 	maxSampleRows := opts.maxSampleRows()
@@ -187,21 +197,14 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 	}
 
 	numFields := len(fieldNames)
-
-	// Initialize per-column profilers and type trackers.
-	profilers := make([]*profile.ColumnProfiler, numFields)
-	colTypes := make([]profile.DataType, numFields)
-	for i := range profilers {
-		profilers[i] = profile.NewColumnProfiler(maxTracked)
-		colTypes[i] = profile.TypeEmpty
-	}
+	stats := newColumnStats(numFields, maxTracked)
 
 	var sampleRows [][]string
 	totalRows := 0
 
 	processRow := func(record []string) {
 		totalRows++
-		observeRow(record, profilers, colTypes, numFields)
+		stats.observeRow(record)
 		if len(sampleRows) < maxSampleRows {
 			sampleRows = append(sampleRows, record)
 		}
@@ -239,8 +242,8 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 	for i, name := range fieldNames {
 		fields[i] = Field{
 			Name:     name,
-			DataType: colTypes[i],
-			Profile:  profilers[i].Finish(topN),
+			DataType: stats.types[i],
+			Profile:  stats.profilers[i].Finish(topN),
 		}
 	}
 
@@ -249,18 +252,182 @@ func streamAnalyze(ctx context.Context, r io.Reader, delimiter rune, opts *Optio
 		TotalRows:  totalRows,
 		Fields:     fields,
 		SampleData: sampleRows,
+		Issues:     collectIssues(headerGuessed, stats, fields),
 	}, nil
 }
 
-// observeRow feeds a single row to per-column profilers and type trackers.
-func observeRow(row []string, profilers []*profile.ColumnProfiler, colTypes []profile.DataType, numFields int) {
+// nullSentinels are the common spellings that mean "no value" but count
+// as ordinary text (issue #81). They are matched exactly after trimming
+// surrounding whitespace; the empty string is absent because it already
+// counts as null. The slice is the canonical iteration order, so issue
+// messages never depend on map order.
+var nullSentinels = []string{"-", "N/A", "NULL", "n/a", "null"}
+
+// sentinelShareFloor is the share of a column's non-null values that
+// must be null sentinels before the column is flagged: below it a
+// stray "-" in free text would make every prose column noisy.
+const sentinelShareFloor = 0.05
+
+// mixedMajorityFloor is the share a single non-text class needs among
+// a text column's non-empty values before the column is reported as
+// mixed-majority. It matches the dominance floor used by shape
+// signatures: a clear dominant, not a bare plurality.
+const mixedMajorityFloor = 0.6
+
+// mixedClassOrder is the canonical order for reporting class splits.
+var mixedClassOrder = []profile.DataType{
+	profile.TypeNumeric,
+	profile.TypeDate,
+	profile.TypeTimestamp,
+	profile.TypeBoolean,
+	profile.TypeText,
+}
+
+// columnStats accumulates everything the streaming pass observes per
+// column: the existing profilers and type trackers, plus the evidence
+// the issues channel reports on (issue #81): ragged rows, sentinel
+// counts, and per-class value counts.
+type columnStats struct {
+	profilers []*profile.ColumnProfiler
+	types     []profile.DataType
+	// classCounts counts non-empty cell classes per column.
+	classCounts []map[profile.DataType]int
+	// sentinelCounts counts exact null-sentinel matches per column.
+	sentinelCounts []map[string]int
+	// shortRows and longRows count ragged rows; droppedCells is the
+	// total number of cells lost from rows longer than the schema.
+	shortRows, longRows, droppedCells int
+}
+
+func newColumnStats(numFields, maxTracked int) *columnStats {
+	s := &columnStats{
+		profilers:      make([]*profile.ColumnProfiler, numFields),
+		types:          make([]profile.DataType, numFields),
+		classCounts:    make([]map[profile.DataType]int, numFields),
+		sentinelCounts: make([]map[string]int, numFields),
+	}
+	for i := 0; i < numFields; i++ {
+		s.profilers[i] = profile.NewColumnProfiler(maxTracked)
+		s.types[i] = profile.TypeEmpty
+		s.classCounts[i] = make(map[profile.DataType]int)
+		s.sentinelCounts[i] = make(map[string]int)
+	}
+	return s
+}
+
+// observeRow feeds a single row to the per-column trackers. Short rows
+// contribute empty cells (nulls) for the missing columns; cells beyond
+// the schema width are dropped. Both distortions are counted so the
+// contract can disclose them.
+func (s *columnStats) observeRow(row []string) {
+	numFields := len(s.profilers)
+	if len(row) < numFields {
+		s.shortRows++
+	}
+	if len(row) > numFields {
+		s.longRows++
+		s.droppedCells += len(row) - numFields
+	}
 	for col := 0; col < numFields; col++ {
 		var value string
 		if col < len(row) {
 			value = row[col]
 		}
-		profilers[col].Observe(value)
+		s.profilers[col].Observe(value)
 		cellType := profile.ClassifyCell(value)
-		colTypes[col] = profile.MergeTypes(colTypes[col], cellType)
+		s.types[col] = profile.MergeTypes(s.types[col], cellType)
+		if cellType != profile.TypeEmpty {
+			s.classCounts[col][cellType]++
+			if trimmed := strings.TrimSpace(value); slices.Contains(nullSentinels, trimmed) {
+				s.sentinelCounts[col][trimmed]++
+			}
+		}
 	}
+}
+
+// collectIssues renders the streaming pass's evidence into the
+// contract's issues channel (issue #81). Order is fixed: the header
+// verdict first, then ragged-row facts, then per-column findings in
+// schema order, so identical input always yields identical output.
+func collectIssues(headerGuessed bool, stats *columnStats, fields []Field) []string {
+	var issues []string
+	if headerGuessed {
+		issues = append(issues, "header detection fell back to the all-text guess: a text header over text columns and headerless text data are indistinguishable, so the first row was assumed to be a header")
+	}
+	if stats.shortRows > 0 {
+		issues = append(issues, fmt.Sprintf("%d rows had fewer than %d columns; missing cells were read as nulls", stats.shortRows, len(fields)))
+	}
+	if stats.longRows > 0 {
+		issues = append(issues, fmt.Sprintf("%d rows had more than %d columns; %d extra cells were dropped", stats.longRows, len(fields), stats.droppedCells))
+	}
+	for i, field := range fields {
+		if msg, ok := sentinelIssue(field, stats.sentinelCounts[i]); ok {
+			issues = append(issues, msg)
+		}
+		if msg, ok := mixedMajorityIssue(field, stats.classCounts[i]); ok {
+			issues = append(issues, msg)
+		}
+	}
+	return issues
+}
+
+// sentinelIssue reports a column whose non-null values include null
+// sentinels above the share floor. The values are NOT reclassified as
+// nulls: that would change the contract's semantics silently; the
+// issue discloses the fact instead.
+func sentinelIssue(field Field, counts map[string]int) (string, bool) {
+	total := 0
+	var seen []string
+	for _, sentinel := range nullSentinels {
+		if n := counts[sentinel]; n > 0 {
+			total += n
+			seen = append(seen, sentinel)
+		}
+	}
+	nonNull := field.Profile.TotalCount - field.Profile.NullCount
+	if total == 0 || float64(total) < sentinelShareFloor*float64(nonNull) {
+		return "", false
+	}
+	return fmt.Sprintf("column %q: %d of %d non-null values are null sentinels (%s); they were profiled as ordinary values", field.Name, total, nonNull, strings.Join(seen, ", ")), true
+}
+
+// mixedMajorityIssue reports a column that typed text even though a
+// clear majority of its non-empty values belong to a single non-text
+// class, so consumers can tell true prose from a typed column with
+// stray text.
+func mixedMajorityIssue(field Field, counts map[profile.DataType]int) (string, bool) {
+	if field.DataType != profile.TypeText {
+		return "", false
+	}
+	total := 0
+	for _, class := range mixedClassOrder {
+		total += counts[class]
+	}
+	dominant := profile.TypeText
+	dominantCount := 0
+	for _, class := range mixedClassOrder[:len(mixedClassOrder)-1] {
+		if counts[class] > dominantCount {
+			dominant = class
+			dominantCount = counts[class]
+		}
+	}
+	// A text-typed column always has at least one text value, so total
+	// is positive whenever a dominant non-text class exists.
+	if dominantCount == 0 || float64(dominantCount)/float64(total) < mixedMajorityFloor {
+		return "", false
+	}
+	// parts is built by walking mixedClassOrder, so the split listing is
+	// deterministic without sorting.
+	parts := make([]string, 0, len(mixedClassOrder))
+	for _, class := range mixedClassOrder {
+		if counts[class] > 0 {
+			parts = append(parts, fmt.Sprintf("%d percent %s", percent(counts[class], total), class))
+		}
+	}
+	return fmt.Sprintf("column %q: typed text but %d percent of its %d non-empty values are %s (%s)", field.Name, percent(dominantCount, total), total, dominant, strings.Join(parts, ", ")), true
+}
+
+// percent renders a share as a whole-number percentage.
+func percent(count, total int) int {
+	return int(math.Round(float64(count) / float64(total) * 100))
 }

--- a/csvcontract/analyze_test.go
+++ b/csvcontract/analyze_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -348,7 +349,11 @@ func TestAnalyzeEmptyCSV(t *testing.T) {
 			{Name: "City", DataType: profile.TypeEmpty, Profile: profile.FieldProfile{TopValues: []ct.TopValue{}}},
 		},
 		SampleData: nil,
-		Issues:     nil,
+		// Issue #81: with no data rows, no column class can anchor the
+		// header verdict, so the contract discloses the guess.
+		Issues: []string{
+			"header detection fell back to the all-text guess: a text header over text columns and headerless text data are indistinguishable, so the first row was assumed to be a header",
+		},
 	})
 }
 
@@ -393,7 +398,92 @@ func TestAnalyzeMixedTypes(t *testing.T) {
 			{"4", "", "2024-01-18", ""},
 			{"5", "500", "2024-01-19", "fifth entry"},
 		},
-		Issues: nil,
+		// Issue #81: text columns dominated by a single non-text class
+		// now disclose their split instead of reading like prose.
+		Issues: []string{
+			`column "Value": typed text but 75 percent of its 4 non-empty values are numeric (75 percent numeric, 25 percent text)`,
+			`column "Date": typed text but 80 percent of its 5 non-empty values are date (80 percent date, 20 percent text)`,
+		},
+	})
+}
+
+// TestAnalyzeRaggedRows pins the issue #81 disclosure for rows that do
+// not match the schema width: short rows read as nulls, and cells
+// beyond the schema are dropped outright, so the contract must say so.
+func TestAnalyzeRaggedRows(t *testing.T) {
+	contract, err := AnalyzeFile(ctx, "testdata/ragged.csv", nil)
+	if err != nil {
+		t.Fatalf("AnalyzeFile: %v", err)
+	}
+
+	assertIssues(t, contract.Issues, []string{
+		"2 rows had fewer than 3 columns; missing cells were read as nulls",
+		"2 rows had more than 3 columns; 3 extra cells were dropped",
+	})
+
+	// The padded nulls land in the profile: Score is missing in both
+	// short rows, Name in one.
+	if got := contract.Fields[2].Profile.NullCount; got != 2 {
+		t.Errorf("Score null_count = %d, want 2", got)
+	}
+	if got := contract.Fields[1].Profile.NullCount; got != 1 {
+		t.Errorf("Name null_count = %d, want 1", got)
+	}
+}
+
+// TestAnalyzeSentinelNulls pins the issue #81 disclosure for columns
+// whose values include the common null sentinels. The values stay
+// profiled as ordinary values (reclassifying them would silently change
+// the contract's semantics); the issue names the column and sentinels.
+func TestAnalyzeSentinelNulls(t *testing.T) {
+	contract, err := AnalyzeFile(ctx, "testdata/sentinels.csv", nil)
+	if err != nil {
+		t.Fatalf("AnalyzeFile: %v", err)
+	}
+
+	assertIssues(t, contract.Issues, []string{
+		`column "Price": 3 of 6 non-null values are null sentinels (-, N/A, NULL); they were profiled as ordinary values`,
+	})
+
+	// Not reclassified: the sentinels still count as non-null values.
+	if got := contract.Fields[2].Profile.NullCount; got != 0 {
+		t.Errorf("Price null_count = %d, want 0 (sentinels are not silently nulled)", got)
+	}
+}
+
+// TestAnalyzeSentinelsBelowFloor pins the noise floor: a single stray
+// sentinel in a large text column is not worth an issue.
+func TestAnalyzeSentinelsBelowFloor(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteString("ID,Comment\n")
+	for i := 0; i < 24; i++ {
+		fmt.Fprintf(&buf, "%d,note about item %02d\n", i+1, i+1)
+	}
+	buf.WriteString("25,-\n")
+
+	contract, err := AnalyzeReader(ctx, bytes.NewReader(buf.Bytes()), nil)
+	if err != nil {
+		t.Fatalf("AnalyzeReader: %v", err)
+	}
+	// 1 of 25 non-null values (4 percent) is below the 5 percent floor.
+	assertIssues(t, contract.Issues, nil)
+}
+
+// TestAnalyzeAllTextHeaderGuess pins the issue #81 disclosure for the
+// documented all-text header fallback: nothing distinguishes a text
+// header from headerless text data, and the contract previously
+// expressed full confidence anyway.
+func TestAnalyzeAllTextHeaderGuess(t *testing.T) {
+	contract, err := AnalyzeFile(ctx, "testdata/all_text.csv", nil)
+	if err != nil {
+		t.Fatalf("AnalyzeFile: %v", err)
+	}
+
+	if !contract.HasHeader {
+		t.Error("has_header = false, want true (the historical guess)")
+	}
+	assertIssues(t, contract.Issues, []string{
+		"header detection fell back to the all-text guess: a text header over text columns and headerless text data are indistinguishable, so the first row was assumed to be a header",
 	})
 }
 
@@ -843,6 +933,47 @@ func TestAnalyzeReaderEmpty(t *testing.T) {
 	_, err := AnalyzeReader(ctx, r, nil)
 	if err == nil {
 		t.Fatal("expected error for empty content")
+	}
+	// Issue #81: only a clean EOF may report emptiness; the message is
+	// pinned so a read failure can never masquerade as an empty file.
+	if err.Error() != "file is empty" {
+		t.Errorf("error = %q, want %q", err.Error(), "file is empty")
+	}
+}
+
+// failingReadSeeker simulates a source that dies after the encoding
+// sniff: the sniff read sees a clean EOF, but every read in the
+// streaming phase fails.
+type failingReadSeeker struct{ sniffed bool }
+
+func (f *failingReadSeeker) Read(p []byte) (int, error) {
+	if !f.sniffed {
+		return 0, io.EOF
+	}
+	return 0, errors.New("disk read failure")
+}
+
+func (f *failingReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	f.sniffed = true
+	return 0, nil
+}
+
+// TestAnalyzeFirstRowReadError pins that a failing first read surfaces
+// the real error instead of being swallowed behind "file is empty"
+// (issue #81).
+func TestAnalyzeFirstRowReadError(t *testing.T) {
+	_, err := AnalyzeReader(ctx, &failingReadSeeker{}, nil)
+	if err == nil {
+		t.Fatal("expected error for failing reader")
+	}
+	if !strings.Contains(err.Error(), "read first row") {
+		t.Errorf("error = %q, want it to be wrapped as a first-row read error", err.Error())
+	}
+	if !strings.Contains(err.Error(), "disk read failure") {
+		t.Errorf("error = %q, want it to carry the underlying cause", err.Error())
+	}
+	if strings.Contains(err.Error(), "file is empty") {
+		t.Errorf("error = %q, must not claim the file is empty", err.Error())
 	}
 }
 

--- a/csvcontract/testdata/all_text.csv
+++ b/csvcontract/testdata/all_text.csv
@@ -1,0 +1,3 @@
+alpha,beta
+gamma,delta
+epsilon,zeta

--- a/csvcontract/testdata/ragged.csv
+++ b/csvcontract/testdata/ragged.csv
@@ -1,0 +1,6 @@
+ID,Name,Score
+1,Alice,10
+2,Bob
+3,Carol,30,extra1,extra2
+4,Dave,40,extra3
+5

--- a/csvcontract/testdata/sentinels.csv
+++ b/csvcontract/testdata/sentinels.csv
@@ -1,0 +1,7 @@
+ID,Product,Price
+1,Widget,10
+2,Gadget,N/A
+3,Sprocket,NULL
+4,Doohickey,-
+5,Gizmo,20
+6,Whatsit,30

--- a/profile/header.go
+++ b/profile/header.go
@@ -61,18 +61,36 @@ func DetectHeader(firstRow []string) bool {
 // HeaderProbeRows is a sensible size. Passing no rows degrades to
 // DetectHeader.
 func DetectHeaderWithRows(firstRow []string, dataRows [][]string) bool {
+	hasHeader, _ := DetectHeaderWithRowsConfidence(firstRow, dataRows)
+	return hasHeader
+}
+
+// DetectHeaderWithRowsConfidence is DetectHeaderWithRows with the
+// verdict's confidence exposed (issue #81). guessed is true when a
+// header was reported by the documented all-text fallback: no column
+// carried a numeric, date, timestamp, or boolean class to anchor the
+// decision, so a text header over text columns and a headerless text
+// file are indistinguishable and the historical header guess applies.
+// Callers can surface that uncertainty instead of expressing full
+// confidence in the contract.
+func DetectHeaderWithRowsConfidence(firstRow []string, dataRows [][]string) (hasHeader, guessed bool) {
 	if !DetectHeader(firstRow) {
-		return false
+		return false, false
 	}
+	anchored := false
 	for col, cell := range firstRow {
-		if !isDataValueClass(ClassifyCell(cell)) {
+		if !isDataValueClass(columnClass(dataRows, col)) {
 			continue
 		}
-		if isDataValueClass(columnClass(dataRows, col)) {
-			return false
+		// A typed column anchors the verdict either way: a first-row
+		// cell of the same kind means data, a name over typed values
+		// means a real header.
+		anchored = true
+		if isDataValueClass(ClassifyCell(cell)) {
+			return false, false
 		}
 	}
-	return true
+	return true, !anchored
 }
 
 // isDataValueClass reports whether a cell class is one real header

--- a/profile/header_test.go
+++ b/profile/header_test.go
@@ -167,6 +167,68 @@ func TestDetectHeaderWithRows(t *testing.T) {
 	}
 }
 
+// TestDetectHeaderWithRowsConfidence pins the guess marker added for
+// issue #81: a header verdict is a guess exactly when no column class
+// anchored it.
+func TestDetectHeaderWithRowsConfidence(t *testing.T) {
+	tests := []struct {
+		name      string
+		firstRow  []string
+		dataRows  [][]string
+		hasHeader bool
+		guessed   bool
+	}{
+		{
+			// The documented all-text fallback: header reported, but
+			// nothing distinguishes it from headerless text data.
+			name:      "all-text columns are a guess",
+			firstRow:  []string{"alpha", "beta"},
+			dataRows:  [][]string{{"gamma", "delta"}, {"epsilon", "zeta"}},
+			hasHeader: true,
+			guessed:   true,
+		},
+		{
+			// A text name over a numeric column anchors the verdict:
+			// real data in that column would have been numeric.
+			name:      "text header over numeric column is anchored",
+			firstRow:  []string{"Name", "Age"},
+			dataRows:  [][]string{{"Alice", "30"}, {"Bob", "25"}},
+			hasHeader: true,
+			guessed:   false,
+		},
+		{
+			name:      "numeric first row is data, not a guess",
+			firstRow:  []string{"1", "2"},
+			dataRows:  [][]string{{"3", "4"}},
+			hasHeader: false,
+			guessed:   false,
+		},
+		{
+			name:      "homogeneous rows are data, not a guess",
+			firstRow:  []string{"widget", "75.50"},
+			dataRows:  [][]string{{"gadget", "189.00"}},
+			hasHeader: false,
+			guessed:   false,
+		},
+		{
+			// No probe rows at all: the single-row heuristic has no
+			// column evidence, so the verdict is a guess.
+			name:      "no data rows is a guess",
+			firstRow:  []string{"Name", "Age"},
+			dataRows:  nil,
+			hasHeader: true,
+			guessed:   true,
+		},
+	}
+	for _, tt := range tests {
+		hasHeader, guessed := DetectHeaderWithRowsConfidence(tt.firstRow, tt.dataRows)
+		if hasHeader != tt.hasHeader || guessed != tt.guessed {
+			t.Errorf("DetectHeaderWithRowsConfidence(%s) = (%v, %v), want (%v, %v)",
+				tt.name, hasHeader, guessed, tt.hasHeader, tt.guessed)
+		}
+	}
+}
+
 func TestGenerateFieldNames(t *testing.T) {
 	names := GenerateFieldNames(3)
 	want := []string{"column_1", "column_2", "column_3"}


### PR DESCRIPTION
Closes #81

The issues array is the contract's only warning channel, and in practice it only ever carried a BOM note while the analyzer quietly distorted the data: short rows became nulls, the extra cells of long rows were dropped without a trace, null sentinels (NULL, N/A, -) were profiled as ordinary values and pushed columns to text, the documented all-text header guess was presented with full confidence, and a column of 90 percent numbers with 10 percent stray text read identically to true prose. A consumer (human or agent) authoring a pipeline from the contract had no way to know any of this happened.

Every one of those silent cases now produces a deterministic issue entry, in a fixed order (encoding, header verdict, ragged-row facts including the dropped-cells count, then per-column findings in schema order). Two deliberate restraints: sentinel values are disclosed but NOT reclassified as nulls, because changing the null semantics silently would be the same sin in the other direction, and the sentinel disclosure has a 5 percent noise floor so one stray "-" in a prose column stays quiet. The mixed-majority floor (60 percent) matches the dominance floor already used by shape signatures.

First-row read errors are also no longer swallowed behind "file is empty": only a clean EOF reports emptiness, anything else wraps the real cause.