### PR TITLE
Adopt ODCS: model, emitter, fingerprint-from-ODCS, and declared-schema import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.out
 *.html
+tools/import/.venv/

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ test:
 	go test -race -coverprofile=coverage.out ./fingerprint/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 100) {printf "FAIL fingerprint %.1f%% < 100%%\n", $$1; exit 1} else {printf "fingerprint: %.1f%%\n", $$1}}'
+	go test -race -coverprofile=coverage.out ./odcs/...
+	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
+		awk '{if ($$1+0 < 100) {printf "FAIL odcs %.1f%% < 100%%\n", $$1; exit 1} else {printf "odcs: %.1f%%\n", $$1}}'
 	go test -race -coverprofile=coverage.out ./jsoncontract/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 95) {printf "FAIL jsoncontract %.1f%% < 95%%\n", $$1; exit 1} else {printf "jsoncontract: %.1f%%\n", $$1}}'

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ test:
 	go test -race -coverprofile=coverage.out ./odcs/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 100) {printf "FAIL odcs %.1f%% < 100%%\n", $$1; exit 1} else {printf "odcs: %.1f%%\n", $$1}}'
+	go test -race -coverprofile=coverage.out ./odcsemit/...
+	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
+		awk '{if ($$1+0 < 100) {printf "FAIL odcsemit %.1f%% < 100%%\n", $$1; exit 1} else {printf "odcsemit: %.1f%%\n", $$1}}'
 	go test -race -coverprofile=coverage.out ./jsoncontract/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 95) {printf "FAIL jsoncontract %.1f%% < 95%%\n", $$1; exit 1} else {printf "jsoncontract: %.1f%%\n", $$1}}'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: build test lint vet tidy check clean setup
+.PHONY: build test lint vet tidy check clean setup import-tools import-test
+
+# Pinned Python toolchain for the declared-schema importer (declimport).
+# Kept out of `make check` on purpose: the declimport unit tests run against
+# a fake command runner and need no Python. Create the venv and install the
+# pinned Data Contract CLI with `make import-tools`, then drive the real tool
+# end to end with `make import-test`.
+IMPORT_VENV := tools/import/.venv
 
 build:
 	go build ./...
@@ -25,6 +32,9 @@ test:
 	go test -race -coverprofile=coverage.out ./excelcontract/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 95) {printf "FAIL excelcontract %.1f%% < 95%%\n", $$1; exit 1} else {printf "excelcontract: %.1f%%\n", $$1}}'
+	go test -race -coverprofile=coverage.out ./declimport/...
+	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
+		awk '{if ($$1+0 < 100) {printf "FAIL declimport %.1f%% < 100%%\n", $$1; exit 1} else {printf "declimport: %.1f%%\n", $$1}}'
 
 lint:
 	golangci-lint run ./...
@@ -39,6 +49,20 @@ check: tidy vet lint test build
 
 setup:
 	git config core.hooksPath .githooks
+
+# Create the importer's venv and install the pinned Data Contract CLI. This
+# is a network install and is deliberately not part of `make check`.
+import-tools:
+	python3 -m venv $(IMPORT_VENV)
+	$(IMPORT_VENV)/bin/pip install --upgrade pip
+	$(IMPORT_VENV)/bin/pip install -r tools/import/requirements.txt
+	@echo "Installed:" && $(IMPORT_VENV)/bin/datacontract --version
+
+# Run the build-tagged integration tests against the real datacontract CLI,
+# putting the venv's bin on PATH so the importer finds the pinned binary. The
+# test skips (does not fail) if the binary is absent.
+import-test:
+	PATH="$(CURDIR)/$(IMPORT_VENV)/bin:$$PATH" go test -tags integration -race ./declimport/...
 
 clean:
 	rm -rf coverage.out

--- a/declimport/declimport.go
+++ b/declimport/declimport.go
@@ -1,7 +1,7 @@
 // Package declimport imports sources that already carry a declared schema
 // and normalises them into the odcs model. Where the file analysers infer a
-// contract from data, a declared schema (a Postgres DDL dump today; OpenAPI
-// and Avro later) is authoritative, so dcg does not infer it: it shells out
+// contract from data, a declared schema (a Postgres DDL dump or an Avro
+// record schema) is authoritative, so dcg does not infer it: it shells out
 // to the Data Contract CLI and reads the ODCS the CLI emits back into the
 // odcs package (spec section 6, DG-4).
 //
@@ -28,9 +28,13 @@
 // exec.go behind the same interface; a build-tagged integration test drives
 // it against the genuine binary.
 //
-// OpenAPI and Avro are deliberate follow-ups: they reuse importToODCS with a
-// different import subcommand and no dialect, so the seam is already shaped
-// for them.
+// Avro reuses the same importToODCS seam with a different import subcommand
+// and no dialect, so SQL and Avro differ only in the import argv. OpenAPI was
+// scoped alongside them, but the pinned Data Contract CLI (1.0.6) ships no
+// OpenAPI importer, and its jsonschema importer does not read an OpenAPI
+// document's components.schemas (it yields an empty model), so there is no
+// faithful OpenAPI path to shell out to yet; the seam is ready for one the
+// day the CLI grows the importer.
 package declimport
 
 import (
@@ -83,6 +87,13 @@ func FromSQLDDL(ctx context.Context, ddlPath, dialect string) (odcs.Contract, er
 	return New(execRunner{}).FromSQLDDL(ctx, ddlPath, dialect)
 }
 
+// FromAvro imports an Avro schema file (a .avsc record schema) into an odcs
+// contract, using the default CLI binary on PATH. It is the package-level
+// convenience over Importer.FromAvro with a real Runner.
+func FromAvro(ctx context.Context, schemaPath string) (odcs.Contract, error) {
+	return New(execRunner{}).FromAvro(ctx, schemaPath)
+}
+
 // FromSQLDDL imports a SQL DDL file into an odcs contract. dialect selects
 // the SQL grammar the CLI parses (for example "postgres"); it is required
 // because the CLI cannot reliably guess it and a wrong dialect parses the
@@ -105,12 +116,37 @@ func (im *Importer) FromSQLDDL(ctx context.Context, ddlPath, dialect string) (od
 	return im.importToODCS(ctx, []string{"import", "sql", "--source", ddlPath, "--dialect", dialect})
 }
 
+// FromAvro imports an Avro schema file into an odcs contract. schemaPath must
+// name a readable Avro schema (an .avsc record definition). Unlike SQL there
+// is no dialect: Avro is a single declared format, so the import step needs
+// only --source. The contract is read from the CLI's own ODCS export, so it
+// is canonical ODCS v3.1.0.
+//
+// The function fails closed: an empty or missing path, a non-zero exit from
+// either CLI step, or output that does not parse as an ODCS contract all
+// return an error and a zero Contract rather than a partial or silently empty
+// result.
+//
+// The Avro importer is an optional extra of the Data Contract CLI; install it
+// with the pinned datacontract-cli[avro] (see tools/import/requirements.txt).
+// Without the extra the import step exits non-zero and that error is wrapped
+// here, so a missing extra surfaces as a clear failure rather than a hang.
+func (im *Importer) FromAvro(ctx context.Context, schemaPath string) (odcs.Contract, error) {
+	if strings.TrimSpace(schemaPath) == "" {
+		return odcs.Contract{}, fmt.Errorf("declimport: empty Avro schema path")
+	}
+	if _, err := os.Stat(schemaPath); err != nil {
+		return odcs.Contract{}, fmt.Errorf("declimport: Avro schema file %q: %w", schemaPath, err)
+	}
+	return im.importToODCS(ctx, []string{"import", "avro", "--source", schemaPath})
+}
+
 // importToODCS runs an import subcommand to an intermediate data contract,
 // then exports that contract to ODCS and parses it. importArgs is the full
 // argv after the binary for the import step, including the source flags; this
 // function appends the --output target and owns the export step, so every
-// declared-schema path (SQL today, OpenAPI/Avro later) shares one import,
-// export, and parse pipeline and differs only in importArgs.
+// declared-schema path (SQL and Avro) shares one import, export, and parse
+// pipeline and differs only in importArgs.
 //
 // The intermediate contract is written to a temp file the function owns and
 // removes, so concurrent imports never collide on a fixed path and nothing
@@ -128,9 +164,9 @@ func (im *Importer) importToODCS(ctx context.Context, importArgs []string) (odcs
 	defer func() { _ = os.Remove(intermediate) }()
 
 	// Copy rather than append onto importArgs: this function is the shared
-	// seam for every declared-schema path (SQL today, OpenAPI/Avro later),
-	// so a future caller that hands in a slice with spare capacity must not
-	// have its backing array overwritten here.
+	// seam for every declared-schema path (SQL and Avro today), so a caller
+	// that hands in a slice with spare capacity must not have its backing
+	// array overwritten here.
 	fullImportArgs := append(append([]string(nil), importArgs...), "--output", intermediate)
 	if out, runErr := im.Runner.Run(ctx, im.Binary, fullImportArgs...); runErr != nil {
 		return odcs.Contract{}, fmt.Errorf("declimport: %s %s: %w: %s",

--- a/declimport/declimport.go
+++ b/declimport/declimport.go
@@ -1,0 +1,155 @@
+// Package declimport imports sources that already carry a declared schema
+// and normalises them into the odcs model. Where the file analysers infer a
+// contract from data, a declared schema (a Postgres DDL dump today; OpenAPI
+// and Avro later) is authoritative, so dcg does not infer it: it shells out
+// to the Data Contract CLI and reads the ODCS the CLI emits back into the
+// odcs package (spec section 6, DG-4).
+//
+// The SQL DDL path is the scoped slice. A live Postgres source has no direct
+// importer, so the producer takes a schema-only dump first:
+//
+//	pg_dump --schema-only db > ddl.sql
+//
+// and declimport runs the two CLI steps over that file:
+//
+//	datacontract import sql --source ddl.sql --dialect postgres --output dc.yaml
+//	datacontract export odcs dc.yaml
+//
+// The export step's stdout is ODCS v3.1.0, which odcs.UnmarshalYAML reads
+// directly. The two steps are kept even though import already emits an
+// ODCS-shaped document, so the canonical ODCS the rest of the platform reads
+// always comes from the tool's own export path rather than from declimport
+// trusting the intermediate.
+//
+// The only os/exec contact is the Runner seam: a single small interface the
+// importer calls for every subprocess. Tests pass a fake Runner, so the
+// argv construction, dialect handling, error paths, and ODCS parsing are all
+// exercised without the Python toolchain. The real implementation lives in
+// exec.go behind the same interface; a build-tagged integration test drives
+// it against the genuine binary.
+//
+// OpenAPI and Avro are deliberate follow-ups: they reuse importToODCS with a
+// different import subcommand and no dialect, so the seam is already shaped
+// for them.
+package declimport
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+)
+
+// DefaultBinary is the Data Contract CLI executable declimport shells out to.
+// It is resolved on the process PATH; pin the version via tools/import (the
+// importer's argv contract targets datacontract-cli 1.0.6).
+const DefaultBinary = "datacontract"
+
+// Runner runs a single subprocess and returns its combined output. It is the
+// one seam between declimport and the operating system: every CLI invocation
+// goes through Run, so a fake Runner makes the whole importer testable
+// without the real binary. The combined stdout+stderr is returned so a
+// caller can surface the CLI's own diagnostics on failure; on a non-zero
+// exit Run returns a non-nil error and the output captured so far.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// Importer imports declared schemas into odcs contracts. The zero value is
+// not ready to use; construct one with New. Binary names the CLI executable;
+// Runner is the subprocess seam.
+type Importer struct {
+	Binary string
+	Runner Runner
+}
+
+// New returns an Importer bound to the given Runner, using DefaultBinary. A
+// nil Runner is a programming error and panics, because an Importer with no
+// way to run the CLI can do nothing useful and silently returning errors
+// would only hide the mistake.
+func New(r Runner) *Importer {
+	if r == nil {
+		panic("declimport: nil Runner")
+	}
+	return &Importer{Binary: DefaultBinary, Runner: r}
+}
+
+// FromSQLDDL imports a SQL DDL file (for example a pg_dump --schema-only
+// output) into an odcs contract, using the default CLI binary on PATH. It is
+// the package-level convenience over Importer.FromSQLDDL with a real Runner.
+func FromSQLDDL(ctx context.Context, ddlPath, dialect string) (odcs.Contract, error) {
+	return New(execRunner{}).FromSQLDDL(ctx, ddlPath, dialect)
+}
+
+// FromSQLDDL imports a SQL DDL file into an odcs contract. dialect selects
+// the SQL grammar the CLI parses (for example "postgres"); it is required
+// because the CLI cannot reliably guess it and a wrong dialect parses the
+// DDL incorrectly. ddlPath must name a readable file. The contract is read
+// from the CLI's own ODCS export, so it is canonical ODCS v3.1.0.
+//
+// The function fails closed: a missing file, a non-zero exit from either CLI
+// step, or output that does not parse as an ODCS contract all return an
+// error and a zero Contract rather than a partial or silently empty result.
+func (im *Importer) FromSQLDDL(ctx context.Context, ddlPath, dialect string) (odcs.Contract, error) {
+	if strings.TrimSpace(ddlPath) == "" {
+		return odcs.Contract{}, fmt.Errorf("declimport: empty DDL path")
+	}
+	if strings.TrimSpace(dialect) == "" {
+		return odcs.Contract{}, fmt.Errorf("declimport: empty SQL dialect")
+	}
+	if _, err := os.Stat(ddlPath); err != nil {
+		return odcs.Contract{}, fmt.Errorf("declimport: DDL file %q: %w", ddlPath, err)
+	}
+	return im.importToODCS(ctx, []string{"import", "sql", "--source", ddlPath, "--dialect", dialect})
+}
+
+// importToODCS runs an import subcommand to an intermediate data contract,
+// then exports that contract to ODCS and parses it. importArgs is the full
+// argv after the binary for the import step, including the source flags; this
+// function appends the --output target and owns the export step, so every
+// declared-schema path (SQL today, OpenAPI/Avro later) shares one import,
+// export, and parse pipeline and differs only in importArgs.
+//
+// The intermediate contract is written to a temp file the function owns and
+// removes, so concurrent imports never collide on a fixed path and nothing
+// is left behind on the caller's disk.
+func (im *Importer) importToODCS(ctx context.Context, importArgs []string) (odcs.Contract, error) {
+	tmp, err := os.CreateTemp("", "declimport-*.yaml")
+	if err != nil {
+		return odcs.Contract{}, fmt.Errorf("declimport: create temp contract: %w", err)
+	}
+	intermediate := tmp.Name()
+	// Close immediately: the CLI writes the file by path, and a lingering
+	// open handle is just a leak. Removal is deferred so it runs on every
+	// exit path, including the error returns below.
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(intermediate) }()
+
+	// Copy rather than append onto importArgs: this function is the shared
+	// seam for every declared-schema path (SQL today, OpenAPI/Avro later),
+	// so a future caller that hands in a slice with spare capacity must not
+	// have its backing array overwritten here.
+	fullImportArgs := append(append([]string(nil), importArgs...), "--output", intermediate)
+	if out, runErr := im.Runner.Run(ctx, im.Binary, fullImportArgs...); runErr != nil {
+		return odcs.Contract{}, fmt.Errorf("declimport: %s %s: %w: %s",
+			im.Binary, strings.Join(fullImportArgs, " "), runErr, strings.TrimSpace(string(out)))
+	}
+
+	exportArgs := []string{"export", "odcs", intermediate}
+	out, runErr := im.Runner.Run(ctx, im.Binary, exportArgs...)
+	if runErr != nil {
+		return odcs.Contract{}, fmt.Errorf("declimport: %s %s: %w: %s",
+			im.Binary, strings.Join(exportArgs, " "), runErr, strings.TrimSpace(string(out)))
+	}
+
+	contract, err := odcs.UnmarshalYAML(out)
+	if err != nil {
+		return odcs.Contract{}, fmt.Errorf("declimport: parse ODCS export: %w", err)
+	}
+	if contract.APIVersion == "" || len(contract.Schema) == 0 {
+		return odcs.Contract{}, fmt.Errorf("declimport: ODCS export has no schema objects (apiVersion %q)", contract.APIVersion)
+	}
+	return contract, nil
+}

--- a/declimport/declimport_test.go
+++ b/declimport/declimport_test.go
@@ -1,0 +1,335 @@
+package declimport
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// odcsExport is a faithful ODCS v3.1.0 export of a small two-column table,
+// matching what `datacontract export odcs` writes for a Postgres DDL. The
+// fake Runner returns it for the export step so the parse path is exercised
+// without the real tool.
+const odcsExport = `version: 1.0.0
+kind: DataContract
+apiVersion: v3.1.0
+id: my-data-contract
+name: My Data Contract
+status: draft
+schema:
+- name: customers
+  physicalType: table
+  logicalType: object
+  physicalName: customers
+  properties:
+  - name: id
+    physicalType: INT
+    primaryKey: true
+    primaryKeyPosition: 1
+    logicalType: integer
+  - name: email
+    physicalType: TEXT
+    logicalType: string
+    required: true
+`
+
+// call records one Runner invocation so a test can assert the argv built for
+// each CLI step.
+type call struct {
+	name string
+	args []string
+}
+
+// fakeRunner is the test seam standing in for the Data Contract CLI. For each
+// call it returns the queued output/error in order, recording the argv. A
+// step keyed by its first two args (the subcommand) can also be made to fail,
+// which is how the import-failure and export-failure paths are driven.
+type fakeRunner struct {
+	calls   []call
+	outputs [][]byte
+	errs    []error
+	failOn  string // subcommand prefix, e.g. "import sql" or "export odcs"
+	failErr error
+	failOut []byte
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, call{name: name, args: append([]string(nil), args...)})
+	joined := strings.Join(args, " ")
+	if f.failOn != "" && strings.HasPrefix(joined, f.failOn) {
+		return f.failOut, f.failErr
+	}
+	idx := len(f.calls) - 1
+	var out []byte
+	if idx < len(f.outputs) {
+		out = f.outputs[idx]
+	}
+	var err error
+	if idx < len(f.errs) {
+		err = f.errs[idx]
+	}
+	return out, err
+}
+
+// writeDDL creates a DDL file in a temp dir and returns its path.
+func writeDDL(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ddl.sql")
+	if err := os.WriteFile(path, []byte("CREATE TABLE customers (id integer);"), 0o600); err != nil {
+		t.Fatalf("write ddl: %v", err)
+	}
+	return path
+}
+
+func TestNewPanicsOnNilRunner(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("New(nil) did not panic")
+		}
+	}()
+	New(nil)
+}
+
+func TestFromSQLDDL_Success(t *testing.T) {
+	ddl := writeDDL(t)
+	fr := &fakeRunner{outputs: [][]byte{nil, []byte(odcsExport)}}
+	im := New(fr)
+
+	got, err := im.FromSQLDDL(context.Background(), ddl, "postgres")
+	if err != nil {
+		t.Fatalf("FromSQLDDL: %v", err)
+	}
+
+	// The contract is the parsed ODCS export, not the intermediate.
+	if got.APIVersion != "v3.1.0" || got.Kind != "DataContract" {
+		t.Fatalf("contract header = %q/%q, want v3.1.0/DataContract", got.APIVersion, got.Kind)
+	}
+	if len(got.Schema) != 1 || got.Schema[0].Name != "customers" {
+		t.Fatalf("schema = %+v, want one object named customers", got.Schema)
+	}
+	if len(got.Schema[0].Properties) != 2 {
+		t.Fatalf("properties = %d, want 2", len(got.Schema[0].Properties))
+	}
+	id := got.Schema[0].Properties[0]
+	if id.Name != "id" || id.LogicalType != "integer" || id.PhysicalType != "INT" {
+		t.Fatalf("id property = %+v, want integer/INT", id)
+	}
+	if id.PrimaryKey == nil || !*id.PrimaryKey {
+		t.Fatalf("id primaryKey = %v, want true", id.PrimaryKey)
+	}
+	email := got.Schema[0].Properties[1]
+	if email.Required == nil || !*email.Required {
+		t.Fatalf("email required = %v, want true", email.Required)
+	}
+
+	// Two steps in order, with the expected argv. Both steps share one
+	// intermediate path: the import's --output and the export's location.
+	if len(fr.calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(fr.calls))
+	}
+	imp := fr.calls[0]
+	if imp.name != DefaultBinary {
+		t.Fatalf("import binary = %q, want %q", imp.name, DefaultBinary)
+	}
+	wantImportHead := []string{"import", "sql", "--source", ddl, "--dialect", "postgres", "--output"}
+	if !startsWith(imp.args, wantImportHead) {
+		t.Fatalf("import argv = %v, want prefix %v", imp.args, wantImportHead)
+	}
+	intermediate := imp.args[len(imp.args)-1]
+	exp := fr.calls[1]
+	wantExport := []string{"export", "odcs", intermediate}
+	if !equal(exp.args, wantExport) {
+		t.Fatalf("export argv = %v, want %v", exp.args, wantExport)
+	}
+
+	// The intermediate temp file is cleaned up.
+	if _, statErr := os.Stat(intermediate); !os.IsNotExist(statErr) {
+		t.Fatalf("intermediate %q not removed (stat err %v)", intermediate, statErr)
+	}
+}
+
+func TestFromSQLDDL_EmptyPath(t *testing.T) {
+	im := New(&fakeRunner{})
+	_, err := im.FromSQLDDL(context.Background(), "  ", "postgres")
+	if err == nil || !strings.Contains(err.Error(), "empty DDL path") {
+		t.Fatalf("err = %v, want empty DDL path", err)
+	}
+}
+
+func TestFromSQLDDL_EmptyDialect(t *testing.T) {
+	im := New(&fakeRunner{})
+	_, err := im.FromSQLDDL(context.Background(), writeDDL(t), "")
+	if err == nil || !strings.Contains(err.Error(), "empty SQL dialect") {
+		t.Fatalf("err = %v, want empty SQL dialect", err)
+	}
+}
+
+func TestFromSQLDDL_MissingFile(t *testing.T) {
+	im := New(&fakeRunner{})
+	_, err := im.FromSQLDDL(context.Background(), filepath.Join(t.TempDir(), "nope.sql"), "postgres")
+	if err == nil || !strings.Contains(err.Error(), "DDL file") {
+		t.Fatalf("err = %v, want DDL file error", err)
+	}
+}
+
+func TestFromSQLDDL_ImportFails(t *testing.T) {
+	fr := &fakeRunner{
+		failOn:  "import sql",
+		failErr: errors.New("exit status 1"),
+		failOut: []byte("could not parse DDL"),
+	}
+	im := New(fr)
+	_, err := im.FromSQLDDL(context.Background(), writeDDL(t), "postgres")
+	if err == nil {
+		t.Fatal("want error on import failure")
+	}
+	if !strings.Contains(err.Error(), "exit status 1") || !strings.Contains(err.Error(), "could not parse DDL") {
+		t.Fatalf("err = %v, want wrapped CLI exit and diagnostics", err)
+	}
+	// Failed before the export step.
+	if len(fr.calls) != 1 {
+		t.Fatalf("calls = %d, want 1 (no export after import failure)", len(fr.calls))
+	}
+}
+
+func TestFromSQLDDL_ExportFails(t *testing.T) {
+	fr := &fakeRunner{
+		failOn:  "export odcs",
+		failErr: errors.New("exit status 2"),
+		failOut: []byte("contract missing status"),
+	}
+	im := New(fr)
+	_, err := im.FromSQLDDL(context.Background(), writeDDL(t), "postgres")
+	if err == nil {
+		t.Fatal("want error on export failure")
+	}
+	if !strings.Contains(err.Error(), "exit status 2") || !strings.Contains(err.Error(), "contract missing status") {
+		t.Fatalf("err = %v, want wrapped export exit and diagnostics", err)
+	}
+}
+
+func TestFromSQLDDL_UnparseableExport(t *testing.T) {
+	fr := &fakeRunner{outputs: [][]byte{nil, []byte("\tnot: [valid: yaml")}}
+	im := New(fr)
+	_, err := im.FromSQLDDL(context.Background(), writeDDL(t), "postgres")
+	if err == nil || !strings.Contains(err.Error(), "parse ODCS export") {
+		t.Fatalf("err = %v, want parse ODCS export error", err)
+	}
+}
+
+func TestFromSQLDDL_EmptyExport(t *testing.T) {
+	// Valid YAML, but no schema objects: fail closed rather than return an
+	// empty contract that downstream would treat as a real (empty) source.
+	fr := &fakeRunner{outputs: [][]byte{nil, []byte("apiVersion: v3.1.0\nkind: DataContract\n")}}
+	im := New(fr)
+	_, err := im.FromSQLDDL(context.Background(), writeDDL(t), "postgres")
+	if err == nil || !strings.Contains(err.Error(), "no schema objects") {
+		t.Fatalf("err = %v, want no schema objects error", err)
+	}
+}
+
+// TestFromSQLDDL_TempCreateFails drives the branch where the intermediate
+// contract file cannot be created, by pointing the temp dir at a path that
+// does not exist. The importer must fail closed before running any CLI step.
+func TestFromSQLDDL_TempCreateFails(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+	fr := &fakeRunner{}
+	im := New(fr)
+	_, err := im.FromSQLDDL(context.Background(), writeDDL(t), "postgres")
+	if err == nil || !strings.Contains(err.Error(), "create temp contract") {
+		t.Fatalf("err = %v, want create temp contract error", err)
+	}
+	if len(fr.calls) != 0 {
+		t.Fatalf("calls = %d, want 0 (no CLI before temp file)", len(fr.calls))
+	}
+}
+
+// TestPackageFromSQLDDL covers the package-level convenience, which binds the
+// real execRunner. It is driven down the early validation path (empty
+// dialect) so no subprocess runs and the test needs no Python toolchain.
+func TestPackageFromSQLDDL_Validates(t *testing.T) {
+	_, err := FromSQLDDL(context.Background(), writeDDL(t), "")
+	if err == nil || !strings.Contains(err.Error(), "empty SQL dialect") {
+		t.Fatalf("err = %v, want empty SQL dialect", err)
+	}
+}
+
+// TestExecRunner exercises the one os/exec glue line without the Data
+// Contract CLI by re-executing this test binary as the subprocess (the
+// standard library's helper-process pattern). The helper echoes a marker and
+// chooses its exit code from an env var, so both the success and the non-zero
+// exit branches of execRunner.Run are covered.
+func TestExecRunner(t *testing.T) {
+	helper := []string{"-test.run=TestHelperProcess", "--", "marker-output"}
+
+	t.Run("success", func(t *testing.T) {
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		out, err := execRunner{}.Run(context.Background(), os.Args[0], helper...)
+		if err != nil {
+			t.Fatalf("Run: %v (out %q)", err, out)
+		}
+		if !strings.Contains(string(out), "marker-output") {
+			t.Fatalf("combined output = %q, want marker-output", out)
+		}
+	})
+
+	t.Run("nonzero exit", func(t *testing.T) {
+		t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+		t.Setenv("DECLIMPORT_HELPER_EXIT", "3")
+		out, err := execRunner{}.Run(context.Background(), os.Args[0], helper...)
+		if err == nil {
+			t.Fatalf("want error on non-zero exit, out %q", out)
+		}
+		if !strings.Contains(string(out), "marker-output") {
+			t.Fatalf("combined output = %q, want marker-output even on failure", out)
+		}
+	})
+}
+
+// TestHelperProcess is not a real test: it is the subprocess execRunner runs
+// in TestExecRunner. Guarded by GO_WANT_HELPER_PROCESS so it no-ops during a
+// normal test run and only acts when re-executed as the child. It echoes its
+// trailing args and exits with the code in DECLIMPORT_HELPER_EXIT (0 when
+// unset), standing in for the CLI.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := os.Args
+	for i, a := range args {
+		if a == "--" {
+			for _, marker := range args[i+1:] {
+				_, _ = os.Stdout.WriteString(marker + "\n")
+			}
+			break
+		}
+	}
+	if code := os.Getenv("DECLIMPORT_HELPER_EXIT"); code != "" {
+		n, _ := strconv.Atoi(code)
+		os.Exit(n)
+	}
+	os.Exit(0)
+}
+
+func startsWith(got, prefix []string) bool {
+	if len(got) < len(prefix) {
+		return false
+	}
+	return equal(got[:len(prefix)], prefix)
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/declimport/declimport_test.go
+++ b/declimport/declimport_test.go
@@ -152,6 +152,114 @@ func TestFromSQLDDL_Success(t *testing.T) {
 	}
 }
 
+// writeAvro creates an Avro schema file in a temp dir and returns its path.
+func writeAvro(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "schema.avsc")
+	schema := `{"type":"record","name":"Customer","fields":[{"name":"id","type":"long"}]}`
+	if err := os.WriteFile(path, []byte(schema), 0o600); err != nil {
+		t.Fatalf("write avro: %v", err)
+	}
+	return path
+}
+
+func TestFromAvro_Success(t *testing.T) {
+	avro := writeAvro(t)
+	fr := &fakeRunner{outputs: [][]byte{nil, []byte(odcsExport)}}
+	im := New(fr)
+
+	got, err := im.FromAvro(context.Background(), avro)
+	if err != nil {
+		t.Fatalf("FromAvro: %v", err)
+	}
+
+	// The contract is the parsed ODCS export, not the intermediate.
+	if got.APIVersion != "v3.1.0" || got.Kind != "DataContract" {
+		t.Fatalf("contract header = %q/%q, want v3.1.0/DataContract", got.APIVersion, got.Kind)
+	}
+	if len(got.Schema) != 1 || len(got.Schema[0].Properties) != 2 {
+		t.Fatalf("schema = %+v, want one object with 2 properties", got.Schema)
+	}
+
+	// Two steps in order. The import step targets the avro subcommand with
+	// --source and no --dialect (Avro is a single declared format); the
+	// export step reuses the same intermediate path.
+	if len(fr.calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(fr.calls))
+	}
+	imp := fr.calls[0]
+	if imp.name != DefaultBinary {
+		t.Fatalf("import binary = %q, want %q", imp.name, DefaultBinary)
+	}
+	wantImportHead := []string{"import", "avro", "--source", avro, "--output"}
+	if !startsWith(imp.args, wantImportHead) {
+		t.Fatalf("import argv = %v, want prefix %v", imp.args, wantImportHead)
+	}
+	// No dialect flag: Avro has only one grammar.
+	for _, a := range imp.args {
+		if a == "--dialect" {
+			t.Fatalf("import argv = %v, want no --dialect for Avro", imp.args)
+		}
+	}
+	intermediate := imp.args[len(imp.args)-1]
+	exp := fr.calls[1]
+	if wantExport := []string{"export", "odcs", intermediate}; !equal(exp.args, wantExport) {
+		t.Fatalf("export argv = %v, want %v", exp.args, wantExport)
+	}
+
+	// The intermediate temp file is cleaned up.
+	if _, statErr := os.Stat(intermediate); !os.IsNotExist(statErr) {
+		t.Fatalf("intermediate %q not removed (stat err %v)", intermediate, statErr)
+	}
+}
+
+func TestFromAvro_EmptyPath(t *testing.T) {
+	im := New(&fakeRunner{})
+	_, err := im.FromAvro(context.Background(), "  ")
+	if err == nil || !strings.Contains(err.Error(), "empty Avro schema path") {
+		t.Fatalf("err = %v, want empty Avro schema path", err)
+	}
+}
+
+func TestFromAvro_MissingFile(t *testing.T) {
+	im := New(&fakeRunner{})
+	_, err := im.FromAvro(context.Background(), filepath.Join(t.TempDir(), "nope.avsc"))
+	if err == nil || !strings.Contains(err.Error(), "Avro schema file") {
+		t.Fatalf("err = %v, want Avro schema file error", err)
+	}
+}
+
+func TestFromAvro_ImportFails(t *testing.T) {
+	// The avro importer is an optional CLI extra; without it the import step
+	// exits non-zero. The error and the CLI's own diagnostics are wrapped.
+	fr := &fakeRunner{
+		failOn:  "import avro",
+		failErr: errors.New("exit status 1"),
+		failOut: []byte("Module avro could not be loaded."),
+	}
+	im := New(fr)
+	_, err := im.FromAvro(context.Background(), writeAvro(t))
+	if err == nil {
+		t.Fatal("want error on import failure")
+	}
+	if !strings.Contains(err.Error(), "exit status 1") || !strings.Contains(err.Error(), "Module avro could not be loaded") {
+		t.Fatalf("err = %v, want wrapped CLI exit and diagnostics", err)
+	}
+	if len(fr.calls) != 1 {
+		t.Fatalf("calls = %d, want 1 (no export after import failure)", len(fr.calls))
+	}
+}
+
+// TestPackageFromAvro covers the package-level convenience, which binds the
+// real execRunner. It is driven down the early validation path (empty path)
+// so no subprocess runs and the test needs no Python toolchain.
+func TestPackageFromAvro_Validates(t *testing.T) {
+	_, err := FromAvro(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "empty Avro schema path") {
+		t.Fatalf("err = %v, want empty Avro schema path", err)
+	}
+}
+
 func TestFromSQLDDL_EmptyPath(t *testing.T) {
 	im := New(&fakeRunner{})
 	_, err := im.FromSQLDDL(context.Background(), "  ", "postgres")

--- a/declimport/exec.go
+++ b/declimport/exec.go
@@ -1,0 +1,23 @@
+package declimport
+
+import (
+	"context"
+	"os/exec"
+)
+
+// execRunner is the production Runner: the single point where declimport
+// touches os/exec. It is deliberately the whole of the package's subprocess
+// glue, so every other line of declimport runs against a fake Runner in
+// tests. Run is exercised in unit tests via the standard re-exec helper
+// pattern (a test process stands in for the CLI), and end to end against the
+// real Data Contract CLI by the build-tagged integration test.
+type execRunner struct{}
+
+// Run executes name with args under ctx and returns the combined
+// stdout+stderr. CommandContext ties the subprocess lifetime to ctx, so a
+// cancelled or timed-out context kills the CLI rather than leaking it.
+// CombinedOutput captures the CLI's own diagnostics, which the caller folds
+// into the error message on a non-zero exit.
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}

--- a/declimport/integration_test.go
+++ b/declimport/integration_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+// Package declimport's integration test drives the real Data Contract CLI
+// end to end, proving the importer's argv contract and ODCS parsing hold
+// against the genuine tool rather than the fake Runner. It is gated behind
+// the `integration` build tag so it never runs in the default `make check`
+// (which is pure Go and needs no Python toolchain); run it with
+//
+//	make import-test
+//
+// which puts dcg's pinned venv on PATH first. If the datacontract binary is
+// not found, the test skips with an explanatory message rather than failing,
+// so a contributor without the toolchain is not blocked.
+package declimport
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+)
+
+const sampleDDL = `CREATE TABLE customers (
+    id integer PRIMARY KEY,
+    email text NOT NULL,
+    created_at timestamp,
+    active boolean
+);
+`
+
+func TestIntegration_FromSQLDDL_Postgres(t *testing.T) {
+	if _, err := exec.LookPath(DefaultBinary); err != nil {
+		t.Skipf("real %q not on PATH; install with `make import-tools` and run `make import-test`", DefaultBinary)
+	}
+
+	ddl := filepath.Join(t.TempDir(), "schema.sql")
+	if err := os.WriteFile(ddl, []byte(sampleDDL), 0o600); err != nil {
+		t.Fatalf("write sample DDL: %v", err)
+	}
+
+	got, err := FromSQLDDL(context.Background(), ddl, "postgres")
+	if err != nil {
+		t.Fatalf("FromSQLDDL against real CLI: %v", err)
+	}
+
+	// A faithful ODCS contract: v3.1.0 header, one table, the typed columns.
+	if got.APIVersion != "v3.1.0" {
+		t.Fatalf("apiVersion = %q, want v3.1.0", got.APIVersion)
+	}
+	if got.Kind != "DataContract" {
+		t.Fatalf("kind = %q, want DataContract", got.Kind)
+	}
+	if len(got.Schema) != 1 {
+		t.Fatalf("schema objects = %d, want 1", len(got.Schema))
+	}
+	tbl := got.Schema[0]
+	if tbl.Name != "customers" {
+		t.Fatalf("table name = %q, want customers", tbl.Name)
+	}
+
+	byName := map[string]odcs.Property{}
+	for _, p := range tbl.Properties {
+		byName[p.Name] = p
+	}
+	if len(byName) != 4 {
+		t.Fatalf("columns = %d, want 4 (%v)", len(byName), tbl.Properties)
+	}
+
+	// The integer primary key: logical integer, marked primary key.
+	id := byName["id"]
+	if id.LogicalType != "integer" {
+		t.Fatalf("id logicalType = %q, want integer", id.LogicalType)
+	}
+	if id.PrimaryKey == nil || !*id.PrimaryKey {
+		t.Fatalf("id primaryKey = %v, want true", id.PrimaryKey)
+	}
+
+	// The NOT NULL text column: logical string, required true.
+	email := byName["email"]
+	if email.LogicalType != "string" {
+		t.Fatalf("email logicalType = %q, want string", email.LogicalType)
+	}
+	if email.Required == nil || !*email.Required {
+		t.Fatalf("email required = %v, want true (NOT NULL)", email.Required)
+	}
+
+	// The timestamp and boolean columns keep their logical types.
+	if got := byName["created_at"].LogicalType; got != "timestamp" {
+		t.Fatalf("created_at logicalType = %q, want timestamp", got)
+	}
+	if got := byName["active"].LogicalType; got != "boolean" {
+		t.Fatalf("active logicalType = %q, want boolean", got)
+	}
+}

--- a/declimport/integration_test.go
+++ b/declimport/integration_test.go
@@ -31,6 +31,23 @@ const sampleDDL = `CREATE TABLE customers (
 );
 `
 
+// sampleAvro is a tiny Avro record schema with a couple of typed fields. The
+// importer's [avro] extra (see tools/import/requirements.txt) must be present
+// for the import step to load; the test skips when the binary is absent and
+// fails loudly if the extra is missing, so a half-installed toolchain is not
+// mistaken for a passing run.
+const sampleAvro = `{
+  "type": "record",
+  "name": "Customer",
+  "namespace": "com.example",
+  "fields": [
+    {"name": "id", "type": "long"},
+    {"name": "email", "type": "string"},
+    {"name": "active", "type": "boolean"}
+  ]
+}
+`
+
 func TestIntegration_FromSQLDDL_Postgres(t *testing.T) {
 	if _, err := exec.LookPath(DefaultBinary); err != nil {
 		t.Skipf("real %q not on PATH; install with `make import-tools` and run `make import-test`", DefaultBinary)
@@ -90,6 +107,62 @@ func TestIntegration_FromSQLDDL_Postgres(t *testing.T) {
 	// The timestamp and boolean columns keep their logical types.
 	if got := byName["created_at"].LogicalType; got != "timestamp" {
 		t.Fatalf("created_at logicalType = %q, want timestamp", got)
+	}
+	if got := byName["active"].LogicalType; got != "boolean" {
+		t.Fatalf("active logicalType = %q, want boolean", got)
+	}
+}
+
+func TestIntegration_FromAvro(t *testing.T) {
+	if _, err := exec.LookPath(DefaultBinary); err != nil {
+		t.Skipf("real %q not on PATH; install with `make import-tools` and run `make import-test`", DefaultBinary)
+	}
+
+	schema := filepath.Join(t.TempDir(), "schema.avsc")
+	if err := os.WriteFile(schema, []byte(sampleAvro), 0o600); err != nil {
+		t.Fatalf("write sample Avro: %v", err)
+	}
+
+	got, err := FromAvro(context.Background(), schema)
+	if err != nil {
+		t.Fatalf("FromAvro against real CLI: %v", err)
+	}
+
+	// A faithful ODCS contract: v3.1.0 header, the record as one schema
+	// object, the typed fields carried through.
+	if got.APIVersion != "v3.1.0" {
+		t.Fatalf("apiVersion = %q, want v3.1.0", got.APIVersion)
+	}
+	if got.Kind != "DataContract" {
+		t.Fatalf("kind = %q, want DataContract", got.Kind)
+	}
+	if len(got.Schema) != 1 {
+		t.Fatalf("schema objects = %d, want 1", len(got.Schema))
+	}
+	rec := got.Schema[0]
+	if rec.Name != "Customer" {
+		t.Fatalf("record name = %q, want Customer", rec.Name)
+	}
+
+	byName := map[string]odcs.Property{}
+	for _, p := range rec.Properties {
+		byName[p.Name] = p
+	}
+	if len(byName) != 3 {
+		t.Fatalf("fields = %d, want 3 (%v)", len(byName), rec.Properties)
+	}
+
+	// The Avro long maps to a logical integer; string and boolean keep their
+	// logical types. A required (non-union) field comes back required.
+	id := byName["id"]
+	if id.LogicalType != "integer" {
+		t.Fatalf("id logicalType = %q, want integer", id.LogicalType)
+	}
+	if id.Required == nil || !*id.Required {
+		t.Fatalf("id required = %v, want true (non-union Avro field)", id.Required)
+	}
+	if got := byName["email"].LogicalType; got != "string" {
+		t.Fatalf("email logicalType = %q, want string", got)
 	}
 	if got := byName["active"].LogicalType; got != "boolean" {
 		t.Fatalf("active logicalType = %q, want boolean", got)

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -294,8 +294,8 @@ func canonicalName(name string) string {
 // analyzer vocabularies is an error (silent coercion could let two shapes
 // share a fingerprint), and a distinction the analyzer exposes is preserved
 // (array element types, binary vs text) rather than coarsened. Only the
-// spec's deliberate collapses apply: int/float to NUMBER, date/timestamp to
-// TEMPORAL, uuid to STRING, json/jsonb to OBJECT. The Postgres source tokens
+// spec's deliberate collapses apply: int/float to NUMBER, date/timestamp/time
+// to TEMPORAL, uuid to STRING, json/jsonb to OBJECT. The Postgres source tokens
 // a PostgreSQL/Supabase introspection emits join their canonical siblings:
 // "double precision" and real are NUMBER, "timestamp without time zone" is
 // TEMPORAL, and json maps to OBJECT alongside jsonb (dcg only describes data,
@@ -308,7 +308,7 @@ func mapDataType(dataType string) (CanonicalType, error) {
 		return TypeBinary, nil
 	case "numeric", "integer", "real", "double precision":
 		return TypeNumber, nil
-	case "date", "timestamp", "timestamptz", "timestamp without time zone":
+	case "date", "timestamp", "timestamptz", "timestamp without time zone", "time":
 		return TypeTemporal, nil
 	case "boolean":
 		return TypeBoolean, nil

--- a/fingerprint/odcs.go
+++ b/fingerprint/odcs.go
@@ -1,0 +1,230 @@
+package fingerprint
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+)
+
+// FromODCS derives structural fingerprint units from an ODCS contract,
+// producing the same canonical Object the native From* functions produce
+// from the analyser contracts. It is the read-side of the build-alongside
+// migration: the orchestrator can switch its fingerprint input from the
+// native contract to the ODCS document only because this path is proven
+// byte-identical to the native one (the conformance corpus). While they
+// stay byte-identical, AlgoVersion stays "fp1" and no cache is invalidated.
+//
+// Each schema object becomes one unit, located by its name (matching the
+// native multi-schema fanout). The source format and parse facts are read
+// from the schema object's dcg custom properties, where the emitter put
+// them, because the ODCS column model has no home for delimiter, encoding,
+// or header presence. A schema object that cannot be fingerprinted is
+// returned in skipped rather than failing the whole contract, mirroring
+// FromDataContract's per-unit blast-radius isolation; a contract-level
+// problem (nil, no schema) is an error.
+func FromODCS(c odcs.Contract) (units []Unit, skipped []SkippedSchema, err error) {
+	if len(c.Schema) == 0 {
+		return nil, nil, errors.New("fingerprint: ODCS contract has no schema objects")
+	}
+	for _, obj := range c.Schema {
+		object, objErr := objectFromODCSSchema(obj)
+		if objErr != nil {
+			skipped = append(skipped, SkippedSchema{Locator: obj.Name, Err: objErr})
+			continue
+		}
+		units = append(units, Unit{Locator: obj.Name, Object: object})
+	}
+	if len(units) == 0 {
+		// Every schema object failed: this is no longer a per-unit problem
+		// but a contract that yields no identity at all, so surface it as an
+		// error rather than an empty success the caller might cache.
+		return nil, skipped, errors.New("fingerprint: no ODCS schema object could be fingerprinted")
+	}
+	return units, skipped, nil
+}
+
+// objectFromODCSSchema builds one canonical Object from a single ODCS
+// schema object: its format and parse profile from the dcg custom
+// properties, its fields from the properties' logical/physical types.
+func objectFromODCSSchema(obj odcs.SchemaObject) (Object, error) {
+	format, err := odcsFormat(obj)
+	if err != nil {
+		return Object{}, err
+	}
+	parseProfile, err := odcsParseProfile(obj, format)
+	if err != nil {
+		return Object{}, err
+	}
+	fields, err := canonicalFields(len(obj.Properties), func(i int) (string, string) {
+		// canonicalFields maps a single analyzer-type token, but ODCS splits
+		// type across logicalType and physicalType. odcsCanonicalToken
+		// collapses the pair back into the exact token mapDataType expects,
+		// so both paths run through the identical field canonicalisation.
+		return obj.Properties[i].Name, odcsCanonicalToken(obj.Properties[i])
+	})
+	if err != nil {
+		return Object{}, err
+	}
+	return Object{
+		AlgoVersion:  AlgoVersion,
+		Format:       format,
+		ParseProfile: parseProfile,
+		Fields:       fields,
+	}, nil
+}
+
+// odcsFormat reads the source-format kind the emitter stamped onto the
+// schema object. An unrecognised or absent format is an error: identity
+// must never be minted under a guessed format, exactly as the native
+// dataContractFormat refuses to guess.
+func odcsFormat(obj odcs.SchemaObject) (Format, error) {
+	raw, ok := odcs.CustomProp(obj.CustomProperties, odcs.CustomKeySourceFormat)
+	if !ok {
+		return "", fmt.Errorf("fingerprint: ODCS schema object %q carries no %s", obj.Name, odcs.CustomKeySourceFormat)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("fingerprint: ODCS schema object %q has non-string %s", obj.Name, odcs.CustomKeySourceFormat)
+	}
+	switch Format(s) {
+	case FormatCSV, FormatJSON, FormatNDJSON, FormatXLSX, FormatAPI:
+		return Format(s), nil
+	}
+	return "", fmt.Errorf("fingerprint: ODCS schema object %q has unrecognised source format %q", obj.Name, s)
+}
+
+// odcsParseProfile reconstructs the parse profile per format, matching what
+// the native From* functions set. CSV carries delimiter, encoding, and
+// header presence; JSON and NDJSON carry only encoding (delimiter and
+// header stay nil so the canonical bytes match FromJSON's); Excel and API
+// carry no parse profile at all (nil, matching FromDataContract). The
+// custom-property values come back from YAML/JSON as their natural scalar
+// types, so each is type-asserted and a wrong type is an error rather than
+// a silent default that would forge a different fingerprint.
+func odcsParseProfile(obj odcs.SchemaObject, format Format) (*ParseProfile, error) {
+	switch format {
+	case FormatCSV:
+		delimiter, err := odcsString(obj, odcs.CustomKeyDelimiter)
+		if err != nil {
+			return nil, err
+		}
+		encoding, err := odcsString(obj, odcs.CustomKeyEncoding)
+		if err != nil {
+			return nil, err
+		}
+		hasHeader, err := odcsBool(obj, odcs.CustomKeyHasHeader)
+		if err != nil {
+			return nil, err
+		}
+		return &ParseProfile{Delimiter: &delimiter, Encoding: &encoding, HasHeader: &hasHeader}, nil
+	case FormatJSON, FormatNDJSON:
+		encoding, err := odcsString(obj, odcs.CustomKeyEncoding)
+		if err != nil {
+			return nil, err
+		}
+		return &ParseProfile{Encoding: &encoding}, nil
+	default:
+		// Excel and API set no parse profile on the native path.
+		return nil, nil
+	}
+}
+
+// odcsString reads a required string custom property. Absence and a
+// non-string value are both errors: the native path always set these, so a
+// missing or mistyped value means the document cannot reproduce the
+// fingerprint and must fail rather than substitute a default.
+func odcsString(obj odcs.SchemaObject, key string) (string, error) {
+	raw, ok := odcs.CustomProp(obj.CustomProperties, key)
+	if !ok {
+		return "", fmt.Errorf("fingerprint: ODCS schema object %q missing %s", obj.Name, key)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("fingerprint: ODCS schema object %q has non-string %s", obj.Name, key)
+	}
+	return s, nil
+}
+
+// odcsBool reads a required boolean custom property. YAML and JSON both
+// decode a boolean scalar to a Go bool, so a single assertion covers both
+// interchange forms.
+func odcsBool(obj odcs.SchemaObject, key string) (bool, error) {
+	raw, ok := odcs.CustomProp(obj.CustomProperties, key)
+	if !ok {
+		return false, fmt.Errorf("fingerprint: ODCS schema object %q missing %s", obj.Name, key)
+	}
+	b, ok := raw.(bool)
+	if !ok {
+		return false, fmt.Errorf("fingerprint: ODCS schema object %q has non-bool %s", obj.Name, key)
+	}
+	return b, nil
+}
+
+// odcsCanonicalToken collapses an ODCS property's logicalType + physicalType
+// back into the single analyzer-type token mapDataType consumes, applying
+// the spec section 5 rules. The physicalType is authoritative where ODCS's
+// nine logical types are too coarse: a string property is BINARY when its
+// physicalType is bytea (ODCS has no binary logical type) and OBJECT when
+// json/jsonb rides under a string, while uuid stays a plain string. An
+// array's element type comes from items so the token carries the inner type
+// the native path preserved. An empty logical type with an empty/null
+// physical token is the unobservable column the analysers emit as empty,
+// which maps to UNKNOWN.
+//
+// The returned token is fed straight to mapDataType, so any pairing the
+// rules below do not recognise reaches mapDataType and fails closed there:
+// no silent coercion, the same discipline as the native path.
+func odcsCanonicalToken(p odcs.Property) string {
+	switch p.LogicalType {
+	case "":
+		// Unobservable column: the analysers carry it as the empty (or, for
+		// JSON, null) token, both of which mapDataType reads as UNKNOWN.
+		switch p.PhysicalType {
+		case "empty", "null", "":
+			return "empty"
+		}
+		return p.PhysicalType
+	case odcs.LogicalString:
+		switch p.PhysicalType {
+		case "bytea":
+			// ODCS has no binary logical type, so a string with a bytea
+			// physical type is the binary payload; physicalType overrides.
+			return "bytea"
+		case "json", "jsonb":
+			// json/jsonb sometimes rides under a string logical type; it
+			// collapses to OBJECT just like the object logical type.
+			return p.PhysicalType
+		}
+		// uuid and every other string physical type collapse to STRING, the
+		// analyzer "text" token. mapDataType already folds uuid into STRING,
+		// so handing it "text" yields the identical canonical type.
+		return "text"
+	case odcs.LogicalNumber:
+		return "numeric"
+	case odcs.LogicalInteger:
+		return "integer"
+	case odcs.LogicalBoolean:
+		return "boolean"
+	case odcs.LogicalDate:
+		return "date"
+	case odcs.LogicalTimestamp:
+		return "timestamp"
+	case odcs.LogicalTime:
+		return "time"
+	case odcs.LogicalObject:
+		return "object"
+	case odcs.LogicalArray:
+		// Element-opaque unless items names the inner logical type, matching
+		// the native ARRAY vs ARRAY<inner> distinction. The inner token is
+		// recursed through odcsCanonicalToken and wrapped in the array[...]
+		// form mapDataType decodes.
+		if p.Items != nil {
+			return "array[" + odcsCanonicalToken(*p.Items) + "]"
+		}
+		return "array"
+	}
+	// An unmodelled logical type: hand it through verbatim so mapDataType is
+	// the single place that decides whether it is known.
+	return string(p.LogicalType)
+}

--- a/fingerprint/odcs.go
+++ b/fingerprint/odcs.go
@@ -3,6 +3,7 @@ package fingerprint
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/JacobJNilsson/data-contract-generator/odcs"
 )
@@ -176,25 +177,38 @@ func odcsBool(obj odcs.SchemaObject, key string) (bool, error) {
 // rules below do not recognise reaches mapDataType and fails closed there:
 // no silent coercion, the same discipline as the native path.
 func odcsCanonicalToken(p odcs.Property) string {
+	// Native type names arrive through physicalType in whatever case the
+	// producing tool used: pg_dump and "datacontract export odcs" routinely
+	// emit mixed or upper case. Fold before matching so an upper-case BYTEA
+	// or JSONB is recognised rather than silently collapsing to the wrong
+	// canonical type. Silent coercion stays forbidden: an unrecognised
+	// pairing reaches mapDataType and fails closed there.
+	phys := strings.ToLower(strings.TrimSpace(p.PhysicalType))
+
+	// bytea is binary whatever logical type ODCS pairs it with. ODCS has no
+	// binary logical type, so the physical type is authoritative and is
+	// checked here, before the logical-type switch: a tool that types a
+	// bytea column as object/array/etc. still fingerprints it as BINARY
+	// rather than losing the binary distinction.
+	if phys == "bytea" {
+		return "bytea"
+	}
+
 	switch p.LogicalType {
 	case "":
 		// Unobservable column: the analysers carry it as the empty (or, for
 		// JSON, null) token, both of which mapDataType reads as UNKNOWN.
-		switch p.PhysicalType {
+		switch phys {
 		case "empty", "null", "":
 			return "empty"
 		}
-		return p.PhysicalType
+		return phys
 	case odcs.LogicalString:
-		switch p.PhysicalType {
-		case "bytea":
-			// ODCS has no binary logical type, so a string with a bytea
-			// physical type is the binary payload; physicalType overrides.
-			return "bytea"
+		switch phys {
 		case "json", "jsonb":
 			// json/jsonb sometimes rides under a string logical type; it
 			// collapses to OBJECT just like the object logical type.
-			return p.PhysicalType
+			return phys
 		}
 		// uuid and every other string physical type collapse to STRING, the
 		// analyzer "text" token. mapDataType already folds uuid into STRING,

--- a/fingerprint/odcs_foreign_test.go
+++ b/fingerprint/odcs_foreign_test.go
@@ -1,0 +1,81 @@
+package fingerprint
+
+import (
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/csvcontract"
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/odcsemit"
+	"github.com/JacobJNilsson/data-contract-generator/profile"
+)
+
+// foreignBase returns a fingerprintable schema object (a valid source format
+// and parse facts in customProperties) whose properties the caller replaces.
+// It lets these tests feed FromODCS documents our own emitter would never
+// produce, the way a DDL importer or "datacontract export odcs" would: native
+// type names in mixed or upper case, and physical types paired with logical
+// types the emitter does not emit.
+func foreignBase(props []odcs.Property) odcs.Contract {
+	base := odcsemit.FromSourceContract(csvcontract.SourceContract{
+		SourcePath: "t.csv", Delimiter: ",", Encoding: "UTF-8", HasHeader: true,
+		Fields: []csvcontract.Field{{Name: "seed", DataType: profile.TypeText}},
+	}).Schema[0]
+	base.Properties = props
+	return odcs.Contract{Schema: []odcs.SchemaObject{base}}
+}
+
+// TestFromODCSForeignPhysicalTypeCasing proves the type projection folds the
+// case of native physical types and treats bytea as binary regardless of the
+// logical type it is paired with. A real producer emits "BYTEA"/"JSONB" and
+// may type a binary column as object; the old exact-lowercase match silently
+// collapsed those to the wrong canonical type instead of failing closed.
+func TestFromODCSForeignPhysicalTypeCasing(t *testing.T) {
+	c := foreignBase([]odcs.Property{
+		{Name: "bin_upper", LogicalType: odcs.LogicalString, PhysicalType: "BYTEA"},
+		{Name: "bin_under_object", LogicalType: odcs.LogicalObject, PhysicalType: "bytea"},
+		{Name: "bin_spaced", LogicalType: odcs.LogicalString, PhysicalType: "  Bytea  "},
+		{Name: "json_upper", LogicalType: odcs.LogicalString, PhysicalType: "JSONB"},
+		{Name: "uuid_upper", LogicalType: odcs.LogicalString, PhysicalType: "UUID"},
+		{Name: "num_upper", LogicalType: odcs.LogicalNumber, PhysicalType: "NUMERIC(10,2)"},
+	})
+	units, skipped, err := FromODCS(c)
+	if err != nil {
+		t.Fatalf("FromODCS: %v (skipped=%+v)", err, skipped)
+	}
+	if len(units) != 1 {
+		t.Fatalf("want one unit, got %d (skipped=%+v)", len(units), skipped)
+	}
+	got := map[string]CanonicalType{}
+	for _, f := range units[0].Object.Fields {
+		got[f.Name] = f.Type
+	}
+	want := map[string]CanonicalType{
+		"bin_upper":        TypeBinary,
+		"bin_under_object": TypeBinary,
+		"bin_spaced":       TypeBinary,
+		"json_upper":       TypeObject,
+		"uuid_upper":       TypeString,
+		"num_upper":        TypeNumber,
+	}
+	for name, wantType := range want {
+		if got[name] != wantType {
+			t.Errorf("field %q: got %s, want %s", name, got[name], wantType)
+		}
+	}
+}
+
+// TestFromODCSForeignUnknownFailsClosed proves an unmodelled logical type from
+// a foreign document still fails closed (the object is skipped) rather than
+// being coerced to a confident wrong canonical type.
+func TestFromODCSForeignUnknownFailsClosed(t *testing.T) {
+	c := foreignBase([]odcs.Property{
+		{Name: "weird", LogicalType: odcs.LogicalType("geography"), PhysicalType: "geography"},
+	})
+	units, skipped, err := FromODCS(c)
+	if err == nil {
+		t.Fatalf("expected fail-closed on an unmodelled logical type, got units=%+v", units)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected one skipped object, got %+v", skipped)
+	}
+}

--- a/fingerprint/odcs_test.go
+++ b/fingerprint/odcs_test.go
@@ -1,0 +1,402 @@
+package fingerprint
+
+import (
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/contract"
+	"github.com/JacobJNilsson/data-contract-generator/csvcontract"
+	"github.com/JacobJNilsson/data-contract-generator/jsoncontract"
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/odcsemit"
+	"github.com/JacobJNilsson/data-contract-generator/profile"
+)
+
+// --- the byte-identity conformance corpus (spec section 5, the DG-3 gate) -
+
+// csvCorpus is the set of CSV analyses the conformance proof runs over. Each
+// exercises a different facet of the canonicalisation: the plain types, the
+// temporal split, an unobservable column, duplicate names, non-ASCII names,
+// and varied parse profiles. For every one of them, FromCSV and
+// FromODCS(FromSourceContract(.)) must produce byte-identical canonical
+// bytes.
+func csvCorpus() []csvcontract.SourceContract {
+	return []csvcontract.SourceContract{
+		{
+			SourcePath: "plain.csv", Delimiter: ",", Encoding: "UTF-8", HasHeader: true,
+			Fields: []csvcontract.Field{
+				{Name: "name", DataType: profile.TypeText},
+				{Name: "qty", DataType: profile.TypeNumeric},
+				{Name: "ok", DataType: profile.TypeBoolean},
+			},
+		},
+		{
+			SourcePath: "temporal.csv", Delimiter: ";", Encoding: "ISO-8859-1", HasHeader: false,
+			Fields: []csvcontract.Field{
+				{Name: "day", DataType: profile.TypeDate},
+				{Name: "moment", DataType: profile.TypeTimestamp},
+			},
+		},
+		{
+			SourcePath: "unknowns.csv", Delimiter: "\t", Encoding: "UTF-8", HasHeader: true,
+			Fields: []csvcontract.Field{
+				{Name: "filled", DataType: profile.TypeText},
+				{Name: "blank", DataType: profile.TypeEmpty},
+			},
+		},
+		{
+			SourcePath: "dupes.csv", Delimiter: ",", Encoding: "UTF-8", HasHeader: true,
+			Fields: []csvcontract.Field{
+				{Name: "id", DataType: profile.TypeNumeric},
+				{Name: "id", DataType: profile.TypeText},
+				{Name: "Ärlig", DataType: profile.TypeText},
+			},
+		},
+	}
+}
+
+func TestConformanceCSVByteIdentical(t *testing.T) {
+	for _, sc := range csvCorpus() {
+		t.Run(sc.SourcePath, func(t *testing.T) {
+			native, err := FromCSV(&sc)
+			if err != nil {
+				t.Fatalf("FromCSV: %v", err)
+			}
+			units, skipped, err := FromODCS(odcsemit.FromSourceContract(sc))
+			if err != nil {
+				t.Fatalf("FromODCS: %v", err)
+			}
+			if len(skipped) != 0 {
+				t.Fatalf("unexpected skipped: %+v", skipped)
+			}
+			if len(units) != 1 {
+				t.Fatalf("expected 1 unit, got %d", len(units))
+			}
+			gotBytes := units[0].Object.CanonicalBytes()
+			wantBytes := native.CanonicalBytes()
+			if string(gotBytes) != string(wantBytes) {
+				t.Errorf("canonical bytes differ:\nnative: %s\nodcs:   %s", wantBytes, gotBytes)
+			}
+			if units[0].Object.Hash() != native.Hash() {
+				t.Errorf("hash differs: native %s vs odcs %s", native.Hash(), units[0].Object.Hash())
+			}
+		})
+	}
+}
+
+func jsonCorpus() []jsoncontract.SourceContract {
+	return []jsoncontract.SourceContract{
+		{
+			SourcePath: "events.json", SourceFormat: "json", Encoding: "UTF-8",
+			Fields: []jsoncontract.Field{
+				{Name: "label", DataType: jsoncontract.TypeText},
+				{Name: "count", DataType: jsoncontract.TypeNumeric},
+				{Name: "flag", DataType: jsoncontract.TypeBoolean},
+				{Name: "payload", DataType: jsoncontract.TypeObject},
+				{Name: "items", DataType: jsoncontract.TypeArray},
+			},
+		},
+		{
+			SourcePath: "stream.ndjson", SourceFormat: "ndjson", Encoding: "UTF-8",
+			Fields: []jsoncontract.Field{
+				{Name: "a", DataType: jsoncontract.TypeText},
+				{Name: "missing", DataType: jsoncontract.TypeNull},
+				{Name: "blank", DataType: jsoncontract.TypeEmpty},
+			},
+		},
+	}
+}
+
+func TestConformanceJSONByteIdentical(t *testing.T) {
+	for _, sc := range jsonCorpus() {
+		t.Run(sc.SourcePath, func(t *testing.T) {
+			native, err := FromJSON(&sc)
+			if err != nil {
+				t.Fatalf("FromJSON: %v", err)
+			}
+			units, skipped, err := FromODCS(odcsemit.FromJSONContract(sc))
+			if err != nil {
+				t.Fatalf("FromODCS: %v", err)
+			}
+			if len(skipped) != 0 || len(units) != 1 {
+				t.Fatalf("units=%d skipped=%+v", len(units), skipped)
+			}
+			if string(units[0].Object.CanonicalBytes()) != string(native.CanonicalBytes()) {
+				t.Errorf("canonical bytes differ:\nnative: %s\nodcs:   %s",
+					native.CanonicalBytes(), units[0].Object.CanonicalBytes())
+			}
+		})
+	}
+}
+
+func TestConformanceDataContractByteIdentical(t *testing.T) {
+	dc := contract.DataContract{
+		ID:       "workbook",
+		Metadata: map[string]any{"source_format": "xlsx"},
+		Schemas: []contract.SchemaContract{
+			{Name: "Sheet1", Fields: []contract.FieldDefinition{
+				{Name: "a", DataType: "text"},
+				{Name: "n", DataType: "numeric"},
+			}},
+			{Name: "Sheet2", Fields: []contract.FieldDefinition{
+				{Name: "d", DataType: "date"},
+			}},
+		},
+	}
+	nativeUnits, nativeSkipped, err := FromDataContract(&dc)
+	if err != nil {
+		t.Fatalf("FromDataContract: %v", err)
+	}
+	odcsUnits, odcsSkipped, err := FromODCS(odcsemit.FromDataContract(dc))
+	if err != nil {
+		t.Fatalf("FromODCS: %v", err)
+	}
+	if len(nativeSkipped) != 0 || len(odcsSkipped) != 0 {
+		t.Fatalf("skipped native=%+v odcs=%+v", nativeSkipped, odcsSkipped)
+	}
+	if len(nativeUnits) != len(odcsUnits) {
+		t.Fatalf("unit count native=%d odcs=%d", len(nativeUnits), len(odcsUnits))
+	}
+	for i := range nativeUnits {
+		if nativeUnits[i].Locator != odcsUnits[i].Locator {
+			t.Errorf("unit %d locator native=%q odcs=%q", i, nativeUnits[i].Locator, odcsUnits[i].Locator)
+		}
+		if string(nativeUnits[i].Object.CanonicalBytes()) != string(odcsUnits[i].Object.CanonicalBytes()) {
+			t.Errorf("unit %d bytes differ:\nnative: %s\nodcs:   %s", i,
+				nativeUnits[i].Object.CanonicalBytes(), odcsUnits[i].Object.CanonicalBytes())
+		}
+	}
+}
+
+// TestConformanceAPIByteIdentical covers the openapi-marked format, the
+// other branch of dataContractFormat.
+func TestConformanceAPIByteIdentical(t *testing.T) {
+	dc := contract.DataContract{
+		ID:       "spec",
+		Metadata: map[string]any{"source": "openapi"},
+		Schemas: []contract.SchemaContract{
+			{Name: "GET /things", Fields: []contract.FieldDefinition{{Name: "id", DataType: "integer"}}},
+		},
+	}
+	nativeUnits, _, err := FromDataContract(&dc)
+	if err != nil {
+		t.Fatalf("FromDataContract: %v", err)
+	}
+	odcsUnits, _, err := FromODCS(odcsemit.FromDataContract(dc))
+	if err != nil {
+		t.Fatalf("FromODCS: %v", err)
+	}
+	if string(nativeUnits[0].Object.CanonicalBytes()) != string(odcsUnits[0].Object.CanonicalBytes()) {
+		t.Errorf("bytes differ:\nnative: %s\nodcs:   %s",
+			nativeUnits[0].Object.CanonicalBytes(), odcsUnits[0].Object.CanonicalBytes())
+	}
+}
+
+// --- direct unit coverage of FromODCS and the ODCS token map --------------
+
+func TestFromODCSNoSchema(t *testing.T) {
+	if _, _, err := FromODCS(odcs.Contract{}); err == nil {
+		t.Error("expected error for ODCS contract with no schema objects")
+	}
+}
+
+func TestFromODCSMissingFormat(t *testing.T) {
+	c := odcs.Contract{Schema: []odcs.SchemaObject{{
+		Name:       "t",
+		Properties: []odcs.Property{{Name: "a", LogicalType: odcs.LogicalString, PhysicalType: "text"}},
+	}}}
+	_, skipped, err := FromODCS(c)
+	if err == nil {
+		t.Fatal("expected error when every object is unfingerprintable")
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("expected one skipped object, got %+v", skipped)
+	}
+}
+
+func TestFromODCSPartialSkip(t *testing.T) {
+	// One good object, one missing its format: the good one survives, the
+	// bad one is isolated into skipped.
+	good := odcsemit.FromSourceContract(csvcontract.SourceContract{
+		SourcePath: "ok.csv", Delimiter: ",", Encoding: "UTF-8", HasHeader: true,
+		Fields: []csvcontract.Field{{Name: "a", DataType: profile.TypeText}},
+	}).Schema[0]
+	bad := odcs.SchemaObject{Name: "bad", Properties: []odcs.Property{{Name: "x", LogicalType: odcs.LogicalString, PhysicalType: "text"}}}
+	c := odcs.Contract{Schema: []odcs.SchemaObject{good, bad}}
+	units, skipped, err := FromODCS(c)
+	if err != nil {
+		t.Fatalf("FromODCS: %v", err)
+	}
+	if len(units) != 1 || units[0].Locator != "ok.csv" {
+		t.Errorf("units = %+v", units)
+	}
+	if len(skipped) != 1 || skipped[0].Locator != "bad" {
+		t.Errorf("skipped = %+v", skipped)
+	}
+}
+
+func TestFromODCSFormatTypeAndValueErrors(t *testing.T) {
+	mk := func(props ...odcs.CustomProperty) odcs.Contract {
+		return odcs.Contract{Schema: []odcs.SchemaObject{{
+			Name:             "t",
+			CustomProperties: props,
+			Properties:       []odcs.Property{{Name: "a", LogicalType: odcs.LogicalString, PhysicalType: "text"}},
+		}}}
+	}
+	cases := []struct {
+		name  string
+		props []odcs.CustomProperty
+	}{
+		{"non-string format", []odcs.CustomProperty{{Property: odcs.CustomKeySourceFormat, Value: 7}}},
+		{"unrecognised format", []odcs.CustomProperty{{Property: odcs.CustomKeySourceFormat, Value: "parquet"}}},
+		{"csv missing delimiter", []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "csv"},
+			{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+			{Property: odcs.CustomKeyHasHeader, Value: true},
+		}},
+		{"csv non-string delimiter", []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "csv"},
+			{Property: odcs.CustomKeyDelimiter, Value: 1},
+			{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+			{Property: odcs.CustomKeyHasHeader, Value: true},
+		}},
+		{"csv missing encoding", []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "csv"},
+			{Property: odcs.CustomKeyDelimiter, Value: ","},
+			{Property: odcs.CustomKeyHasHeader, Value: true},
+		}},
+		{"csv missing header", []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "csv"},
+			{Property: odcs.CustomKeyDelimiter, Value: ","},
+			{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+		}},
+		{"csv non-bool header", []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "csv"},
+			{Property: odcs.CustomKeyDelimiter, Value: ","},
+			{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+			{Property: odcs.CustomKeyHasHeader, Value: "yes"},
+		}},
+		{"json missing encoding", []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "json"},
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, _, err := FromODCS(mk(c.props...)); err == nil {
+				t.Errorf("expected error for %s", c.name)
+			}
+		})
+	}
+}
+
+func TestFromODCSUnmappedFieldType(t *testing.T) {
+	// A property whose type token mapDataType does not know fails the whole
+	// object (which then becomes a contract-level error here).
+	c := odcs.Contract{Schema: []odcs.SchemaObject{{
+		Name: "t",
+		CustomProperties: []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "json"},
+			{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+		},
+		Properties: []odcs.Property{{Name: "a", LogicalType: odcs.LogicalType("mystery")}},
+	}}}
+	if _, _, err := FromODCS(c); err == nil {
+		t.Error("expected error for unmapped logical type")
+	}
+}
+
+func TestFromODCSNoFields(t *testing.T) {
+	c := odcs.Contract{Schema: []odcs.SchemaObject{{
+		Name: "t",
+		CustomProperties: []odcs.CustomProperty{
+			{Property: odcs.CustomKeySourceFormat, Value: "json"},
+			{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+		},
+	}}}
+	if _, _, err := FromODCS(c); err == nil {
+		t.Error("expected error for schema object with no properties")
+	}
+}
+
+// TestODCSTokenSpecialTypes covers the spec section 5 physicalType overrides
+// directly: bytea -> BINARY, uuid -> STRING, json/jsonb -> OBJECT, array with
+// items -> ARRAY<inner>, and time -> TEMPORAL. These types do not arise from
+// the file analysers yet, so they are proven through FromODCS against the
+// canonical lattice rather than through a native byte comparison.
+func TestODCSTokenSpecialTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		prop odcs.Property
+		want CanonicalType
+	}{
+		{"bytea-binary", odcs.Property{Name: "b", LogicalType: odcs.LogicalString, PhysicalType: "bytea"}, TypeBinary},
+		{"uuid-string", odcs.Property{Name: "u", LogicalType: odcs.LogicalString, PhysicalType: "uuid"}, TypeString},
+		{"json-object", odcs.Property{Name: "j", LogicalType: odcs.LogicalString, PhysicalType: "json"}, TypeObject},
+		{"jsonb-object", odcs.Property{Name: "k", LogicalType: odcs.LogicalString, PhysicalType: "jsonb"}, TypeObject},
+		{"integer-number", odcs.Property{Name: "i", LogicalType: odcs.LogicalInteger, PhysicalType: "bigint"}, TypeNumber},
+		{"time-temporal", odcs.Property{Name: "t", LogicalType: odcs.LogicalTime}, TypeTemporal},
+		{"array-inner", odcs.Property{
+			Name: "a", LogicalType: odcs.LogicalArray, PhysicalType: "text[]",
+			Items: &odcs.Property{LogicalType: odcs.LogicalString, PhysicalType: "text"},
+		}, CanonicalType("ARRAY<STRING>")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			obj := odcs.Contract{Schema: []odcs.SchemaObject{{
+				Name: "t",
+				CustomProperties: []odcs.CustomProperty{
+					{Property: odcs.CustomKeySourceFormat, Value: "json"},
+					{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+				},
+				Properties: []odcs.Property{c.prop},
+			}}}
+			units, _, err := FromODCS(obj)
+			if err != nil {
+				t.Fatalf("FromODCS: %v", err)
+			}
+			if units[0].Object.Fields[0].Type != c.want {
+				t.Errorf("type = %q, want %q", units[0].Object.Fields[0].Type, c.want)
+			}
+		})
+	}
+}
+
+// TestODCSTokenUnknownColumn covers the empty/null physical token collapse to
+// UNKNOWN and the echo-through of an unrecognised physical token under no
+// logical type.
+func TestODCSTokenUnknownColumn(t *testing.T) {
+	cases := []struct {
+		physical string
+		want     CanonicalType
+		wantErr  bool
+	}{
+		{"empty", TypeUnknown, false},
+		{"null", TypeUnknown, false},
+		{"", TypeUnknown, false},
+		{"weird", "", true}, // echoed through, then mapDataType fails closed
+	}
+	for _, c := range cases {
+		t.Run(c.physical, func(t *testing.T) {
+			obj := odcs.Contract{Schema: []odcs.SchemaObject{{
+				Name: "t",
+				CustomProperties: []odcs.CustomProperty{
+					{Property: odcs.CustomKeySourceFormat, Value: "json"},
+					{Property: odcs.CustomKeyEncoding, Value: "UTF-8"},
+				},
+				Properties: []odcs.Property{{Name: "x", PhysicalType: c.physical}},
+			}}}
+			units, _, err := FromODCS(obj)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for physical %q", c.physical)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("FromODCS: %v", err)
+			}
+			if units[0].Object.Fields[0].Type != c.want {
+				t.Errorf("type = %q, want %q", units[0].Object.Fields[0].Type, c.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/xuri/excelize/v2 v2.10.1
 	golang.org/x/text v0.35.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/JacobJNilsson/data-contract-generator
 go 1.25.0
 
 require (
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/xuri/excelize/v2 v2.10.1
 	golang.org/x/text v0.35.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -24,5 +24,7 @@ golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/richardlehane/mscfb v1.0.6 h1:eN3bvvZCp00bs7Zf52bxNwAx5lJDBK1tCuH19qq
 github.com/richardlehane/mscfb v1.0.6/go.mod h1:pe0+IUIc0AHh0+teNzBlJCtSyZdFOGgV4ZK9bsoV+Jo=
 github.com/richardlehane/msoleps v1.0.6 h1:9BvkpjvD+iUBalUY4esMwv6uBkfOip/Lzvd93jvR9gg=
 github.com/richardlehane/msoleps v1.0.6/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tiendc/go-deepcopy v1.7.2 h1:Ut2yYR7W9tWjTQitganoIue4UGxZwCcJy3orjrrIj44=

--- a/odcs/marshal.go
+++ b/odcs/marshal.go
@@ -1,0 +1,40 @@
+package odcs
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MarshalYAML renders the contract as an ODCS YAML document.
+func (c Contract) MarshalYAML() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// UnmarshalYAML parses an ODCS YAML document into a contract.
+func UnmarshalYAML(data []byte) (Contract, error) {
+	var c Contract
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return Contract{}, err
+	}
+	return c, nil
+}
+
+// MarshalJSON renders the contract as an ODCS JSON document. It satisfies
+// json.Marshaler, so json.Marshal of a Contract (including a Contract
+// nested in another value) routes through here. The alias type strips the
+// method set before the inner Marshal call, so the struct tags drive the
+// encoding and there is no recursion.
+func (c Contract) MarshalJSON() ([]byte, error) {
+	type alias Contract
+	return json.Marshal(alias(c))
+}
+
+// UnmarshalJSON parses an ODCS JSON document into a contract.
+func UnmarshalJSON(data []byte) (Contract, error) {
+	var c Contract
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Contract{}, err
+	}
+	return c, nil
+}

--- a/odcs/odcs.go
+++ b/odcs/odcs.go
@@ -1,0 +1,151 @@
+// Package odcs models the subset of the Open Data Contract Standard
+// (ODCS) v3.1.0 that the data-contract-generator emits and reads. It is
+// pure data modelling and serialisation: no I/O, no inference, and no
+// dependency on the analysers. The structs marshal to and from both YAML
+// (gopkg.in/yaml.v3) and JSON, which are the two interchange forms ODCS
+// tools accept.
+//
+// The model is deliberately a subset. ODCS v3.1.0 defines far more than
+// dcg uses; only the fields the platform reads or writes are present, so
+// the type stays honest about what dcg actually round-trips. Fields absent
+// from a given document marshal away (omitempty) rather than appearing as
+// empty placeholders, which keeps emitted documents minimal and stable.
+package odcs
+
+// APIVersion is the ODCS schema version this package models.
+const APIVersion = "v3.1.0"
+
+// KindDataContract is the only ODCS kind dcg produces.
+const KindDataContract = "DataContract"
+
+// Contract is a complete ODCS data contract document: the top-level
+// object an ODCS YAML or JSON file deserialises into. Schema holds one
+// SchemaObject per table/section the source exposes.
+type Contract struct {
+	APIVersion string         `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string         `json:"kind" yaml:"kind"`
+	ID         string         `json:"id" yaml:"id"`
+	Version    string         `json:"version,omitempty" yaml:"version,omitempty"`
+	Schema     []SchemaObject `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+// SchemaObject is one schema in a contract: a table, a view, or a file.
+// Objects describe structure only and carry no logicalType of their own;
+// the logical typing lives on each Property. PhysicalType is the kind of
+// object (table/view/file), not a column type.
+type SchemaObject struct {
+	Name         string     `json:"name" yaml:"name"`
+	PhysicalName string     `json:"physicalName,omitempty" yaml:"physicalName,omitempty"`
+	PhysicalType string     `json:"physicalType,omitempty" yaml:"physicalType,omitempty"`
+	Properties   []Property `json:"properties,omitempty" yaml:"properties,omitempty"`
+}
+
+// LogicalType is one of the nine ODCS v3.1.0 logical types. ODCS has no
+// first-class binary or enum type: binary payloads are carried as a string
+// logicalType with a physicalType that names the native binary type, and
+// enums as a string logicalType with a quality rule (see the emitter).
+type LogicalType string
+
+// The nine ODCS v3.1.0 logical types.
+const (
+	LogicalString    LogicalType = "string"
+	LogicalDate      LogicalType = "date"
+	LogicalTimestamp LogicalType = "timestamp"
+	LogicalTime      LogicalType = "time"
+	LogicalNumber    LogicalType = "number"
+	LogicalInteger   LogicalType = "integer"
+	LogicalObject    LogicalType = "object"
+	LogicalArray     LogicalType = "array"
+	LogicalBoolean   LogicalType = "boolean"
+)
+
+// Property is one column of a schema object. LogicalType is one of the
+// nine; PhysicalType is the free-form native type (e.g. "text", "uuid",
+// "account_status"). Required is nullability with ODCS semantics: true
+// means NOT NULL. Items carries the element typing of an array property.
+type Property struct {
+	Name         string      `json:"name" yaml:"name"`
+	LogicalType  LogicalType `json:"logicalType,omitempty" yaml:"logicalType,omitempty"`
+	PhysicalType string      `json:"physicalType,omitempty" yaml:"physicalType,omitempty"`
+
+	// Required is nullability under ODCS semantics: true = NOT NULL. It is
+	// a pointer so an unspecified nullability (nil) is distinct from an
+	// explicit false, and absence marshals away rather than asserting the
+	// column is nullable when the source never said so.
+	Required *bool `json:"required,omitempty" yaml:"required,omitempty"`
+
+	PrimaryKey         *bool `json:"primaryKey,omitempty" yaml:"primaryKey,omitempty"`
+	PrimaryKeyPosition *int  `json:"primaryKeyPosition,omitempty" yaml:"primaryKeyPosition,omitempty"`
+	Unique             *bool `json:"unique,omitempty" yaml:"unique,omitempty"`
+
+	LogicalTypeOptions *LogicalTypeOptions `json:"logicalTypeOptions,omitempty" yaml:"logicalTypeOptions,omitempty"`
+
+	// Items carries the element typing of an array property. It is only
+	// meaningful when LogicalType is "array"; nil otherwise.
+	Items *Property `json:"items,omitempty" yaml:"items,omitempty"`
+
+	Quality []Quality `json:"quality,omitempty" yaml:"quality,omitempty"`
+}
+
+// LogicalTypeOptions carries the ODCS constraint refinements that apply to
+// a logical type: string-shape constraints (length, pattern, format) and
+// numeric-range constraints (minimum, maximum, multipleOf). Every field is
+// a pointer so an unspecified constraint marshals away rather than
+// asserting a zero bound the source never observed.
+type LogicalTypeOptions struct {
+	MinLength *int   `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MaxLength *int   `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	Pattern   string `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Format    string `json:"format,omitempty" yaml:"format,omitempty"`
+
+	Minimum    *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	Maximum    *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MultipleOf *float64 `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+}
+
+// QualityType is the ODCS quality-rule kind.
+type QualityType string
+
+// The ODCS quality-rule kinds dcg uses.
+const (
+	QualityText    QualityType = "text"
+	QualityLibrary QualityType = "library"
+	QualitySQL     QualityType = "sql"
+	QualityCustom  QualityType = "custom"
+)
+
+// QualityMetric is the ODCS library-metric name a library quality rule
+// asserts against.
+type QualityMetric string
+
+// The ODCS library metrics dcg uses.
+const (
+	MetricNullValues      QualityMetric = "nullValues"
+	MetricMissingValues   QualityMetric = "missingValues"
+	MetricInvalidValues   QualityMetric = "invalidValues"
+	MetricDuplicateValues QualityMetric = "duplicateValues"
+	MetricRowCount        QualityMetric = "rowCount"
+)
+
+// Quality is one quality rule on a property. dcg's primary use is the enum
+// rule: type=library, metric=invalidValues, arguments.validValues carrying
+// the ordered label set, mustBe=0, unit=rows. Arguments is free-form (the
+// ODCS JSON Schema does not validate it), so the emitter and reader own the
+// round-trip of any structure carried there.
+//
+// The MustBe family are typed as any so each carries whatever JSON/YAML
+// scalar an ODCS rule compares against; with omitempty, an unset threshold
+// (nil) marshals away rather than asserting a zero bound.
+type Quality struct {
+	ID        string         `json:"id,omitempty" yaml:"id,omitempty"`
+	Type      QualityType    `json:"type,omitempty" yaml:"type,omitempty"`
+	Metric    QualityMetric  `json:"metric,omitempty" yaml:"metric,omitempty"`
+	Arguments map[string]any `json:"arguments,omitempty" yaml:"arguments,omitempty"`
+
+	MustBe            any `json:"mustBe,omitempty" yaml:"mustBe,omitempty"`
+	MustNotBe         any `json:"mustNotBe,omitempty" yaml:"mustNotBe,omitempty"`
+	MustBeGreaterThan any `json:"mustBeGreaterThan,omitempty" yaml:"mustBeGreaterThan,omitempty"`
+	MustBeLessThan    any `json:"mustBeLessThan,omitempty" yaml:"mustBeLessThan,omitempty"`
+
+	Unit string `json:"unit,omitempty" yaml:"unit,omitempty"`
+}

--- a/odcs/odcs.go
+++ b/odcs/odcs.go
@@ -18,6 +18,11 @@ const APIVersion = "v3.1.0"
 // KindDataContract is the only ODCS kind dcg produces.
 const KindDataContract = "DataContract"
 
+// StatusActive is the contract lifecycle status the emitter stamps on every
+// document. ODCS v3.1.0 requires a contract-level status; "active" is the
+// truthful value for a contract dcg has just derived and is using.
+const StatusActive = "active"
+
 // dcg custom-property keys. ODCS carries structure and types, but it has no
 // first-class home for the source-parse facts the fingerprint treats as
 // identity-bearing (the source format kind, and a CSV's delimiter,
@@ -56,10 +61,17 @@ func CustomProp(props []CustomProperty, key string) (any, bool) {
 // object an ODCS YAML or JSON file deserialises into. Schema holds one
 // SchemaObject per table/section the source exposes.
 type Contract struct {
-	APIVersion       string           `json:"apiVersion" yaml:"apiVersion"`
-	Kind             string           `json:"kind" yaml:"kind"`
-	ID               string           `json:"id" yaml:"id"`
-	Version          string           `json:"version,omitempty" yaml:"version,omitempty"`
+	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string `json:"kind" yaml:"kind"`
+	ID         string `json:"id" yaml:"id"`
+	Version    string `json:"version,omitempty" yaml:"version,omitempty"`
+	// Status is the ODCS-required contract lifecycle status (for example
+	// StatusActive). ODCS v3.1.0 lists it among the contract's required
+	// properties, so a document that omits it fails official ODCS schema
+	// validation and is rejected by ecosystem tools: the Data Contract CLI
+	// refuses to export a contract without it. The emitter always sets it.
+	// It is unrelated to any column a source happens to name "status".
+	Status           string           `json:"status,omitempty" yaml:"status,omitempty"`
 	Schema           []SchemaObject   `json:"schema,omitempty" yaml:"schema,omitempty"`
 	CustomProperties []CustomProperty `json:"customProperties,omitempty" yaml:"customProperties,omitempty"`
 }

--- a/odcs/odcs.go
+++ b/odcs/odcs.go
@@ -18,15 +18,50 @@ const APIVersion = "v3.1.0"
 // KindDataContract is the only ODCS kind dcg produces.
 const KindDataContract = "DataContract"
 
+// dcg custom-property keys. ODCS carries structure and types, but it has no
+// first-class home for the source-parse facts the fingerprint treats as
+// identity-bearing (the source format kind, and a CSV's delimiter,
+// encoding, and header presence). The emitter writes these into a schema
+// object's customProperties under the keys below, and the fingerprint reads
+// them back, so a fingerprint derived from an ODCS document is byte-
+// identical to one derived from the native contract. They are namespaced
+// with a "dcg" prefix so they never collide with an authored custom
+// property.
+const (
+	// CustomKeySourceFormat carries the fingerprint source-format kind
+	// (csv, json, ndjson, xlsx, api).
+	CustomKeySourceFormat = "dcgSourceFormat"
+	// CustomKeyDelimiter carries a CSV field delimiter.
+	CustomKeyDelimiter = "dcgDelimiter"
+	// CustomKeyEncoding carries a source's character encoding.
+	CustomKeyEncoding = "dcgEncoding"
+	// CustomKeyHasHeader carries whether a CSV had a header row.
+	CustomKeyHasHeader = "dcgHasHeader"
+)
+
+// CustomProp returns the first custom property with the given key, and
+// whether one was present. The lookup is linear because the list is short
+// (a handful of dcg keys) and ODCS stores custom properties as an ordered
+// array, not a map.
+func CustomProp(props []CustomProperty, key string) (any, bool) {
+	for _, p := range props {
+		if p.Property == key {
+			return p.Value, true
+		}
+	}
+	return nil, false
+}
+
 // Contract is a complete ODCS data contract document: the top-level
 // object an ODCS YAML or JSON file deserialises into. Schema holds one
 // SchemaObject per table/section the source exposes.
 type Contract struct {
-	APIVersion string         `json:"apiVersion" yaml:"apiVersion"`
-	Kind       string         `json:"kind" yaml:"kind"`
-	ID         string         `json:"id" yaml:"id"`
-	Version    string         `json:"version,omitempty" yaml:"version,omitempty"`
-	Schema     []SchemaObject `json:"schema,omitempty" yaml:"schema,omitempty"`
+	APIVersion       string           `json:"apiVersion" yaml:"apiVersion"`
+	Kind             string           `json:"kind" yaml:"kind"`
+	ID               string           `json:"id" yaml:"id"`
+	Version          string           `json:"version,omitempty" yaml:"version,omitempty"`
+	Schema           []SchemaObject   `json:"schema,omitempty" yaml:"schema,omitempty"`
+	CustomProperties []CustomProperty `json:"customProperties,omitempty" yaml:"customProperties,omitempty"`
 }
 
 // SchemaObject is one schema in a contract: a table, a view, or a file.
@@ -34,10 +69,25 @@ type Contract struct {
 // the logical typing lives on each Property. PhysicalType is the kind of
 // object (table/view/file), not a column type.
 type SchemaObject struct {
-	Name         string     `json:"name" yaml:"name"`
-	PhysicalName string     `json:"physicalName,omitempty" yaml:"physicalName,omitempty"`
-	PhysicalType string     `json:"physicalType,omitempty" yaml:"physicalType,omitempty"`
-	Properties   []Property `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Name             string           `json:"name" yaml:"name"`
+	PhysicalName     string           `json:"physicalName,omitempty" yaml:"physicalName,omitempty"`
+	PhysicalType     string           `json:"physicalType,omitempty" yaml:"physicalType,omitempty"`
+	Properties       []Property       `json:"properties,omitempty" yaml:"properties,omitempty"`
+	CustomProperties []CustomProperty `json:"customProperties,omitempty" yaml:"customProperties,omitempty"`
+}
+
+// CustomProperty is one ODCS custom key/value pair. ODCS v3.1.0 carries
+// these as an array of objects (not a map) on both the contract root and
+// each schema object. dcg uses them to carry source-parse facts (the
+// source format kind, and a CSV delimiter / encoding / header presence)
+// that the ODCS column model has no first-class home for but the
+// fingerprint needs to stay byte-identical to the native path. Property is
+// the key name; Value is a free-form scalar.
+type CustomProperty struct {
+	Property    string `json:"property" yaml:"property"`
+	Value       any    `json:"value" yaml:"value"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	ID          string `json:"id,omitempty" yaml:"id,omitempty"`
 }
 
 // LogicalType is one of the nine ODCS v3.1.0 logical types. ODCS has no

--- a/odcs/odcs_test.go
+++ b/odcs/odcs_test.go
@@ -1,0 +1,257 @@
+package odcs
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func ptrBool(b bool) *bool        { return &b }
+func ptrInt(i int) *int           { return &i }
+func ptrFloat(f float64) *float64 { return &f }
+
+// fullContract exercises every field of every struct so a round-trip test
+// over it proves each tag survives marshalling in both directions.
+func fullContract() Contract {
+	return Contract{
+		APIVersion: APIVersion,
+		Kind:       KindDataContract,
+		ID:         "orders.public.orders",
+		Version:    "1.0.0",
+		Schema: []SchemaObject{
+			{
+				Name:         "orders",
+				PhysicalName: "orders",
+				PhysicalType: "table",
+				Properties: []Property{
+					{
+						Name:               "id",
+						LogicalType:        LogicalInteger,
+						PhysicalType:       "bigint",
+						Required:           ptrBool(true),
+						PrimaryKey:         ptrBool(true),
+						PrimaryKeyPosition: ptrInt(1),
+						Unique:             ptrBool(true),
+					},
+					{
+						Name:         "code",
+						LogicalType:  LogicalString,
+						PhysicalType: "text",
+						Required:     ptrBool(false),
+						LogicalTypeOptions: &LogicalTypeOptions{
+							MinLength: ptrInt(1),
+							MaxLength: ptrInt(32),
+							Pattern:   "^[A-Z]+$",
+							Format:    "uuid",
+						},
+					},
+					{
+						Name:        "amount",
+						LogicalType: LogicalNumber,
+						LogicalTypeOptions: &LogicalTypeOptions{
+							Minimum:    ptrFloat(0),
+							Maximum:    ptrFloat(1000),
+							MultipleOf: ptrFloat(0.01),
+						},
+					},
+					{
+						Name:         "tags",
+						LogicalType:  LogicalArray,
+						PhysicalType: "text[]",
+						Items: &Property{
+							LogicalType:  LogicalString,
+							PhysicalType: "text",
+						},
+					},
+					{
+						Name:         "status",
+						LogicalType:  LogicalString,
+						PhysicalType: "account_status",
+						Quality: []Quality{
+							{
+								ID:     "status_valid_values",
+								Type:   QualityLibrary,
+								Metric: MetricInvalidValues,
+								Arguments: map[string]any{
+									"validValues": []any{"active", "closed", "pending"},
+								},
+								MustBe: 0,
+								Unit:   "rows",
+							},
+						},
+					},
+					{
+						Name:         "extras",
+						LogicalType:  LogicalObject,
+						PhysicalType: "jsonb",
+					},
+					{
+						Name:        "created_on",
+						LogicalType: LogicalDate,
+						LogicalTypeOptions: &LogicalTypeOptions{
+							Format: "date",
+						},
+						Quality: []Quality{
+							{
+								ID:                "freshness",
+								Type:              QualityText,
+								Metric:            MetricRowCount,
+								MustNotBe:         0,
+								MustBeGreaterThan: 1,
+								MustBeLessThan:    100,
+							},
+						},
+					},
+					{
+						Name:        "seen_at",
+						LogicalType: LogicalTimestamp,
+						LogicalTypeOptions: &LogicalTypeOptions{
+							Format: "date-time",
+						},
+					},
+					{
+						Name:        "seen_time",
+						LogicalType: LogicalTime,
+					},
+					{
+						Name:        "ok",
+						LogicalType: LogicalBoolean,
+						Quality: []Quality{
+							{
+								ID:     "no_nulls",
+								Type:   QualitySQL,
+								Metric: MetricNullValues,
+								MustBe: 0,
+								Unit:   "rows",
+							},
+							{
+								ID:     "no_dupes",
+								Type:   QualityCustom,
+								Metric: MetricDuplicateValues,
+							},
+							{
+								ID:     "no_missing",
+								Metric: MetricMissingValues,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestJSONRoundTripBytes(t *testing.T) {
+	c := fullContract()
+	data, err := c.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	got, err := UnmarshalJSON(data)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	// any-typed fields (MustBe family, Arguments values) decode to
+	// float64/[]any, so re-marshal and compare bytes rather than the Go
+	// values: a stable byte form is the contract this package guarantees.
+	again, err := got.MarshalJSON()
+	if err != nil {
+		t.Fatalf("re-MarshalJSON: %v", err)
+	}
+	if string(data) != string(again) {
+		t.Errorf("JSON round-trip not byte-stable:\nfirst:  %s\nsecond: %s", data, again)
+	}
+}
+
+func TestYAMLRoundTripBytes(t *testing.T) {
+	c := fullContract()
+	data, err := c.MarshalYAML()
+	if err != nil {
+		t.Fatalf("MarshalYAML: %v", err)
+	}
+	got, err := UnmarshalYAML(data)
+	if err != nil {
+		t.Fatalf("UnmarshalYAML: %v", err)
+	}
+	again, err := got.MarshalYAML()
+	if err != nil {
+		t.Fatalf("re-MarshalYAML: %v", err)
+	}
+	if string(data) != string(again) {
+		t.Errorf("YAML round-trip not byte-stable:\nfirst:  %s\nsecond: %s", data, again)
+	}
+}
+
+func TestEmptyContractOmitsOptionalKeys(t *testing.T) {
+	c := Contract{APIVersion: APIVersion, Kind: KindDataContract, ID: "x"}
+	data, err := c.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	got := string(data)
+	want := `{"apiVersion":"v3.1.0","kind":"DataContract","id":"x"}`
+	if got != want {
+		t.Errorf("empty contract JSON = %s, want %s", got, want)
+	}
+}
+
+func TestJSONMarshalerSatisfied(t *testing.T) {
+	// Encoding a Contract nested in another value must route through the
+	// Contract's MarshalJSON without recursing.
+	wrapper := struct {
+		C Contract `json:"c"`
+	}{C: Contract{APIVersion: APIVersion, Kind: KindDataContract, ID: "y"}}
+	data, err := json.Marshal(wrapper)
+	if err != nil {
+		t.Fatalf("json.Marshal wrapper: %v", err)
+	}
+	want := `{"c":{"apiVersion":"v3.1.0","kind":"DataContract","id":"y"}}`
+	if string(data) != want {
+		t.Errorf("nested marshal = %s, want %s", data, want)
+	}
+}
+
+func TestUnmarshalYAMLError(t *testing.T) {
+	if _, err := UnmarshalYAML([]byte("\tnot: valid: yaml:")); err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestUnmarshalJSONError(t *testing.T) {
+	if _, err := UnmarshalJSON([]byte("{not json")); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestMarshalYAMLParsesBack(t *testing.T) {
+	// Guard the YAML path specifically: marshal, then parse with a raw
+	// yaml.Unmarshal to confirm the document is well-formed YAML and the
+	// enum quality rule survives with its ordered labels.
+	c := fullContract()
+	data, err := c.MarshalYAML()
+	if err != nil {
+		t.Fatalf("MarshalYAML: %v", err)
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("raw yaml.Unmarshal: %v", err)
+	}
+	got, err := UnmarshalYAML(data)
+	if err != nil {
+		t.Fatalf("UnmarshalYAML: %v", err)
+	}
+	status := got.Schema[0].Properties[4]
+	if status.Name != "status" {
+		t.Fatalf("expected status property, got %q", status.Name)
+	}
+	labels, ok := status.Quality[0].Arguments["validValues"].([]any)
+	if !ok {
+		t.Fatalf("validValues not a list: %T", status.Quality[0].Arguments["validValues"])
+	}
+	want := []any{"active", "closed", "pending"}
+	if !reflect.DeepEqual(labels, want) {
+		t.Errorf("validValues = %v, want %v", labels, want)
+	}
+}

--- a/odcs/odcs_test.go
+++ b/odcs/odcs_test.go
@@ -20,11 +20,17 @@ func fullContract() Contract {
 		Kind:       KindDataContract,
 		ID:         "orders.public.orders",
 		Version:    "1.0.0",
+		CustomProperties: []CustomProperty{
+			{Property: "dcgSourceFormat", Value: "csv", Description: "the source format kind", ID: "fmt"},
+		},
 		Schema: []SchemaObject{
 			{
 				Name:         "orders",
 				PhysicalName: "orders",
 				PhysicalType: "table",
+				CustomProperties: []CustomProperty{
+					{Property: "dcgDelimiter", Value: ","},
+				},
 				Properties: []Property{
 					{
 						Name:               "id",
@@ -253,5 +259,24 @@ func TestMarshalYAMLParsesBack(t *testing.T) {
 	want := []any{"active", "closed", "pending"}
 	if !reflect.DeepEqual(labels, want) {
 		t.Errorf("validValues = %v, want %v", labels, want)
+	}
+}
+
+func TestCustomProp(t *testing.T) {
+	props := []CustomProperty{
+		{Property: CustomKeySourceFormat, Value: "csv"},
+		{Property: CustomKeyDelimiter, Value: ";"},
+	}
+	if v, ok := CustomProp(props, CustomKeySourceFormat); !ok || v != "csv" {
+		t.Errorf("source format lookup = %v, %v", v, ok)
+	}
+	if v, ok := CustomProp(props, CustomKeyDelimiter); !ok || v != ";" {
+		t.Errorf("delimiter lookup = %v, %v", v, ok)
+	}
+	if _, ok := CustomProp(props, CustomKeyEncoding); ok {
+		t.Error("absent key should report not found")
+	}
+	if _, ok := CustomProp(nil, CustomKeyHasHeader); ok {
+		t.Error("nil props should report not found")
 	}
 }

--- a/odcs/schema_test.go
+++ b/odcs/schema_test.go
@@ -1,0 +1,109 @@
+package odcs_test
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// The official ODCS v3.1.0 JSON Schema (the offline copy the Data Contract CLI
+// ships). Validating against it makes ODCS conformance a checked fact rather
+// than an asserted one: if the model drifts from a required field or a
+// constraint the standard imposes, this test fails instead of the breakage
+// surfacing later in an ecosystem tool.
+//
+//go:embed testdata/odcs-3.1.0.schema.json
+var odcsSchema []byte
+
+func compileODCSSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("odcs.json", bytes.NewReader(odcsSchema)); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	sch, err := c.Compile("odcs.json")
+	if err != nil {
+		t.Fatalf("compile ODCS schema: %v", err)
+	}
+	return sch
+}
+
+func validate(t *testing.T, sch *jsonschema.Schema, c odcs.Contract) error {
+	t.Helper()
+	raw, err := c.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal contract: %v", err)
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("decode contract json: %v", err)
+	}
+	return sch.Validate(v)
+}
+
+// representativeContract is the OP-8 destination shape: every native type the
+// platform cares about, including an enum encoded as the invalidValues quality
+// rule and a typed array. It mirrors what the emitter produces.
+func representativeContract() odcs.Contract {
+	b := func(v bool) *bool { return &v }
+	i := func(v int) *int { return &v }
+	return odcs.Contract{
+		APIVersion: odcs.APIVersion,
+		Kind:       odcs.KindDataContract,
+		ID:         "spike-accounts",
+		Version:    "1.0.0",
+		Status:     odcs.StatusActive,
+		Schema: []odcs.SchemaObject{{
+			Name:         "accounts",
+			PhysicalName: "accounts",
+			PhysicalType: "table",
+			Properties: []odcs.Property{
+				{
+					Name: "id", LogicalType: odcs.LogicalString, PhysicalType: "uuid",
+					Required: b(true), PrimaryKey: b(true), PrimaryKeyPosition: i(1),
+					LogicalTypeOptions: &odcs.LogicalTypeOptions{Format: "uuid"},
+				},
+				{Name: "balance", LogicalType: odcs.LogicalNumber, PhysicalType: "numeric(12,2)", Required: b(true)},
+				{Name: "opened_on", LogicalType: odcs.LogicalDate, PhysicalType: "date"},
+				{Name: "created_at", LogicalType: odcs.LogicalTimestamp, PhysicalType: "timestamptz"},
+				{Name: "metadata", LogicalType: odcs.LogicalObject, PhysicalType: "jsonb"},
+				{
+					Name: "status", LogicalType: odcs.LogicalString, PhysicalType: "account_status",
+					Quality: []odcs.Quality{{
+						ID: "status_valid_values", Type: odcs.QualityLibrary, Metric: odcs.MetricInvalidValues,
+						Arguments: map[string]any{"validValues": []string{"active", "closed", "pending"}},
+						MustBe:    0, Unit: "rows",
+					}},
+				},
+				{
+					Name: "tags", LogicalType: odcs.LogicalArray, PhysicalType: "text[]",
+					Items: &odcs.Property{LogicalType: odcs.LogicalString, PhysicalType: "text"},
+				},
+			},
+		}},
+	}
+}
+
+func TestRepresentativeContractValidatesAgainstODCSSchema(t *testing.T) {
+	sch := compileODCSSchema(t)
+	if err := validate(t, sch, representativeContract()); err != nil {
+		t.Fatalf("emitted-shape contract failed official ODCS v3.1.0 schema: %v", err)
+	}
+}
+
+// TestMissingStatusFailsODCSSchema proves the validator is real (not vacuous):
+// the contract status is required by ODCS, and dropping it must fail. This is
+// the exact conformance gap the real-tools spike found: the Data Contract CLI
+// refused to export a contract without a status.
+func TestMissingStatusFailsODCSSchema(t *testing.T) {
+	sch := compileODCSSchema(t)
+	c := representativeContract()
+	c.Status = ""
+	if err := validate(t, sch, c); err == nil {
+		t.Fatal("expected ODCS schema validation to fail when status is absent")
+	}
+}

--- a/odcs/testdata/odcs-3.1.0.schema.json
+++ b/odcs/testdata/odcs-3.1.0.schema.json
@@ -1,0 +1,2928 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Open Data Contract Standard (ODCS)",
+  "description": "An open data contract specification to establish agreement between data producers and consumers.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Current version of the data contract."
+    },
+    "kind": {
+      "type": "string",
+      "default": "DataContract",
+      "description": "The kind of file this is. Valid value is `DataContract`.",
+      "enum": ["DataContract"]
+    },
+    "apiVersion": {
+      "type": "string",
+      "default": "v3.1.0",
+      "description": "Version of the standard used to build data contract. Default value is v3.1.0.",
+      "enum": ["v3.1.0", "v3.0.2", "v3.0.1", "v3.0.0", "v2.2.2", "v2.2.1", "v2.2.0"]
+    },
+    "id": {
+      "type": "string",
+      "description": "A unique identifier used to reduce the risk of dataset name collisions, such as a UUID."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the data contract."
+    },
+    "tenant": {
+      "type": "string",
+      "description": "Indicates the property the data is primarily associated with. Value is case insensitive."
+    },
+    "tags": {
+      "$ref": "#/$defs/Tags"
+    },
+    "status": {
+      "type": "string",
+      "description": "Current status of the dataset.",
+      "examples": [
+        "proposed", "draft", "active", "deprecated", "retired"
+      ]
+    },
+    "servers": {
+      "type": "array",
+      "description": "List of servers where the datasets reside.",
+      "items": {
+        "$ref": "#/$defs/Server"
+      }
+    },
+    "dataProduct": {
+      "type": "string",
+      "description": "The name of the data product."
+    },
+    "description": {
+      "type": "object",
+      "description": "High level description of the dataset.",
+      "properties": {
+        "usage": {
+          "type": "string",
+          "description": "Intended usage of the dataset."
+        },
+        "purpose": {
+          "type": "string",
+          "description": "Purpose of the dataset."
+        },
+        "limitations": {
+          "type": "string",
+          "description": "Limitations of the dataset."
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      }
+    },
+    "domain": {
+      "type": "string",
+      "description": "Name of the logical data domain.",
+      "examples": ["imdb_ds_aggregate", "receiver_profile_out", "transaction_profile_out"]
+    },
+    "schema": {
+      "type": "array",
+      "description": "A list of elements within the schema to be cataloged.",
+      "items": {
+        "$ref": "#/$defs/SchemaObject"
+      }
+    },
+    "support": {
+      "$ref": "#/$defs/Support"
+    },
+    "price": {
+      "$ref": "#/$defs/Pricing"
+    },
+    "team": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/Team",
+          "description": "Team information object with members array (v3.1.0+)."
+        },
+        {
+          "type": "array",
+          "description": "DEPRECATED: Array of team members. Use the Team object structure instead. This array format is maintained for backward compatibility with v3.0.2 and earlier versions and will be removed in ODCS 4.0.",
+          "deprecated": true,
+          "items": {
+            "$ref": "#/$defs/TeamMember"
+          }
+        }
+      ]
+    },
+    "roles": {
+      "type": "array",
+      "description": "A list of roles that will provide user access to the dataset.",
+      "items": {
+        "$ref": "#/$defs/Role"
+      }
+    },
+    "slaDefaultElement": {
+      "type": "string",
+      "description": "DEPRECATED SINCE 3.1. WILL BE REMOVED IN ODCS 4.0. Element (using the element path notation) to do the checks on.",
+      "deprecated": true
+    },
+    "slaProperties": {
+      "type": "array",
+      "description": "A list of key/value pairs for SLA specific properties. There is no limit on the type of properties (more details to come).",
+      "items": {
+        "$ref": "#/$defs/ServiceLevelAgreementProperty"
+      }
+    },
+    "authoritativeDefinitions": {
+      "$ref": "#/$defs/AuthoritativeDefinitions"
+    },
+    "customProperties": {
+      "$ref": "#/$defs/CustomProperties"
+    },
+    "contractCreatedTs": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp in UTC of when the data contract was created."
+    }
+  },
+  "required": ["version", "apiVersion", "kind", "id", "status"],
+  "additionalProperties": false,
+  "unevaluatedProperties": false,
+  "$defs": {
+    "ShorthandReference": {
+      "type": "string",
+      "description": "Shorthand notation using name fields (table_name.column_name)",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*\\.[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "FullyQualifiedReference": {
+      "type": "string",
+      "description": "Fully qualified notation using id fields (section/id/properties/id), optionally prefixed with external file reference",
+      "pattern": "^(?:(?:https?:\\/\\/)?[A-Za-z0-9._\\-\\/]+\\.yaml#)?\\/?[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+(?:\\/[A-Za-z_][A-Za-z0-9_]*\\/[A-Za-z0-9_-]+)*$"
+    },
+    "StableId": {
+      "type": "string",
+      "description": "Stable technical identifier for references. Must be unique within its containing array. Cannot contain special characters ('-', '_' allowed).",
+      "pattern": "^[A-Za-z0-9_-]+$"
+    },
+    "Server": {
+      "type": "object",
+      "description": "Data source details of where data is physically stored.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "server": {
+          "type": "string",
+          "description": "Identifier of the server."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the server.",
+          "enum": [
+            "api", "athena", "azure", "bigquery", "clickhouse", "databricks", "denodo", "dremio",
+            "duckdb", "glue", "cloudsql", "db2", "hive", "impala", "informix", "kafka", "kinesis", "local",
+            "mysql", "oracle", "postgresql", "postgres", "presto", "pubsub",
+            "redshift", "s3", "sftp", "snowflake", "sqlserver", "synapse", "trino", "vertica", "zen", "custom"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the server."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment of the server.",
+          "examples": ["prod", "preprod", "dev", "uat"]
+        },
+        "roles": {
+          "type": "array",
+          "description": "List of roles that have access to the server.",
+          "items": {
+            "$ref": "#/$defs/Role"
+          }
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "api"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ApiServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "athena"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/AthenaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "azure"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/AzureServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "bigquery"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/BigQueryServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "clickhouse"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ClickHouseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "databricks"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DatabricksServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "denodo"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DenodoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dremio"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DremioServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "duckdb"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/DuckdbServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "glue"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/GlueServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "cloudsql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/GoogleCloudSqlServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "db2"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/IBMDB2Server"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "hive"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/HiveServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "impala"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ImpalaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "informix"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/InformixServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "zen"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/ZenServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "custom"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/CustomServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "kafka"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/KafkaServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "kinesis"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/KinesisServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "local"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/LocalServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mysql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/MySqlServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oracle"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/OracleServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "postgresql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PostgresServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "postgres"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PostgresServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "presto"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PrestoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "pubsub"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/PubSubServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "redshift"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/RedshiftServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "s3"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/S3Server"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "sftp"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SftpServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "snowflake"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SnowflakeServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "sqlserver"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SqlserverServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "synapse"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/SynapseServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "trino"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/TrinoServer"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "vertica"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/ServerSource/VerticaServer"
+          }
+        }
+      ],
+      "required": ["server", "type"],
+      "unevaluatedProperties": false
+    },
+    "ServerSource": {
+      "ApiServer": {
+        "type": "object",
+        "title": "AthenaServer",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "The url to the API.",
+            "examples": [
+              "https://api.example.com/v1"
+            ]
+          }
+        },
+        "required": [
+          "location"
+        ]
+      },
+      "AthenaServer": {
+        "type": "object",
+        "title": "AthenaServer",
+        "properties": {
+          "stagingDir": {
+            "type": "string",
+            "format": "uri",
+            "description": "Amazon Athena automatically stores query results and metadata information for each query that runs in a query result location that you can specify in Amazon S3.",
+            "examples": [
+              "s3://my_storage_account_name/my_container/path"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "Identify the schema in the data source in which your tables exist."
+          },
+          "catalog": {
+            "type": "string",
+            "description": "Identify the name of the Data Source, also referred to as a Catalog.",
+            "default": "awsdatacatalog"
+          },
+          "regionName": {
+            "type": "string",
+            "description": "The region your AWS account uses.",
+            "examples": ["eu-west-1"]
+          }
+        },
+        "required": [
+          "stagingDir",
+          "schema"
+        ]
+      },
+      "AzureServer": {
+        "type": "object",
+        "title": "AzureServer",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "Fully qualified path to Azure Blob Storage or Azure Data Lake Storage (ADLS), supports globs.",
+            "examples": [
+              "az://my_storage_account_name.blob.core.windows.net/my_container/path/*.parquet",
+              "abfss://my_storage_account_name.dfs.core.windows.net/my_container_name/path/*.parquet"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "examples": [
+              "parquet",
+              "delta",
+              "json",
+              "csv"
+            ],
+            "description": "File format."
+          },
+          "delimiter": {
+            "type": "string",
+            "examples": [
+              "new_line",
+              "array"
+            ],
+            "description": "Only for format = json. How multiple json documents are delimited within one file"
+          }
+        },
+        "required": [
+          "location",
+          "format"
+        ]
+      },
+      "BigQueryServer": {
+        "type": "object",
+        "title": "BigQueryServer",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The GCP project name."
+          },
+          "dataset": {
+            "type": "string",
+            "description": "The GCP dataset name."
+          }
+        },
+        "required": [
+          "project",
+          "dataset"
+        ]
+      },
+      "ClickHouseServer": {
+        "type": "object",
+        "title": "ClickHouseServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the ClickHouse server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the ClickHouse server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "DatabricksServer": {
+        "type": "object",
+        "title": "DatabricksServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The Databricks host",
+            "examples": [
+              "dbc-abcdefgh-1234.cloud.databricks.com"
+            ]
+          },
+          "catalog": {
+            "type": "string",
+            "description": "The name of the Hive or Unity catalog"
+          },
+          "schema": {
+            "type": "string",
+            "description": "The schema name in the catalog"
+          }
+        },
+        "required": [
+          "catalog",
+          "schema"
+        ]
+      },
+      "DenodoServer": {
+        "type": "object",
+        "title": "DenodoServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Denodo server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Denodo server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port"
+        ]
+      },
+      "DremioServer": {
+        "type": "object",
+        "title": "DremioServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Dremio server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Dremio server."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port"
+        ]
+      },
+      "DuckdbServer": {
+        "type": "object",
+        "title": "DuckdbServer",
+        "properties": {
+          "database": {
+            "type": "string",
+            "description": "Path to duckdb database file."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "database"
+        ]
+      },
+      "GlueServer": {
+        "type": "object",
+        "title": "GlueServer",
+        "properties": {
+          "account": {
+            "type": "string",
+            "description": "The AWS Glue account",
+            "examples": [
+              "1234-5678-9012"
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "The AWS Glue database name",
+            "examples": [
+              "my_database"
+            ]
+          },
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "The AWS S3 path. Must be in the form of a URL.",
+            "examples": [
+              "s3://datacontract-example-orders-latest/data/{model}"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the files",
+            "examples": [
+              "parquet",
+              "csv",
+              "json",
+              "delta"
+            ]
+          }
+        },
+        "required": [
+          "account",
+          "database"
+        ]
+      },
+      "GoogleCloudSqlServer": {
+        "type": "object",
+        "title": "GoogleCloudSqlServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Google Cloud Sql server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Google Cloud Sql server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database",
+          "schema"
+        ]
+      },
+      "IBMDB2Server": {
+        "type": "object",
+        "title": "IBMDB2Server",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the IBM DB2 server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the IBM DB2 server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "HiveServer": {
+        "type": "object",
+        "title": "HiveServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Hive server. "
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Hive server. Defaults to 10000."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the Hive database."
+          }
+        },
+        "required": [
+          "host",
+          "database"
+        ]
+      },
+      "ImpalaServer": {
+        "type": "object",
+        "title": "ImpalaServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Impala server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Impala server. Defaults to 21050."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the Impala database."
+          }
+        },
+        "required": [
+          "host",
+          "database"
+        ]
+      },
+      "InformixServer": {
+        "type": "object",
+        "title": "InformixServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Informix server. "
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Informix server. Defaults to 9088."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "database"
+        ]
+      },
+      "ZenServer": {
+        "type": "object",
+        "title": "ZenServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address of the Zen server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "Zen server SQL connections port. Defaults to 1583."
+          },
+          "database": {
+            "type": "string",
+            "description": "Database name to connect to on the Zen server."
+          }
+        },
+        "required": ["host", "database"]
+      },
+      "CustomServer": {
+        "type": "object",
+        "title": "CustomServer",
+        "properties": {
+          "account": {
+            "type": "string",
+            "description": "Account used by the server."
+          },
+          "catalog": {
+            "type": "string",
+            "description": "Name of the catalog."
+          },
+          "database": {
+            "type": "string",
+            "description": "Name of the database."
+          },
+          "dataset": {
+            "type": "string",
+            "description": "Name of the dataset."
+          },
+          "delimiter": {
+            "type": "string",
+            "description": "Delimiter."
+          },
+          "endpointUrl": {
+            "type": "string",
+            "description": "Server endpoint.",
+            "format": "uri"
+          },
+          "format": {
+            "type": "string",
+            "description": "File format."
+          },
+          "host": {
+            "type": "string",
+            "description": "Host name or IP address."
+          },
+          "location": {
+            "type": "string",
+            "description": "A URL to a location.",
+            "format": "uri"
+          },
+          "path": {
+            "type": "string",
+            "description": "Relative or absolute path to the data file(s)."
+          },
+          "port": {
+            "type": "integer",
+            "description": "Port to the server. No default value is assumed for custom servers."
+          },
+          "project": {
+            "type": "string",
+            "description": "Project name."
+          },
+          "region": {
+            "type": "string",
+            "description": "Cloud region."
+          },
+          "regionName": {
+            "type": "string",
+            "description": "Region name."
+          },
+          "schema": {
+            "type": "string",
+            "description": "Name of the schema."
+          },
+          "serviceName": {
+            "type": "string",
+            "description": "Name of the service."
+          },
+          "stagingDir": {
+            "type": "string",
+            "description": "Staging directory."
+          },
+          "warehouse": {
+            "type": "string",
+            "description": "Name of the cluster or warehouse."
+          },
+          "stream": {
+            "type": "string",
+            "description": "Name of the data stream."
+          }
+        }
+      },
+      "KafkaServer": {
+        "type": "object",
+        "title": "KafkaServer",
+        "description": "Kafka Server",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The bootstrap server of the kafka cluster."
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the messages.",
+            "examples": ["json", "avro", "protobuf", "xml"],
+            "default": "json"
+          }
+        },
+        "required": [
+          "host"
+        ]
+      },
+      "KinesisServer": {
+        "type": "object",
+        "title": "KinesisDataStreamsServer",
+        "description": "Kinesis Data Streams Server",
+        "properties": {
+          "region": {
+            "type": "string",
+            "description": "AWS region.",
+            "examples": [
+              "eu-west-1"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the record",
+            "examples": [
+              "json",
+              "avro",
+              "protobuf"
+            ]
+          }
+        }
+      },
+      "LocalServer": {
+        "type": "object",
+        "title": "LocalServer",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The relative or absolute path to the data file(s).",
+            "examples": [
+              "./folder/data.parquet",
+              "./folder/*.parquet"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the file(s)",
+            "examples": [
+              "json",
+              "parquet",
+              "delta",
+              "csv"
+            ]
+          }
+        },
+        "required": [
+          "path",
+          "format"
+        ]
+      },
+      "MySqlServer": {
+        "type": "object",
+        "title": "MySqlServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the MySql server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the MySql server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "OracleServer": {
+        "type": "object",
+        "title": "OracleServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the oracle server",
+            "examples": [
+              "localhost"
+            ]
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the oracle server.",
+            "examples": [
+              1523
+            ]
+          },
+          "serviceName": {
+            "type": "string",
+            "description": "The name of the service.",
+            "examples": [
+              "service"
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "serviceName"
+        ]
+      },
+      "PostgresServer": {
+        "type": "object",
+        "title": "PostgresServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Postgres server"
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Postgres server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema in the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database",
+          "schema"
+        ]
+      },
+      "PrestoServer": {
+        "type": "object",
+        "title": "PrestoServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Presto server",
+            "examples": [
+              "localhost:8080"
+            ]
+          },
+          "catalog": {
+            "type": "string",
+            "description": "The name of the catalog.",
+            "examples": [
+              "postgres"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema.",
+            "examples": [
+              "public"
+            ]
+          }
+        },
+        "required": [
+          "host"
+        ]
+      },
+      "PubSubServer": {
+        "type": "object",
+        "title": "PubSubServer",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The GCP project name."
+          }
+        },
+        "required": [
+          "project"
+        ]
+      },
+      "RedshiftServer": {
+        "type": "object",
+        "title": "RedshiftServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "An optional string describing the server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          },
+          "region": {
+            "type": "string",
+            "description": "AWS region of Redshift server.",
+            "examples": ["us-east-1"]
+          },
+          "account": {
+            "type": "string",
+            "description": "The account used by the server."
+          }
+        },
+        "required": [
+          "database",
+          "schema"
+        ]
+      },
+      "S3Server": {
+        "type": "object",
+        "title": "S3Server",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "description": "S3 URL, starting with `s3://`",
+            "examples": [
+              "s3://datacontract-example-orders-latest/data/{model}/*.json"
+            ]
+          },
+          "endpointUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "The server endpoint for S3-compatible servers.",
+            "examples": ["https://minio.example.com"]
+          },
+          "format": {
+            "type": "string",
+            "examples": [
+              "parquet",
+              "delta",
+              "json",
+              "csv"
+            ],
+            "description": "File format."
+          },
+          "delimiter": {
+            "type": "string",
+            "examples": [
+              "new_line",
+              "array"
+            ],
+            "description": "Only for format = json. How multiple json documents are delimited within one file"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      },
+      "SftpServer": {
+        "type": "object",
+        "title": "SftpServer",
+        "properties": {
+          "location": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^sftp://.*",
+            "description": "SFTP URL, starting with `sftp://`",
+            "examples": [
+              "sftp://123.123.12.123/{model}/*.json"
+            ]
+          },
+          "format": {
+            "type": "string",
+            "examples": [
+              "parquet",
+              "delta",
+              "json",
+              "csv"
+            ],
+            "description": "File format."
+          },
+          "delimiter": {
+            "type": "string",
+            "examples": [
+              "new_line",
+              "array"
+            ],
+            "description": "Only for format = json. How multiple json documents are delimited within one file"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      },
+      "SnowflakeServer": {
+        "type": "object",
+        "title": "SnowflakeServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the Snowflake server"
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the Snowflake server."
+          },
+          "account": {
+            "type": "string",
+            "description": "The Snowflake account used by the server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          },
+          "warehouse": {
+            "type": "string",
+            "description": "The name of the cluster of resources that is a Snowflake virtual warehouse."
+          }
+        },
+        "required": [
+          "account",
+          "database",
+          "schema"
+        ]
+      },
+      "SqlserverServer": {
+        "type": "object",
+        "title": "SqlserverServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host to the database server",
+            "examples": [
+              "localhost"
+            ]
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port to the database server.",
+            "default": 1433,
+            "examples": [
+              1433
+            ]
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database.",
+            "examples": [
+              "database"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema in the database.",
+            "examples": [
+              "dbo"
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "database",
+          "schema"
+        ]
+      },
+      "SynapseServer": {
+        "type": "object",
+        "title": "SynapseServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Synapse server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Synapse server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database"
+        ]
+      },
+      "TrinoServer": {
+        "type": "object",
+        "title": "TrinoServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The Trino host URL.",
+            "examples": [
+              "localhost"
+            ]
+          },
+          "port": {
+            "type": "integer",
+            "description": "The Trino port."
+          },
+          "catalog": {
+            "type": "string",
+            "description": "The name of the catalog.",
+            "examples": [
+              "hive"
+            ]
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema in the database.",
+            "examples": [
+              "my_schema"
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "catalog",
+          "schema"
+        ]
+      },
+      "VerticaServer": {
+        "type": "object",
+        "title": "VerticaServer",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The host of the Vertica server."
+          },
+          "port": {
+            "type": "integer",
+            "description": "The port of the Vertica server."
+          },
+          "database": {
+            "type": "string",
+            "description": "The name of the database."
+          },
+          "schema": {
+            "type": "string",
+            "description": "The name of the schema."
+          }
+        },
+        "required": [
+          "host",
+          "port",
+          "database",
+          "schema"
+        ]
+      }
+    },
+    "SchemaElement": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the element."
+        },
+        "physicalType": {
+          "type": "string",
+          "description": "The physical element data type in the data source.",
+          "examples": ["table", "view", "topic", "file"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the element."
+        },
+        "businessName": {
+          "type": "string",
+          "description": "The business name of the element."
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      }
+    },
+    "SchemaObject": {
+      "type": "object",
+      "properties": {
+        "logicalType": {
+          "type": "string",
+          "description": "The logical element data type.",
+          "enum": ["object", "blob"]
+        },
+        "physicalName": {
+          "type": "string",
+          "description": "Physical name.",
+          "examples": ["table_1_2_0"]
+        },
+        "dataGranularityDescription": {
+          "type": "string",
+          "description": "Granular level of the data in the object.",
+          "examples": ["Aggregation by country"]
+        },
+        "properties": {
+          "type": "array",
+          "description": "A list of properties for the object.",
+          "items": {
+            "$ref": "#/$defs/SchemaProperty"
+          }
+        },
+        "relationships": {
+          "type": "array",
+          "description": "A list of relationships to other properties. Each relationship must have 'from', 'to' and optionally 'type' field.",
+          "items": {
+            "$ref": "#/$defs/RelationshipSchemaLevel"
+          }
+        },
+        "quality": {
+          "$ref": "#/$defs/DataQualityChecks"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/SchemaElement"
+        }
+      ],
+      "required": ["name"],
+      "unevaluatedProperties": false
+    },
+    "SchemaBaseProperty": {
+      "type": "object",
+      "properties": {
+        "primaryKey": {
+          "type": "boolean",
+          "description": "Boolean value specifying whether the element is primary or not. Default is false."
+        },
+        "primaryKeyPosition": {
+          "type": "integer",
+          "default": -1,
+          "description": "If element is a primary key, the position of the primary key element. Starts from 1. Example of `account_id, name` being primary key columns, `account_id` has primaryKeyPosition 1 and `name` primaryKeyPosition 2. Default to -1."
+        },
+        "logicalType": {
+          "type": "string",
+          "description": "The logical element data type.",
+          "enum": ["string", "date", "timestamp", "time", "number", "integer", "object", "array", "boolean"]
+        },
+        "logicalTypeOptions": {
+          "type": "object",
+          "description": "Additional optional metadata to describe the logical type."
+        },
+        "physicalType": {
+          "type": "string",
+          "description": "The physical element data type in the data source. For example, VARCHAR(2), DOUBLE, INT."
+        },
+        "physicalName": {
+          "type": "string",
+          "description": "Physical name.",
+          "examples": ["col_str_a"]
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates if the element may contain Null values; possible values are true and false. Default is false."
+        },
+        "unique": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates if the element contains unique values; possible values are true and false. Default is false."
+        },
+        "partitioned": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates if the element is partitioned; possible values are true and false."
+        },
+        "partitionKeyPosition": {
+          "type": "integer",
+          "default": -1,
+          "description": "If element is used for partitioning, the position of the partition element. Starts from 1. Example of `country, year` being partition columns, `country` has partitionKeyPosition 1 and `year` partitionKeyPosition 2. Default to -1."
+        },
+        "classification": {
+          "type": "string",
+          "description": "Can be anything, like confidential, restricted, and public to more advanced categorization. Some companies like PayPal, use data classification indicating the class of data in the element; expected values are 1, 2, 3, 4, or 5.",
+          "examples": ["confidential", "restricted", "public"]
+        },
+        "encryptedName": {
+          "type": "string",
+          "description": "The element name within the dataset that contains the encrypted element value. For example, unencrypted element `email_address` might have an encryptedName of `email_address_encrypt`."
+        },
+        "transformSourceObjects": {
+          "type": "array",
+          "description": "List of objects in the data source used in the transformation.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transformLogic": {
+          "type": "string",
+          "description": "Logic used in the element transformation."
+        },
+        "transformDescription": {
+          "type": "string",
+          "description": "Describes the transform logic in very simple terms."
+        },
+        "examples": {
+          "type": "array",
+          "description": "List of sample element values.",
+          "items": {
+            "$ref": "#/$defs/AnyType"
+          }
+        },
+        "criticalDataElement": {
+          "type": "boolean",
+          "default": false,
+          "description": "True or false indicator; If element is considered a critical data element (CDE) then true else false."
+        },
+        "relationships": {
+          "type": "array",
+          "description": "A list of relationships to other properties. When defined at property level, the 'from' field is implicit and should not be specified.",
+          "items": {
+            "$ref": "#/$defs/RelationshipPropertyLevel"
+          }
+        },
+        "quality": {
+          "$ref": "#/$defs/DataQualityChecks"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/SchemaElement"
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "string"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum length of the string."
+                  },
+                  "maxLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum length of the string."
+                  },
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regular expression pattern to define valid value. Follows regular expression syntax from ECMA-262 (https://262.ecma-international.org/5.1/#sec-15.10.1)."
+                  },
+                  "format": {
+                    "type": "string",
+                    "examples": ["password", "byte", "binary", "email", "uuid", "uri", "hostname", "ipv4", "ipv6"],
+                    "description": "Provides extra context about what format the string follows."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "date"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "format": {
+                    "type": "string",
+                    "examples": ["yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss", "HH:mm:ss"],
+                    "description": "Format of the date. Follows the format as prescribed by [JDK DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, format 'yyyy-MM-dd'."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "string",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "maximum": {
+                    "type": "string",
+                    "description": "All date values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "string",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "minimum": {
+                    "type": "string",
+                    "description": "All date values are greater than or equal to this value (values >= minimum)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "timestamp"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "time"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "format": {
+                    "type": "string",
+                    "examples": ["yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss", "HH:mm:ss"],
+                    "description": "Format of the date. Follows the format as prescribed by [JDK DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html). For example, format 'yyyy-MM-dd'."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "string",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "maximum": {
+                    "type": "string",
+                    "description": "All date values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "string",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "minimum": {
+                    "type": "string",
+                    "description": "All date values are greater than or equal to this value (values >= minimum)."
+                  },
+                  "timezone": {
+                    "type": "boolean",
+                    "description": "Whether the timestamp defines the timezone or not. If true, timezone information is included in the timestamp."
+                  },
+                  "defaultTimezone": {
+                    "type": "string",
+                    "description": "The default timezone of the timestamp. If timezone is not defined, the default timezone UTC is used.",
+                    "default": "Etc/UTC"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "integer"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "description": "Values must be multiples of this number. For example, multiple of 5 has valid values 0, 5, 10, -5."
+                  },
+                  "maximum": {
+                    "type": "number",
+                    "description": "All values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "number",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "minimum": {
+                    "type": "number",
+                    "description": "All values are greater than or equal to this value (values >= minimum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "number",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "format": {
+                    "type": "string",
+                    "default": "i32",
+                    "description": "Format of the value in terms of how many bits of space it can use and whether it is signed or unsigned (follows the Rust integer types).",
+                    "enum": ["i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "logicalType": {
+                    "const": "number"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "multipleOf": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "description": "Values must be multiples of this number. For example, multiple of 5 has valid values 0, 5, 10, -5."
+                  },
+                  "maximum": {
+                    "type": "number",
+                    "description": "All values are less than or equal to this value (values <= maximum)."
+                  },
+                  "exclusiveMaximum": {
+                    "type": "number",
+                    "description": "All values must be strictly less than this value (values < exclusiveMaximum)."
+                  },
+                  "minimum": {
+                    "type": "number",
+                    "description": "All values are greater than or equal to this value (values >= minimum)."
+                  },
+                  "exclusiveMinimum": {
+                    "type": "number",
+                    "description": "All values must be strictly greater than this value (values > exclusiveMinimum)."
+                  },
+                  "format": {
+                    "type": "string",
+                    "default": "i32",
+                    "description": "Format of the value in terms of how many bits of space it can use (follows the Rust float types).",
+                    "enum": ["f32", "f64"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "object"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum number of properties."
+                  },
+                  "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Minimum number of properties."
+                  },
+                  "required": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "description": "Property names that are required to exist in the object."
+                  }
+                }
+              },
+              "properties": {
+                "type": "array",
+                "description": "A list of properties for the object.",
+                "items": {
+                  "$ref": "#/$defs/SchemaProperty"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "logicalType": {
+                "const": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "logicalTypeOptions": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "maxItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum number of items."
+                  },
+                  "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Minimum number of items"
+                  },
+                  "uniqueItems": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If set to true, all items in the array are unique."
+                  }
+                }
+              },
+              "items": {
+                "$ref": "#/$defs/SchemaItemProperty",
+                "description": "List of items in an array (only applicable when `logicalType: array`)."
+              }
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "SchemaProperty": {
+      "type": "object",
+      "$ref": "#/$defs/SchemaBaseProperty",
+      "required": ["name"],
+      "unevaluatedProperties": false
+    },
+    "SchemaItemProperty": {
+      "type": "object",
+      "$ref": "#/$defs/SchemaBaseProperty",
+      "properties": {
+        "properties": {
+          "type": "array",
+          "description": "A list of properties for the object.",
+          "items": {
+            "$ref": "#/$defs/SchemaProperty"
+          }
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "Tags": {
+      "type": "array",
+      "description": "A list of tags that may be assigned to the elements (object or property); the tags keyword may appear at any level. Tags may be used to better categorize an element. For example, `finance`, `sensitive`, `employee_record`.",
+      "examples": ["finance", "sensitive", "employee_record"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "DataQuality": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        },
+        "businessImpact": {
+          "type": "string",
+          "description": "Consequences of the rule failure.",
+          "examples": ["operational", "regulatory"]
+        },
+        "customProperties": {
+          "type": "array",
+          "description": "Additional properties required for rule execution.",
+          "items": {
+            "$ref": "#/$defs/CustomProperty"
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Describe the quality check to be completed."
+        },
+        "dimension": {
+          "type": "string",
+          "description": "The key performance indicator (KPI) or dimension for data quality.",
+          "enum": ["accuracy", "completeness", "conformity", "consistency", "coverage", "timeliness", "uniqueness"]
+        },
+        "method": {
+          "type": "string",
+          "examples": ["reconciliation"]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the data quality check."
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Rule execution schedule details.",
+          "examples": ["0 20 * * *"]
+        },
+        "scheduler": {
+          "type": "string",
+          "description": "The name or type of scheduler used to start the data quality check.",
+          "examples": ["cron"]
+        },
+        "severity": {
+          "type": "string",
+          "description": "The severance of the quality rule.",
+          "examples": ["info", "warning", "error"]
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of quality check. 'text' is human-readable text that describes the quality of the data. 'library' is a set of maintained predefined quality attributes such as row count or unique. 'sql' is an individual SQL query that returns a value that can be compared. 'custom' is quality attributes that are vendor-specific, such as Soda or Great Expectations.",
+          "enum": ["text", "library", "sql", "custom"],
+          "default": "library"
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit the rule is using, popular values are `rows` or `percent`, but any value is allowed.",
+          "examples": ["rows", "percent"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "library"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "properties": {
+                  "metric": {
+                    "type": "string"
+                  }
+                },
+                "required": ["metric"]
+              }
+            ]
+          },
+          "then": {
+            "$ref": "#/$defs/DataQualityLibrary"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "sql"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/DataQualitySql"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "custom"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "$ref": "#/$defs/DataQualityCustom"
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "DataQualityChecks": {
+      "type": "array",
+      "description": "Data quality rules with all the relevant information for rule setup and execution.",
+      "items": {
+        "$ref": "#/$defs/DataQuality"
+      }
+    },
+    "DataQualityOperators": {
+      "type": "object",
+      "description": "Common comparison operators for data quality checks.",
+      "oneOf": [
+        {
+          "properties": {
+            "mustBe": {
+              "description": "Must be equal to the value to be valid. When using numbers, it is equivalent to '='."
+            }
+          },
+          "required": ["mustBe"]
+        },
+        {
+          "properties": {
+            "mustNotBe": {
+              "description": "Must not be equal to the value to be valid. When using numbers, it is equivalent to '!='."
+            }
+          },
+          "required": ["mustNotBe"]
+        },
+        {
+          "properties": {
+            "mustBeGreaterThan": {
+              "type": "number",
+              "description": "Must be greater than the value to be valid. It is equivalent to '>'."
+            }
+          },
+          "required": ["mustBeGreaterThan"]
+        },
+        {
+          "properties": {
+            "mustBeGreaterOrEqualTo": {
+              "type": "number",
+              "description": "Must be greater than or equal to the value to be valid. It is equivalent to '>='."
+            }
+          },
+          "required": ["mustBeGreaterOrEqualTo"]
+        },
+        {
+          "properties": {
+            "mustBeLessThan": {
+              "type": "number",
+              "description": "Must be less than the value to be valid. It is equivalent to '<'."
+            }
+          },
+          "required": ["mustBeLessThan"]
+        },
+        {
+          "properties": {
+            "mustBeLessOrEqualTo": {
+              "type": "number",
+              "description": "Must be less than or equal to the value to be valid. It is equivalent to '<='."
+            }
+          },
+          "required": ["mustBeLessOrEqualTo"]
+        },
+        {
+          "properties": {
+            "mustBeBetween": {
+              "type": "array",
+              "description": "Must be between the two numbers to be valid. Smallest number first in the array.",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "required": ["mustBeBetween"]
+        },
+        {
+          "properties": {
+            "mustNotBeBetween": {
+              "type": "array",
+              "description": "Must not be between the two numbers to be valid. Smallest number first in the array.",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "required": ["mustNotBeBetween"]
+        }
+      ]
+    },
+    "DataQualityLibrary": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/DataQualityOperators"
+        }
+      ],
+      "properties": {
+        "metric": {
+          "type": "string",
+          "description": "Define a data quality check based on the predefined metrics as per ODCS.",
+          "enum": ["nullValues", "missingValues", "invalidValues", "duplicateValues", "rowCount"]
+        },
+        "rule": {
+          "type": "string",
+          "deprecated": true,
+          "description": "Use metric instead"
+        },
+        "arguments": {
+          "type": "object",
+          "description": "Additional arguments for the metric, if needed."
+        }
+      },
+      "required": ["metric"]
+    },
+    "DataQualitySql": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/DataQualityOperators"
+        }
+      ],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Query string that adheres to the dialect of the provided server.",
+          "examples": ["SELECT COUNT(*) FROM ${table} WHERE ${column} IS NOT NULL"]
+        }
+      },
+      "required": ["query"]
+    },
+    "DataQualityCustom": {
+      "type": "object",
+      "properties": {
+        "engine": {
+          "type": "string",
+          "description": "Name of the engine which executes the data quality checks.",
+          "examples": ["soda", "great-expectations", "monte-carlo", "dbt"]
+        },
+        "implementation": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "required": ["engine", "implementation"]
+    },
+    "AuthoritativeDefinitions": {
+      "type": "array",
+      "description": "List of links to sources that provide more details on the dataset; examples would be a link to an external definition, a training video, a git repo, data catalog, or another tool. Authoritative definitions follow the same structure in the standard.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/$defs/StableId"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL to the authority."
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of definition for authority: v2.3 adds standard values: `businessDefinition`, `transformationImplementation`, `videoTutorial`, `tutorial`, and `implementation`.",
+            "examples": ["businessDefinition", "transformationImplementation", "videoTutorial", "tutorial", "implementation"]
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the authoritative definition for humans."
+          }
+        },
+        "required": ["url", "type"],
+        "additionalProperties": false
+      }
+    },
+    "Support": {
+      "type": "array",
+      "description": "Top level for support channels.",
+      "items": {
+        "$ref": "#/$defs/SupportItem"
+      }
+    },
+    "SupportItem": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "channel": {
+          "type": "string",
+          "description": "Channel name or identifier."
+        },
+        "url": {
+          "type": "string",
+          "description": "Access URL using normal [URL scheme](https://en.wikipedia.org/wiki/URL#Syntax) (https, mailto, etc.)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the channel, free text."
+        },
+        "tool": {
+          "type": "string",
+          "description": "Name of the tool, value can be `email`, `slack`, `teams`, `discord`, `ticket`, `googlechat`, or `other`.",
+          "examples": ["email", "slack", "teams", "discord", "ticket", "googlechat", "other"]
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope can be: `interactive`, `announcements`, `issues`, `notifications`.",
+          "examples": ["interactive", "announcements", "issues", "notifications"]
+        },
+        "invitationUrl": {
+          "type": "string",
+          "description": "Some tools uses invitation URL for requesting or subscribing. Follows the [URL scheme](https://en.wikipedia.org/wiki/URL#Syntax)."
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      },
+      "required": ["channel"],
+      "additionalProperties": false
+    },
+    "Pricing": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "priceAmount": {
+          "type": "number",
+          "description": "Subscription price per unit of measure in `priceUnit`."
+        },
+        "priceCurrency": {
+          "type": "string",
+          "description": "Currency of the subscription price in `price.priceAmount`."
+        },
+        "priceUnit": {
+          "type": "string",
+          "description": "The unit of measure for calculating cost. Examples megabyte, gigabyte."
+        }
+      },
+      "additionalProperties": false
+    },
+    "TeamMember": {
+      "type": "object",
+      "description": "Team member information.",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "username": {
+          "type": "string",
+          "description": "The user's username or email."
+        },
+        "name": {
+          "type": "string",
+          "description": "The user's name."
+        },
+        "description": {
+          "type": "string",
+          "description": "The user's description."
+        },
+        "role": {
+          "type": "string",
+          "description": "The user's job role; Examples might be owner, data steward. There is no limit on the role."
+        },
+        "dateIn": {
+          "type": "string",
+          "format": "date",
+          "description": "The date when the user joined the team."
+        },
+        "dateOut": {
+          "type": "string",
+          "format": "date",
+          "description": "The date when the user ceased to be part of the team."
+        },
+        "replacedByUsername": {
+          "type": "string",
+          "description": "The username of the user who replaced the previous user."
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "customProperties": {
+          "type": "array",
+          "description": "Custom properties block.",
+          "items": {
+            "$ref": "#/$defs/CustomProperty"
+          }
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        }
+      },
+      "required": ["username"]
+    },
+    "Team": {
+      "type": "object",
+      "description": "Team information.",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "name": {
+          "type": "string",
+          "description": "Team name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Team description."
+        },
+        "members": {
+          "type": "array",
+          "description": "List of members.",
+          "items": {
+            "$ref": "#/$defs/TeamMember"
+          }
+        },
+        "tags": {
+          "$ref": "#/$defs/Tags"
+        },
+        "customProperties": {
+          "type": "array",
+          "description": "Custom properties block.",
+          "items": {
+            "$ref": "#/$defs/CustomProperty"
+          }
+        },
+        "authoritativeDefinitions": {
+          "$ref": "#/$defs/AuthoritativeDefinitions"
+        }
+      }
+    },
+    "Role": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "role": {
+          "type": "string",
+          "description": "Name of the IAM role that provides access to the dataset."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the IAM role and its permissions."
+        },
+        "access": {
+          "type": "string",
+          "description": "The type of access provided by the IAM role."
+        },
+        "firstLevelApprovers": {
+          "type": "string",
+          "description": "The name(s) of the first-level approver(s) of the role."
+        },
+        "secondLevelApprovers": {
+          "type": "string",
+          "description": "The name(s) of the second-level approver(s) of the role."
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      },
+      "required": ["role"],
+      "additionalProperties": false
+    },
+    "ServiceLevelAgreementProperty": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "property": {
+          "type": "string",
+          "description": "Specific property in SLA, check the periodic table. May requires units (more details to come)."
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Agreement value. The label will change based on the property itself."
+        },
+        "valueExt": {
+          "$ref": "#/$defs/AnyNonCollectionType",
+          "description": "Extended agreement value. The label will change based on the property itself."
+        },
+        "unit": {
+          "type": "string",
+          "description": "**d**, day, days for days; **y**, yr, years for years, etc. Units use the ISO standard."
+        },
+        "element": {
+          "type": "string",
+          "description": "Element(s) to check on. Multiple elements should be extremely rare and, if so, separated by commas."
+        },
+        "driver": {
+          "type": "string",
+          "description": "Describes the importance of the SLA from the list of: `regulatory`, `analytics`, or `operational`.",
+          "examples": ["regulatory", "analytics", "operational"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the SLA for humans.",
+          "examples": ["99.9% of the time, data is available by 6 AM UTC"]
+        },
+        "scheduler": {
+          "type": "string",
+          "description": "Name of the scheduler, can be cron or any tool your organization support.",
+          "examples": ["cron"]
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Configuration information for the scheduling tool, for cron a possible value is 0 20 * * *.",
+          "examples": ["0 20 * * *"]
+        }
+      },
+      "required": ["property", "value"],
+      "additionalProperties": false
+    },
+    "CustomProperties": {
+      "type": "array",
+      "description": "A list of key/value pairs for custom properties.",
+      "items": {
+        "$ref": "#/$defs/CustomProperty"
+      }
+    },
+    "CustomProperty": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/StableId"
+        },
+        "property": {
+          "type": "string",
+          "description": "The name of the key. Names should be in camel case–the same as if they were permanent properties in the contract."
+        },
+        "value": {
+          "$ref": "#/$defs/AnyType",
+          "description": "The value of the key."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the custom property."
+        }
+      },
+      "required": ["property", "value"],
+      "additionalProperties": false
+    },
+    "AnyType": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "AnyNonCollectionType": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "RelationshipBase": {
+      "type": "object",
+      "description": "Base definition for relationships between properties, typically for foreign key constraints.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of relationship. Defaults to 'foreignKey'.",
+          "default": "foreignKey",
+          "enum": ["foreignKey"]
+        },
+        "from": {
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ShorthandReference"
+                },
+                {
+                  "$ref": "#/$defs/FullyQualifiedReference"
+                }
+              ],
+              "description": "Source property reference using fully qualified or shorthand notation."
+            },
+            {
+              "type": "array",
+              "description": "Array of source properties for composite keys.",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ShorthandReference"
+                  },
+                  {
+                    "$ref": "#/$defs/FullyQualifiedReference"
+                  }
+                ]
+              },
+              "minItems": 1
+            }
+          ],
+          "description": "Source property or properties."
+        },
+        "to": {
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ShorthandReference"
+                },
+                {
+                  "$ref": "#/$defs/FullyQualifiedReference"
+                }
+              ],
+              "description": "Target property reference using fully qualified or shorthand notation."
+            },
+            {
+              "type": "array",
+              "description": "Array of target properties for composite keys.",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/ShorthandReference"
+                  },
+                  {
+                    "$ref": "#/$defs/FullyQualifiedReference"
+                  }
+                ]
+              },
+              "minItems": 1
+            }
+          ],
+          "description": "Target property or properties to reference."
+        },
+        "customProperties": {
+          "$ref": "#/$defs/CustomProperties"
+        }
+      }
+    },
+    "RelationshipSchemaLevel": {
+      "type": "object",
+      "description": "Relationship definition at schema level, requiring both 'from' and 'to' fields with matching types.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/RelationshipBase"
+        },
+        {
+          "required": ["from", "to"]
+        },
+        {
+          "oneOf": [
+            {
+              "description": "Single-column relationship - both fields must be strings",
+              "properties": {
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "description": "Composite key relationship - both fields must be arrays with matching lengths",
+              "properties": {
+                "from": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                },
+                "to": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "RelationshipPropertyLevel": {
+      "type": "object",
+      "description": "Relationship definition at property level, where 'from' is implicitly the current property.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/RelationshipBase"
+        },
+        {
+          "type": "object",
+          "required": ["to"]
+        },
+        {
+          "not": {
+            "required": ["from"]
+          },
+          "description": "The 'from' field must not be specified at property level as it is implicitly derived from the property context"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Relationship": {
+      "description": "Compatibility wrapper for relationship definitions.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/RelationshipSchemaLevel"
+        },
+        {
+          "$ref": "#/$defs/RelationshipPropertyLevel"
+        }
+      ]
+    }
+  }
+}

--- a/odcsemit/emit.go
+++ b/odcsemit/emit.go
@@ -27,7 +27,17 @@ func FromSourceContract(sc csvcontract.SourceContract) odcs.Contract {
 	for _, f := range sc.Fields {
 		props = append(props, propertyFromProfileType(f.Name, string(f.DataType)))
 	}
-	return singleObjectContract(sc.SourcePath, sc.SourcePath, props)
+	// Carry the CSV parse facts the fingerprint treats as identity-bearing
+	// (format, delimiter, encoding, header presence). The ODCS column model
+	// has no home for these, so they ride in the schema object's custom
+	// properties; the fingerprint reads them back to stay byte-identical.
+	custom := []odcs.CustomProperty{
+		{Property: odcs.CustomKeySourceFormat, Value: "csv"},
+		{Property: odcs.CustomKeyDelimiter, Value: sc.Delimiter},
+		{Property: odcs.CustomKeyEncoding, Value: sc.Encoding},
+		{Property: odcs.CustomKeyHasHeader, Value: sc.HasHeader},
+	}
+	return singleObjectContract(sc.SourcePath, sc.SourcePath, props, custom)
 }
 
 // FromJSONContract renders a JSON or NDJSON analysis as a single-object
@@ -39,7 +49,15 @@ func FromJSONContract(sc jsoncontract.SourceContract) odcs.Contract {
 	for _, f := range sc.Fields {
 		props = append(props, propertyFromJSONType(f.Name, string(f.DataType)))
 	}
-	return singleObjectContract(sc.SourcePath, sc.SourcePath, props)
+	// JSON and NDJSON parse differently, so the source format is identity-
+	// bearing; encoding is the only parse fact the JSON fingerprint carries
+	// (no delimiter, no header). The format token is echoed verbatim so an
+	// unrecognised value reaches the fingerprint, which fails closed on it.
+	custom := []odcs.CustomProperty{
+		{Property: odcs.CustomKeySourceFormat, Value: sc.SourceFormat},
+		{Property: odcs.CustomKeyEncoding, Value: sc.Encoding},
+	}
+	return singleObjectContract(sc.SourcePath, sc.SourcePath, props, custom)
 }
 
 // FromDataContract renders a multi-schema native contract (an Excel
@@ -50,6 +68,14 @@ func FromJSONContract(sc jsoncontract.SourceContract) odcs.Contract {
 // is left nullable (required unset), one it never saw a null in is marked
 // required.
 func FromDataContract(dc contract.DataContract) odcs.Contract {
+	// The native fingerprint reads the source-format kind from contract
+	// metadata (xlsx -> the Excel format, openapi -> the API format) and
+	// stamps it on every unit. Echo whatever the metadata implies onto each
+	// schema object so the fingerprint recovers the same format token; an
+	// absent or unrecognised marker rides through as an empty token, which
+	// the fingerprint then rejects, matching the native path's refusal to
+	// guess a format.
+	format := dataContractFormat(dc)
 	objects := make([]odcs.SchemaObject, 0, len(dc.Schemas))
 	for _, schema := range dc.Schemas {
 		props := make([]odcs.Property, 0, len(schema.Fields))
@@ -65,7 +91,10 @@ func FromDataContract(dc contract.DataContract) odcs.Contract {
 			Name:         schema.Name,
 			PhysicalName: schema.Name,
 			PhysicalType: "table",
-			Properties:   props,
+			CustomProperties: []odcs.CustomProperty{
+				{Property: odcs.CustomKeySourceFormat, Value: format},
+			},
+			Properties: props,
 		})
 	}
 	return odcs.Contract{
@@ -76,19 +105,36 @@ func FromDataContract(dc contract.DataContract) odcs.Contract {
 	}
 }
 
+// dataContractFormat maps the native contract's metadata markers to the
+// fingerprint source-format token. It mirrors the fingerprint's own
+// dataContractFormat: xlsx metadata is the Excel format, an openapi source
+// is the API format. Anything else yields an empty token, deferring the
+// refusal to the fingerprint so the emitter never invents a format.
+func dataContractFormat(dc contract.DataContract) string {
+	if sf, ok := dc.Metadata["source_format"].(string); ok && sf == "xlsx" {
+		return "xlsx"
+	}
+	if src, ok := dc.Metadata["source"].(string); ok && src == "openapi" {
+		return "api"
+	}
+	return ""
+}
+
 // singleObjectContract wraps one schema object's worth of properties into a
 // contract, the shape the single-table file analysers (CSV, JSON) produce.
-func singleObjectContract(id, name string, props []odcs.Property) odcs.Contract {
+// custom carries the schema object's source-parse facts.
+func singleObjectContract(id, name string, props []odcs.Property, custom []odcs.CustomProperty) odcs.Contract {
 	return odcs.Contract{
 		APIVersion: odcs.APIVersion,
 		Kind:       odcs.KindDataContract,
 		ID:         id,
 		Schema: []odcs.SchemaObject{
 			{
-				Name:         name,
-				PhysicalName: name,
-				PhysicalType: "file",
-				Properties:   props,
+				Name:             name,
+				PhysicalName:     name,
+				PhysicalType:     "file",
+				CustomProperties: custom,
+				Properties:       props,
 			},
 		},
 	}

--- a/odcsemit/emit.go
+++ b/odcsemit/emit.go
@@ -101,6 +101,7 @@ func FromDataContract(dc contract.DataContract) odcs.Contract {
 		APIVersion: odcs.APIVersion,
 		Kind:       odcs.KindDataContract,
 		ID:         dc.ID,
+		Status:     odcs.StatusActive,
 		Schema:     objects,
 	}
 }
@@ -128,6 +129,7 @@ func singleObjectContract(id, name string, props []odcs.Property, custom []odcs.
 		APIVersion: odcs.APIVersion,
 		Kind:       odcs.KindDataContract,
 		ID:         id,
+		Status:     odcs.StatusActive,
 		Schema: []odcs.SchemaObject{
 			{
 				Name:             name,

--- a/odcsemit/emit.go
+++ b/odcsemit/emit.go
@@ -1,0 +1,95 @@
+// Package odcsemit renders dcg's native analyser results into ODCS
+// contracts. It is the one-way bridge from the analyser vocabulary
+// (csvcontract / jsoncontract / contract) into the odcs model: one entry
+// point per source shape, each producing an odcs.Contract.
+//
+// The emitter owns the type encoding (spec section 4.1) and the enum
+// quality-rule encoding (spec section 4.2). It deliberately carries the
+// original native type token in physicalType so the fingerprint can derive
+// the same canonical type from the ODCS document that it derives from the
+// native contract, which is what makes the DG-3 byte-identity proof
+// possible. Profiles and statistics are not pushed into ODCS; they stay a
+// dcg-native artefact (spec section 4.3).
+package odcsemit
+
+import (
+	"github.com/JacobJNilsson/data-contract-generator/contract"
+	"github.com/JacobJNilsson/data-contract-generator/csvcontract"
+	"github.com/JacobJNilsson/data-contract-generator/jsoncontract"
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+)
+
+// FromSourceContract renders a CSV analysis as a single-object ODCS
+// contract. The schema object is named for the source path; each field
+// becomes a property typed per encodeProfileType.
+func FromSourceContract(sc csvcontract.SourceContract) odcs.Contract {
+	props := make([]odcs.Property, 0, len(sc.Fields))
+	for _, f := range sc.Fields {
+		props = append(props, propertyFromProfileType(f.Name, string(f.DataType)))
+	}
+	return singleObjectContract(sc.SourcePath, sc.SourcePath, props)
+}
+
+// FromJSONContract renders a JSON or NDJSON analysis as a single-object
+// ODCS contract. JSON exposes object and array fields the CSV path never
+// produces, so its property encoding is the superset handled by
+// propertyFromJSONType.
+func FromJSONContract(sc jsoncontract.SourceContract) odcs.Contract {
+	props := make([]odcs.Property, 0, len(sc.Fields))
+	for _, f := range sc.Fields {
+		props = append(props, propertyFromJSONType(f.Name, string(f.DataType)))
+	}
+	return singleObjectContract(sc.SourcePath, sc.SourcePath, props)
+}
+
+// FromDataContract renders a multi-schema native contract (an Excel
+// workbook is one schema per sheet) as an ODCS contract with one schema
+// object per schema. Each field's DataType is a profile-vocabulary token,
+// so it shares propertyFromProfileType with the CSV path. Nullability is
+// carried as ODCS required (NOT NULL): a field the analyser saw nulls in
+// is left nullable (required unset), one it never saw a null in is marked
+// required.
+func FromDataContract(dc contract.DataContract) odcs.Contract {
+	objects := make([]odcs.SchemaObject, 0, len(dc.Schemas))
+	for _, schema := range dc.Schemas {
+		props := make([]odcs.Property, 0, len(schema.Fields))
+		for _, f := range schema.Fields {
+			p := propertyFromProfileType(f.Name, f.DataType)
+			if !f.Nullable {
+				req := true
+				p.Required = &req
+			}
+			props = append(props, p)
+		}
+		objects = append(objects, odcs.SchemaObject{
+			Name:         schema.Name,
+			PhysicalName: schema.Name,
+			PhysicalType: "table",
+			Properties:   props,
+		})
+	}
+	return odcs.Contract{
+		APIVersion: odcs.APIVersion,
+		Kind:       odcs.KindDataContract,
+		ID:         dc.ID,
+		Schema:     objects,
+	}
+}
+
+// singleObjectContract wraps one schema object's worth of properties into a
+// contract, the shape the single-table file analysers (CSV, JSON) produce.
+func singleObjectContract(id, name string, props []odcs.Property) odcs.Contract {
+	return odcs.Contract{
+		APIVersion: odcs.APIVersion,
+		Kind:       odcs.KindDataContract,
+		ID:         id,
+		Schema: []odcs.SchemaObject{
+			{
+				Name:         name,
+				PhysicalName: name,
+				PhysicalType: "file",
+				Properties:   props,
+			},
+		},
+	}
+}

--- a/odcsemit/emit_test.go
+++ b/odcsemit/emit_test.go
@@ -267,3 +267,81 @@ func TestReadEnumLabelsNonEnum(t *testing.T) {
 		t.Error("non-string label should fail closed")
 	}
 }
+
+func customVal(props []odcs.CustomProperty, key string) (any, bool) {
+	for _, p := range props {
+		if p.Property == key {
+			return p.Value, true
+		}
+	}
+	return nil, false
+}
+
+func TestFromSourceContractCarriesParseFacts(t *testing.T) {
+	sc := csvcontract.SourceContract{
+		SourcePath: "x.csv",
+		Delimiter:  ";",
+		Encoding:   "UTF-8",
+		HasHeader:  true,
+		Fields:     []csvcontract.Field{{Name: "a", DataType: profile.TypeText}},
+	}
+	cp := FromSourceContract(sc).Schema[0].CustomProperties
+	if v, _ := customVal(cp, odcs.CustomKeySourceFormat); v != "csv" {
+		t.Errorf("source format = %v, want csv", v)
+	}
+	if v, _ := customVal(cp, odcs.CustomKeyDelimiter); v != ";" {
+		t.Errorf("delimiter = %v, want ;", v)
+	}
+	if v, _ := customVal(cp, odcs.CustomKeyEncoding); v != "UTF-8" {
+		t.Errorf("encoding = %v", v)
+	}
+	if v, _ := customVal(cp, odcs.CustomKeyHasHeader); v != true {
+		t.Errorf("hasHeader = %v, want true", v)
+	}
+}
+
+func TestFromJSONContractCarriesParseFacts(t *testing.T) {
+	for _, format := range []string{"json", "ndjson"} {
+		sc := jsoncontract.SourceContract{
+			SourcePath:   "x",
+			SourceFormat: format,
+			Encoding:     "UTF-8",
+			Fields:       []jsoncontract.Field{{Name: "a", DataType: jsoncontract.TypeText}},
+		}
+		cp := FromJSONContract(sc).Schema[0].CustomProperties
+		if v, _ := customVal(cp, odcs.CustomKeySourceFormat); v != format {
+			t.Errorf("source format = %v, want %v", v, format)
+		}
+		if _, ok := customVal(cp, odcs.CustomKeyDelimiter); ok {
+			t.Errorf("%s should carry no delimiter", format)
+		}
+	}
+}
+
+func TestFromDataContractFormatMarkers(t *testing.T) {
+	cases := []struct {
+		name     string
+		metadata map[string]any
+		want     string
+	}{
+		{"xlsx", map[string]any{"source_format": "xlsx"}, "xlsx"},
+		{"openapi", map[string]any{"source": "openapi"}, "api"},
+		{"none", nil, ""},
+		{"unknown", map[string]any{"source_format": "weird"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dc := contract.DataContract{
+				ID:       "d",
+				Metadata: c.metadata,
+				Schemas: []contract.SchemaContract{
+					{Name: "S", Fields: []contract.FieldDefinition{{Name: "a", DataType: "text"}}},
+				},
+			}
+			cp := FromDataContract(dc).Schema[0].CustomProperties
+			if v, _ := customVal(cp, odcs.CustomKeySourceFormat); v != c.want {
+				t.Errorf("format = %v, want %v", v, c.want)
+			}
+		})
+	}
+}

--- a/odcsemit/emit_test.go
+++ b/odcsemit/emit_test.go
@@ -1,0 +1,269 @@
+package odcsemit
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/contract"
+	"github.com/JacobJNilsson/data-contract-generator/csvcontract"
+	"github.com/JacobJNilsson/data-contract-generator/jsoncontract"
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/profile"
+)
+
+func TestFromSourceContractTypeEncoding(t *testing.T) {
+	sc := csvcontract.SourceContract{
+		SourcePath: "orders.csv",
+		Fields: []csvcontract.Field{
+			{Name: "name", DataType: profile.TypeText},
+			{Name: "qty", DataType: profile.TypeNumeric},
+			{Name: "day", DataType: profile.TypeDate},
+			{Name: "seen", DataType: profile.TypeTimestamp},
+			{Name: "ok", DataType: profile.TypeBoolean},
+			{Name: "blank", DataType: profile.TypeEmpty},
+		},
+	}
+	c := FromSourceContract(sc)
+
+	if c.APIVersion != odcs.APIVersion || c.Kind != odcs.KindDataContract {
+		t.Fatalf("contract envelope = %q/%q", c.APIVersion, c.Kind)
+	}
+	if c.ID != "orders.csv" {
+		t.Errorf("id = %q, want orders.csv", c.ID)
+	}
+	if len(c.Schema) != 1 {
+		t.Fatalf("expected one schema object, got %d", len(c.Schema))
+	}
+	obj := c.Schema[0]
+	if obj.Name != "orders.csv" || obj.PhysicalName != "orders.csv" || obj.PhysicalType != "file" {
+		t.Errorf("schema object = %+v", obj)
+	}
+
+	type want struct {
+		logical  odcs.LogicalType
+		physical string
+		format   string
+	}
+	wants := []want{
+		{odcs.LogicalString, "text", ""},
+		{odcs.LogicalNumber, "numeric", ""},
+		{odcs.LogicalDate, "date", "date"},
+		{odcs.LogicalTimestamp, "timestamp", "date-time"},
+		{odcs.LogicalBoolean, "boolean", ""},
+		{"", "empty", ""},
+	}
+	if len(obj.Properties) != len(wants) {
+		t.Fatalf("got %d properties, want %d", len(obj.Properties), len(wants))
+	}
+	for i, w := range wants {
+		p := obj.Properties[i]
+		if p.LogicalType != w.logical {
+			t.Errorf("prop %d logicalType = %q, want %q", i, p.LogicalType, w.logical)
+		}
+		if p.PhysicalType != w.physical {
+			t.Errorf("prop %d physicalType = %q, want %q", i, p.PhysicalType, w.physical)
+		}
+		gotFormat := ""
+		if p.LogicalTypeOptions != nil {
+			gotFormat = p.LogicalTypeOptions.Format
+		}
+		if gotFormat != w.format {
+			t.Errorf("prop %d format = %q, want %q", i, gotFormat, w.format)
+		}
+	}
+}
+
+func TestFromSourceContractUnknownToken(t *testing.T) {
+	// An unrecognised native token is echoed into physicalType with no
+	// logical type, so the gap surfaces rather than being guessed away.
+	sc := csvcontract.SourceContract{
+		SourcePath: "x.csv",
+		Fields:     []csvcontract.Field{{Name: "weird", DataType: profile.DataType("mystery")}},
+	}
+	p := FromSourceContract(sc).Schema[0].Properties[0]
+	if p.LogicalType != "" || p.PhysicalType != "mystery" {
+		t.Errorf("unknown token property = %+v", p)
+	}
+}
+
+func TestFromJSONContractTypeEncoding(t *testing.T) {
+	sc := jsoncontract.SourceContract{
+		SourcePath:   "events.json",
+		SourceFormat: "json",
+		Fields: []jsoncontract.Field{
+			{Name: "label", DataType: jsoncontract.TypeText},
+			{Name: "count", DataType: jsoncontract.TypeNumeric},
+			{Name: "flag", DataType: jsoncontract.TypeBoolean},
+			{Name: "payload", DataType: jsoncontract.TypeObject},
+			{Name: "items", DataType: jsoncontract.TypeArray},
+			{Name: "missing", DataType: jsoncontract.TypeNull},
+			{Name: "blank", DataType: jsoncontract.TypeEmpty},
+		},
+	}
+	obj := FromJSONContract(sc).Schema[0]
+
+	got := map[string]odcs.Property{}
+	for _, p := range obj.Properties {
+		got[p.Name] = p
+	}
+	if p := got["payload"]; p.LogicalType != odcs.LogicalObject || p.PhysicalType != "object" {
+		t.Errorf("payload = %+v", p)
+	}
+	if p := got["items"]; p.LogicalType != odcs.LogicalArray || p.PhysicalType != "array" || p.Items != nil {
+		t.Errorf("items = %+v (Items=%v)", p, p.Items)
+	}
+	if p := got["missing"]; p.LogicalType != "" || p.PhysicalType != "null" {
+		t.Errorf("missing = %+v", p)
+	}
+	if p := got["blank"]; p.LogicalType != "" || p.PhysicalType != "empty" {
+		t.Errorf("blank = %+v", p)
+	}
+	if p := got["label"]; p.LogicalType != odcs.LogicalString || p.PhysicalType != "text" {
+		t.Errorf("label = %+v", p)
+	}
+}
+
+func TestFromDataContractMultiSchemaAndNullability(t *testing.T) {
+	dc := contract.DataContract{
+		ID: "workbook",
+		Schemas: []contract.SchemaContract{
+			{
+				Name: "Sheet1",
+				Fields: []contract.FieldDefinition{
+					{Name: "a", DataType: "text", Nullable: false},
+					{Name: "b", DataType: "numeric", Nullable: true},
+				},
+			},
+			{
+				Name: "Sheet2",
+				Fields: []contract.FieldDefinition{
+					{Name: "c", DataType: "boolean", Nullable: false},
+				},
+			},
+		},
+	}
+	c := FromDataContract(dc)
+	if c.ID != "workbook" {
+		t.Errorf("id = %q", c.ID)
+	}
+	if len(c.Schema) != 2 {
+		t.Fatalf("expected 2 schema objects, got %d", len(c.Schema))
+	}
+	s1 := c.Schema[0]
+	if s1.Name != "Sheet1" || s1.PhysicalType != "table" {
+		t.Errorf("sheet1 = %+v", s1)
+	}
+	// Nullable=false -> required true (NOT NULL); Nullable=true -> required unset.
+	if s1.Properties[0].Required == nil || !*s1.Properties[0].Required {
+		t.Errorf("a should be required (NOT NULL): %+v", s1.Properties[0])
+	}
+	if s1.Properties[1].Required != nil {
+		t.Errorf("b should have no required flag (nullable): %+v", s1.Properties[1])
+	}
+	if c.Schema[1].Properties[0].LogicalType != odcs.LogicalBoolean {
+		t.Errorf("c logicalType = %q", c.Schema[1].Properties[0].LogicalType)
+	}
+}
+
+// TestEnumRoundTrip is the spec section 4.2 proof: emit an enum to ODCS,
+// read it back, and recover the identical ordered labels and native type
+// name. Arguments is free-form in ODCS, so this round-trip is owned by our
+// encoder/reader pair.
+func TestEnumRoundTrip(t *testing.T) {
+	typeName := "account_status"
+	labels := []string{"active", "closed", "pending"}
+
+	p := EnumProperty("status", typeName, labels)
+
+	if p.LogicalType != odcs.LogicalString {
+		t.Errorf("enum logicalType = %q, want string", p.LogicalType)
+	}
+	if p.PhysicalType != typeName {
+		t.Errorf("enum physicalType = %q, want %q", p.PhysicalType, typeName)
+	}
+	if len(p.Quality) != 1 {
+		t.Fatalf("expected one quality rule, got %d", len(p.Quality))
+	}
+	q := p.Quality[0]
+	if q.Type != odcs.QualityLibrary || q.Metric != odcs.MetricInvalidValues || q.Unit != "rows" {
+		t.Errorf("quality rule = %+v", q)
+	}
+	if q.MustBe != 0 {
+		t.Errorf("mustBe = %v, want 0", q.MustBe)
+	}
+
+	gotType, gotLabels, ok := ReadEnumLabels(p)
+	if !ok {
+		t.Fatal("ReadEnumLabels reported no enum rule")
+	}
+	if gotType != typeName {
+		t.Errorf("recovered type = %q, want %q", gotType, typeName)
+	}
+	if !reflect.DeepEqual(gotLabels, labels) {
+		t.Errorf("recovered labels = %v, want %v (ordered)", gotLabels, labels)
+	}
+}
+
+// TestEnumRoundTripThroughYAML proves the labels survive a real ODCS YAML
+// serialisation, not just the in-memory structs: this is the form a reader
+// in another process actually consumes.
+func TestEnumRoundTripThroughYAML(t *testing.T) {
+	labels := []string{"red", "green", "blue"}
+	c := odcs.Contract{
+		APIVersion: odcs.APIVersion,
+		Kind:       odcs.KindDataContract,
+		ID:         "x",
+		Schema: []odcs.SchemaObject{
+			{Name: "t", Properties: []odcs.Property{EnumProperty("color", "color_enum", labels)}},
+		},
+	}
+	data, err := c.MarshalYAML()
+	if err != nil {
+		t.Fatalf("MarshalYAML: %v", err)
+	}
+	back, err := odcs.UnmarshalYAML(data)
+	if err != nil {
+		t.Fatalf("UnmarshalYAML: %v", err)
+	}
+	gotType, gotLabels, ok := ReadEnumLabels(back.Schema[0].Properties[0])
+	if !ok {
+		t.Fatal("no enum rule after YAML round-trip")
+	}
+	if gotType != "color_enum" || !reflect.DeepEqual(gotLabels, labels) {
+		t.Errorf("after YAML: type=%q labels=%v, want color_enum %v", gotType, gotLabels, labels)
+	}
+}
+
+func TestReadEnumLabelsNonEnum(t *testing.T) {
+	// A plain string property carries no enum rule.
+	if _, _, ok := ReadEnumLabels(propertyFromProfileType("name", "text")); ok {
+		t.Error("plain text property should not read as an enum")
+	}
+	// A library rule missing validValues is not an enum rule.
+	p := odcs.Property{
+		Name: "x",
+		Quality: []odcs.Quality{
+			{Type: odcs.QualityLibrary, Metric: odcs.MetricInvalidValues, Arguments: map[string]any{}},
+			{Type: odcs.QualitySQL, Metric: odcs.MetricNullValues},
+		},
+	}
+	if _, _, ok := ReadEnumLabels(p); ok {
+		t.Error("library rule without validValues should not read as an enum")
+	}
+	// validValues present but not a list.
+	p2 := odcs.Property{Quality: []odcs.Quality{{
+		Type: odcs.QualityLibrary, Metric: odcs.MetricInvalidValues,
+		Arguments: map[string]any{"validValues": "active"},
+	}}}
+	if _, _, ok := ReadEnumLabels(p2); ok {
+		t.Error("non-list validValues should not read as an enum")
+	}
+	// validValues is a list but holds a non-string: fail closed.
+	p3 := odcs.Property{Quality: []odcs.Quality{{
+		Type: odcs.QualityLibrary, Metric: odcs.MetricInvalidValues,
+		Arguments: map[string]any{"validValues": []any{"active", 7}},
+	}}}
+	if _, _, ok := ReadEnumLabels(p3); ok {
+		t.Error("non-string label should fail closed")
+	}
+}

--- a/odcsemit/encode.go
+++ b/odcsemit/encode.go
@@ -1,0 +1,133 @@
+package odcsemit
+
+import "github.com/JacobJNilsson/data-contract-generator/odcs"
+
+// propertyFromProfileType encodes a profile-vocabulary type token (the CSV
+// and Excel analysers' DataType: text, numeric, date, timestamp, boolean,
+// empty) onto an ODCS property. The native token is echoed into
+// physicalType so the fingerprint can recover the same canonical type from
+// the ODCS document; for the empty token, where there is no logical type to
+// assign, the token is still carried in physicalType so the unknown column
+// stays distinguishable on the way back.
+func propertyFromProfileType(name, dataType string) odcs.Property {
+	p := odcs.Property{Name: name}
+	switch dataType {
+	case "text":
+		p.LogicalType = odcs.LogicalString
+		p.PhysicalType = "text"
+	case "numeric":
+		p.LogicalType = odcs.LogicalNumber
+		p.PhysicalType = "numeric"
+	case "date":
+		p.LogicalType = odcs.LogicalDate
+		p.PhysicalType = "date"
+		p.LogicalTypeOptions = &odcs.LogicalTypeOptions{Format: "date"}
+	case "timestamp":
+		p.LogicalType = odcs.LogicalTimestamp
+		p.PhysicalType = "timestamp"
+		p.LogicalTypeOptions = &odcs.LogicalTypeOptions{Format: "date-time"}
+	case "boolean":
+		p.LogicalType = odcs.LogicalBoolean
+		p.PhysicalType = "boolean"
+	case "empty":
+		// No observable type. ODCS has no unknown logical type, so leave
+		// logicalType empty and carry the native token in physicalType. The
+		// fingerprint maps "no logicalType, physicalType empty/null" back to
+		// its UNKNOWN canonical type.
+		p.PhysicalType = "empty"
+	default:
+		// Unrecognised profile token. Echo it into physicalType rather than
+		// guessing a logical type; the fingerprint fails closed on it, which
+		// surfaces the gap instead of hiding it.
+		p.PhysicalType = dataType
+	}
+	return p
+}
+
+// propertyFromJSONType encodes a jsoncontract type token (text, numeric,
+// date, boolean, object, array, null, empty) onto an ODCS property. It
+// extends the profile encoding with the object and array shapes JSON
+// exposes. The JSON analyser does not expose array element types, so an
+// array is emitted element-opaque (no items); a DB source that does know
+// its element type slots in through the same array branch by setting items.
+func propertyFromJSONType(name, dataType string) odcs.Property {
+	switch dataType {
+	case "object":
+		return odcs.Property{Name: name, LogicalType: odcs.LogicalObject, PhysicalType: "object"}
+	case "array":
+		// Element-opaque: the JSON analyser does not expose the element
+		// type, so items stays nil and the fingerprint reads this as the
+		// bare ARRAY token, matching the native path.
+		return odcs.Property{Name: name, LogicalType: odcs.LogicalArray, PhysicalType: "array"}
+	case "null":
+		// JSON's all-null token is the unknown column, same canonical fate
+		// as the profile "empty" token; carry it in physicalType.
+		return odcs.Property{Name: name, PhysicalType: "null"}
+	default:
+		// text, numeric, date, boolean, empty share the profile encoding.
+		return propertyFromProfileType(name, dataType)
+	}
+}
+
+// EnumProperty builds the ODCS encoding of a named enum column: a string
+// logical type, the enum type name in physicalType, and a library quality
+// rule carrying the ordered label set (spec section 4.2). ODCS v3.1.0 has
+// no first-class enum type and no validValues field, so this rule is how
+// the label set survives the round-trip. The file analysers do not yet
+// surface enums; this is the seam a DB source plugs into, and it is proven
+// by the enum round-trip test.
+func EnumProperty(name, enumTypeName string, labels []string) odcs.Property {
+	values := make([]any, len(labels))
+	for i, l := range labels {
+		values[i] = l
+	}
+	zero := 0
+	return odcs.Property{
+		Name:         name,
+		LogicalType:  odcs.LogicalString,
+		PhysicalType: enumTypeName,
+		Quality: []odcs.Quality{
+			{
+				ID:     name + "_valid_values",
+				Type:   odcs.QualityLibrary,
+				Metric: odcs.MetricInvalidValues,
+				Arguments: map[string]any{
+					"validValues": values,
+				},
+				MustBe: zero,
+				Unit:   "rows",
+			},
+		},
+	}
+}
+
+// ReadEnumLabels recovers the ordered label set and native enum type name
+// from an enum property encoded by EnumProperty. The bool is false when the
+// property does not carry an enum quality rule. This is the reader half of
+// the round-trip the spec requires us to own (arguments is free-form, so
+// only our own encoder/decoder pair guarantees the labels survive).
+func ReadEnumLabels(p odcs.Property) (typeName string, labels []string, ok bool) {
+	for _, q := range p.Quality {
+		if q.Type != odcs.QualityLibrary || q.Metric != odcs.MetricInvalidValues {
+			continue
+		}
+		raw, present := q.Arguments["validValues"]
+		if !present {
+			continue
+		}
+		list, isList := raw.([]any)
+		if !isList {
+			continue
+		}
+		labels = make([]string, 0, len(list))
+		for _, v := range list {
+			s, isStr := v.(string)
+			if !isStr {
+				return "", nil, false
+			}
+			labels = append(labels, s)
+		}
+		return p.PhysicalType, labels, true
+	}
+	return "", nil, false
+}

--- a/odcsemit/status_test.go
+++ b/odcsemit/status_test.go
@@ -1,0 +1,34 @@
+package odcsemit
+
+import (
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/contract"
+	"github.com/JacobJNilsson/data-contract-generator/csvcontract"
+	"github.com/JacobJNilsson/data-contract-generator/jsoncontract"
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/profile"
+)
+
+// Every emitter entry point must stamp the ODCS-required contract status.
+// Without it the document fails official ODCS schema validation and the Data
+// Contract CLI refuses to export it, which breaks the emission pipeline.
+func TestEmittersSetContractStatus(t *testing.T) {
+	csv := FromSourceContract(csvcontract.SourceContract{
+		SourcePath: "t.csv", Delimiter: ",", Encoding: "UTF-8", HasHeader: true,
+		Fields: []csvcontract.Field{{Name: "a", DataType: profile.TypeText}},
+	})
+	js := FromJSONContract(jsoncontract.SourceContract{
+		SourcePath: "t.json", Encoding: "UTF-8",
+		Fields: []jsoncontract.Field{{Name: "a", DataType: jsoncontract.TypeText}},
+	})
+	dc := FromDataContract(contract.DataContract{
+		ID:      "t",
+		Schemas: []contract.SchemaContract{{Name: "s", Fields: []contract.FieldDefinition{{Name: "a", DataType: "text"}}}},
+	})
+	for name, got := range map[string]odcs.Contract{"csv": csv, "json": js, "data": dc} {
+		if got.Status != odcs.StatusActive {
+			t.Errorf("%s emitter: status = %q, want %q", name, got.Status, odcs.StatusActive)
+		}
+	}
+}

--- a/tools/import/requirements.txt
+++ b/tools/import/requirements.txt
@@ -1,13 +1,18 @@
 # Pinned Python toolchain for the declared-schema importer (declimport).
 #
 # The dcg Go module shells out to the Data Contract CLI to import sources
-# that already carry a schema (a Postgres DDL dump today; OpenAPI and Avro
-# later) and normalise them into the odcs package. The CLI is pinned to an
-# exact version so the importer's argv contract and the ODCS it emits are
+# that already carry a schema (a Postgres DDL dump or an Avro record schema)
+# and normalise them into the odcs package. The CLI is pinned to an exact
+# version so the importer's argv contract and the ODCS it emits are
 # reproducible across machines and CI.
+#
+# The [avro] extra is required: the Avro importer lives behind it, and without
+# it `datacontract import avro` exits non-zero with "Module avro could not be
+# loaded". The SQL importer needs no extra. (The pinned CLI has no OpenAPI
+# importer at all, so there is nothing to install for that format yet.)
 #
 # This toolchain is intentionally NOT installed by `make check`: the Go unit
 # tests run against a fake command runner and need no Python. Install it with
 # `make import-tools`; the build-tagged integration test drives the real
 # binary.
-datacontract-cli==1.0.6
+datacontract-cli[avro]==1.0.6

--- a/tools/import/requirements.txt
+++ b/tools/import/requirements.txt
@@ -1,0 +1,13 @@
+# Pinned Python toolchain for the declared-schema importer (declimport).
+#
+# The dcg Go module shells out to the Data Contract CLI to import sources
+# that already carry a schema (a Postgres DDL dump today; OpenAPI and Avro
+# later) and normalise them into the odcs package. The CLI is pinned to an
+# exact version so the importer's argv contract and the ODCS it emits are
+# reproducible across machines and CI.
+#
+# This toolchain is intentionally NOT installed by `make check`: the Go unit
+# tests run against a fake command runner and need no Python. Install it with
+# `make import-tools`; the build-tagged integration test drives the real
+# binary.
+datacontract-cli==1.0.6


### PR DESCRIPTION
Graduates the dcg ODCS line to main: the odcs v3.1.0 model (schema-validated), the analysis-to-ODCS emitter, FromODCS proven byte-identical to the native path (no cache invalidation), the required-status and case-folding fixes, and declared-schema import (SQL DDL + Avro) via the Data Contract CLI. Each commit was individually reviewed and is green at 100% coverage.