### PR TITLE
Map common Postgres source types onto the lattice

### DIFF
--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -295,20 +295,24 @@ func canonicalName(name string) string {
 // share a fingerprint), and a distinction the analyzer exposes is preserved
 // (array element types, binary vs text) rather than coarsened. Only the
 // spec's deliberate collapses apply: int/float to NUMBER, date/timestamp to
-// TEMPORAL, uuid to STRING, jsonb to OBJECT.
+// TEMPORAL, uuid to STRING, json/jsonb to OBJECT. The Postgres source tokens
+// a PostgreSQL/Supabase introspection emits join their canonical siblings:
+// "double precision" and real are NUMBER, "timestamp without time zone" is
+// TEMPORAL, and json maps to OBJECT alongside jsonb (dcg only describes data,
+// so json carries no equality constraint that would exclude it).
 func mapDataType(dataType string) (CanonicalType, error) {
 	switch dataType {
 	case "text", "uuid":
 		return TypeString, nil
 	case "bytea":
 		return TypeBinary, nil
-	case "numeric", "integer":
+	case "numeric", "integer", "real", "double precision":
 		return TypeNumber, nil
-	case "date", "timestamp", "timestamptz":
+	case "date", "timestamp", "timestamptz", "timestamp without time zone":
 		return TypeTemporal, nil
 	case "boolean":
 		return TypeBoolean, nil
-	case "object", "jsonb":
+	case "object", "json", "jsonb":
 		return TypeObject, nil
 	case "array":
 		return TypeArray, nil

--- a/fingerprint/fingerprint_test.go
+++ b/fingerprint/fingerprint_test.go
@@ -575,6 +575,51 @@ func TestNestedArrayTypes(t *testing.T) {
 	}
 }
 
+// TestPostgresTypesMap pins the Postgres source vocabulary extension: the
+// data_type tokens a PostgreSQL/Supabase introspection emits all project
+// onto the canonical lattice rather than failing closed. uuid stays STRING,
+// date and "timestamp without time zone" join the TEMPORAL collapse,
+// "double precision" and real join NUMBER, and both json and jsonb map to
+// OBJECT (dcg only describes data, so json has no equality constraint to
+// exclude it, unlike a delivery client).
+func TestPostgresTypesMap(t *testing.T) {
+	dc := &contract.DataContract{
+		Metadata: map[string]any{"source": "openapi"},
+		Schemas: []contract.SchemaContract{
+			{Name: "public.events", Fields: []contract.FieldDefinition{
+				{Name: "id", DataType: "uuid"},
+				{Name: "happened_on", DataType: "date"},
+				{Name: "happened_at", DataType: "timestamp without time zone"},
+				{Name: "amount", DataType: "double precision"},
+				{Name: "ratio", DataType: "real"},
+				{Name: "payload", DataType: "json"},
+				{Name: "settings", DataType: "jsonb"},
+			}},
+		},
+	}
+	units, skipped, err := FromDataContract(dc)
+	if err != nil {
+		t.Fatalf("FromDataContract: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("unexpected skipped schemas: %v", skipped)
+	}
+	want := map[string]CanonicalType{
+		"id":          TypeString,
+		"happened_on": TypeTemporal,
+		"happened_at": TypeTemporal,
+		"amount":      TypeNumber,
+		"ratio":       TypeNumber,
+		"payload":     TypeObject,
+		"settings":    TypeObject,
+	}
+	for _, f := range units[0].Object.Fields {
+		if want[f.Name] != f.Type {
+			t.Errorf("field %q mapped to %q, want %q", f.Name, f.Type, want[f.Name])
+		}
+	}
+}
+
 // TestGoldenHashUnchangedByNewTypes pins the exact hash of a fingerprint
 // built from the pre-issue-#80 analyzer vocabulary (text, numeric, date,
 // empty). The golden value was computed on main before the boolean and


### PR DESCRIPTION
Extends mapDataType (the Postgres data_type -> canonical-type lattice used by fingerprinting) to cover types real Supabase/Postgres schemas use. uuid/date/jsonb were already mapped; this adds the four that were missing and fail-closed:

- json -> OBJECT (dcg only describes data, so unlike the orchestrator's delivery path it has no upsert-equality reason to exclude json)
- timestamp without time zone -> TEMPORAL
- double precision -> NUMBER
- real -> NUMBER

Fail-closed behaviour for genuinely-unknown tokens is preserved (mapDataType still errors with 'unmapped analyzer type' so two shapes never silently share a fingerprint). TDD: TestPostgresTypesMap added first (red on 'timestamp without time zone'), green after.

CSV value-level inference of uuid/json is a separate, deliberately-untouched concern (the coarse profiler classifies them as text). Follow-up: the orchestrator pins dcg in go.mod, so picking this up there means bumping that dependency once this merges.