### PR TITLE
Live destination introspection + faithful contract generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,27 @@ jobs:
           echo "odcsemit: ${COVERAGE}%"
           awk "BEGIN {if ($COVERAGE < 100) {print \"FAIL\"; exit 1}}"
 
+      - name: Test odcsdest (100%)
+        run: |
+          go test -race -coverprofile=coverage.out ./odcsdest/...
+          COVERAGE=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | sed 's/%//')
+          echo "odcsdest: ${COVERAGE}%"
+          awk "BEGIN {if ($COVERAGE < 100) {print \"FAIL\"; exit 1}}"
+
+      - name: Test pgcheck (100%)
+        run: |
+          go test -race -coverprofile=coverage.out ./pgcheck/...
+          COVERAGE=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | sed 's/%//')
+          echo "pgcheck: ${COVERAGE}%"
+          awk "BEGIN {if ($COVERAGE < 100) {print \"FAIL\"; exit 1}}"
+
+      - name: Test pgintrospect (100%)
+        run: |
+          go test -race -coverprofile=coverage.out ./pgintrospect/...
+          COVERAGE=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | sed 's/%//')
+          echo "pgintrospect: ${COVERAGE}%"
+          awk "BEGIN {if ($COVERAGE < 100) {print \"FAIL\"; exit 1}}"
+
       # declimport's coverage is measured from its unit tests only; the
       # end-to-end CLI tests are behind the `integration` tag and excluded here.
       - name: Test declimport (100%)
@@ -106,3 +127,14 @@ jobs:
       # skip here (their pinned binary is not installed), which is expected.
       - name: Integration tests (-tags=integration)
         run: go test -tags=integration -race ./...
+
+      # pgcontract's faithful generator needs a live Postgres, so it is gated
+      # 100% HERE (in the tier that exercises its full behaviour) rather than in
+      # the fast job: the pure assembly/validation core and the live-DB reads
+      # are both measured, with no branch faked to hit the number.
+      - name: Test pgcontract (100%, integration)
+        run: |
+          go test -tags=integration -race -coverprofile=coverage.out ./pgcontract/...
+          COVERAGE=$(go tool cover -func=coverage.out | tail -1 | awk '{print $3}' | sed 's/%//')
+          echo "pgcontract: ${COVERAGE}%"
+          awk "BEGIN {if ($COVERAGE < 100) {print \"FAIL\"; exit 1}}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ sd ready        # Find unblocked work
 ## Project Rules
 
 - **Go conventions**: Prefer stdlib, remove dead code, no type aliases, no circular dependencies. External deps: golang.org/x/text, excelize/v2.
-- **Testing**: Per-package coverage gates (profile/csv/fingerprint/odcs/odcsemit/odcsdest/pgcheck/declimport 100%, json/excel 95%). Compare complete objects in tests. Race detector on all runs.
+- **Testing**: Per-package coverage gates (profile/csv/fingerprint/odcs/odcsemit/odcsdest/pgcheck/pgintrospect/declimport 100%, json/excel 95%) in the fast tier; `pgcontract` gated 100% in the integration tier (it needs a live Postgres). Compare complete objects in tests. Race detector on all runs.
 - **Pre-commit**: Runs `make check` (tidy, vet, lint, per-package coverage, build). All must pass.
 - **Commits**: Conventional Commits format (`<type>[optional scope]: <description>`). Imperative mood, start capitalized, no trailing period.
 - **All changes go through PRs.** Never push directly to main.

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ test:
 	go test -race -coverprofile=coverage.out ./pgcheck/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 100) {printf "FAIL pgcheck %.1f%% < 100%%\n", $$1; exit 1} else {printf "pgcheck: %.1f%%\n", $$1}}'
+	go test -race -coverprofile=coverage.out ./pgintrospect/...
+	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
+		awk '{if ($$1+0 < 100) {printf "FAIL pgintrospect %.1f%% < 100%%\n", $$1; exit 1} else {printf "pgintrospect: %.1f%%\n", $$1}}'
 	go test -race -coverprofile=coverage.out ./jsoncontract/...
 	@go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//' | \
 		awk '{if ($$1+0 < 95) {printf "FAIL jsoncontract %.1f%% < 95%%\n", $$1; exit 1} else {printf "jsoncontract: %.1f%%\n", $$1}}'

--- a/README.md
+++ b/README.md
@@ -69,11 +69,14 @@ The pre-commit hook runs `make check` which enforces per-package coverage:
 | odcsemit | 100% |
 | odcsdest | 100% |
 | pgcheck | 100% |
+| pgintrospect | 100% |
 | declimport | 100% |
 | jsoncontract | 95% |
 | excelcontract | 95% |
 
-CI runs the fast tier and the integration tier as separate jobs, so the pure-Go promise holds for the default path while destination code is still covered against a real Postgres.
+`pgcontract` is gated at 100% in the INTEGRATION tier instead of the fast tier: its faithful generator (`Generate`) needs a live Postgres, so its full behaviour — the pure assembly/validation core and the live-DB reads alike — is exercised and measured under `-tags=integration` rather than faked to hit a fast-tier number.
+
+CI runs the fast tier and the integration tier as separate jobs, so the pure-Go promise holds for the default path while destination code is still covered against a real Postgres. Both jobs enforce the per-package coverage gates above (the fast tier for the pure packages, the integration tier for `pgcontract`).
 
 ## Architecture
 

--- a/pgcontract/assemble.go
+++ b/pgcontract/assemble.go
@@ -1,0 +1,235 @@
+package pgcontract
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/odcsdest"
+	"github.com/JacobJNilsson/data-contract-generator/pgintrospect"
+)
+
+// userDefinedDataType is the data_type string information_schema.columns
+// reports for an enum (and other USER-DEFINED types). The mapping routes it to
+// the enum path, resolving labels from pg_enum; a USER-DEFINED type carrying no
+// enum labels fails closed in odcsdest.PostgresProperty rather than reaching
+// the contract as an empty enum.
+const userDefinedDataType = "USER-DEFINED"
+
+// enumKey identifies one enum type by the (schema, name) pair its labels are
+// resolved under, so a type used on many columns is read once and looked up by
+// the same key the column carries.
+type enumKey struct{ schema, name string }
+
+// facts is the already-read catalog state assemble turns into a contract: the
+// tables (filtered to the included set, sorted), every column (assemble skips
+// an excluded one), and the per-table constraints with their exclusion policy
+// already applied. enums maps each enum type to its ordered labels, resolved by
+// a DB read the caller (Generate) performs; a USER-DEFINED column whose type is
+// absent or empty here fails closed as a non-enum. Holding the facts as plain
+// values keeps assemble a pure function the fast tier can drive without a
+// database.
+type facts struct {
+	tables  []string
+	columns []pgintrospect.Column
+	pks     map[string][]string
+	uniques map[string][]odcs.UniqueConstraint
+	checks  map[string][]odcs.CheckConstraint
+	fks     map[string][]odcs.ForeignKey
+	enums   map[enumKey][]string
+}
+
+// assemble composes the read catalog facts into a FAITHFUL odcs.Contract: each
+// included table becomes a schema object carrying its columns (in ordinal
+// order, at their exact widths and RAW destination nullability), primary key,
+// unique constraints, verbatim CHECK constraints, and single-column foreign
+// keys (the structural triple only). It fails CLOSED, joining every column
+// whose Postgres type is outside the reproducible vocabulary so an operator
+// sees them all at once, and validates the assembled contract before returning
+// it.
+//
+// It carries the faithful shape ONLY. The producer-optionality folding (MP-3),
+// merge-key selection (MP-2), surrogate/generated markers, column defaults,
+// destination-not-null markers, and foreign-key natural-key resolution are
+// POLICY a caller layers on top afterwards; assemble never applies them, so the
+// contract it returns describes exactly what the destination declares.
+func assemble(f facts, excludedColumn map[string]struct{}) (odcs.Contract, error) {
+	objs := make([]odcs.SchemaObject, 0, len(f.tables))
+	var typeErrs []error
+	for _, name := range f.tables {
+		var props []odcs.Property
+		for _, col := range f.columns {
+			if col.Table != name {
+				continue
+			}
+			if _, skip := excludedColumn[col.Name]; skip {
+				continue
+			}
+			prop, err := mapColumn(col, f.enums)
+			if err != nil {
+				typeErrs = append(typeErrs, fmt.Errorf("table %q %w", name, err))
+				continue
+			}
+			props = append(props, prop)
+		}
+		obj := odcsdest.Table(name, props, f.pks[name])
+		obj = odcsdest.WithUnique(obj, f.uniques[name]...)
+		obj = odcsdest.WithChecks(obj, f.checks[name]...)
+		obj = odcsdest.WithForeignKeys(obj, f.fks[name]...)
+		objs = append(objs, obj)
+	}
+	if len(typeErrs) > 0 {
+		// Fail closed on any column the vocabulary cannot represent: a generated
+		// contract that silently dropped or mistyped a column would mislead both
+		// an agent and a mirror.
+		return odcs.Contract{}, fmt.Errorf("pgcontract: generate: %w", errors.Join(typeErrs...))
+	}
+	contract := odcsdest.NewContract(objs...)
+	if err := validate(contract); err != nil {
+		return odcs.Contract{}, fmt.Errorf("pgcontract: generated contract is invalid: %w", err)
+	}
+	return contract, nil
+}
+
+// mapColumn turns one catalog column into its ODCS property through the pure
+// B1 mapper (odcsdest.PostgresProperty), which owns the type vocabulary and the
+// fail-closed rules. The nullability passed is the column's RAW destination
+// nullability (is_nullable), NOT a producer-optionality fold: the faithful
+// contract encodes exactly the destination's NOT NULL, and a policy layer folds
+// database-populated columns to optional afterwards. An enum column's labels
+// come from the pre-resolved enums map; an absent or empty entry makes the
+// mapper fail closed on a non-enum USER-DEFINED type.
+func mapColumn(col pgintrospect.Column, enums map[enumKey][]string) (odcs.Property, error) {
+	desc := odcsdest.PostgresColumnType{
+		Name:             col.Name,
+		Nullable:         col.Nullable == "YES",
+		DataType:         col.DataType,
+		UDTName:          col.UDTName,
+		NumericPrecision: nullInt(col.NumericPrecision),
+		NumericScale:     nullInt(col.NumericScale),
+		CharMaxLength:    nullInt(col.CharMaxLength),
+		ElementDataType:  col.ElementDataType,
+		ElementTypeMod:   col.ElementTypeMod,
+		ArrayDims:        col.ArrayDims,
+	}
+	if col.DataType == userDefinedDataType {
+		desc.EnumLabels = enums[enumKey{col.UDTSchema, col.UDTName}]
+	}
+	return odcsdest.PostgresProperty(desc)
+}
+
+// includedTables drops the excluded tables from the (sorted) base-table list,
+// so the contract's table order stays deterministic.
+func includedTables(raw []string, excluded map[string]struct{}) []string {
+	var out []string
+	for _, name := range raw {
+		if _, skip := excluded[name]; !skip {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// includedPrimaryKeys drops a primary key whole when it includes an excluded
+// column: the contract withholds that column, so it cannot declare a key that
+// references it. A key over only included columns is kept in its key order.
+func includedPrimaryKeys(raw map[string][]string, excluded map[string]struct{}) map[string][]string {
+	out := map[string][]string{}
+	for table, columns := range raw {
+		if !anyExcluded(columns, excluded) {
+			out[table] = columns
+		}
+	}
+	return out
+}
+
+// includedUniques groups the non-primary UNIQUE constraints by table, dropping
+// a constraint whole when it spans an excluded column. The gateway returns them
+// in deterministic (table, constraint name) order, so appending per table
+// preserves a stable constraint order.
+func includedUniques(raw []pgintrospect.UniqueConstraint, excluded map[string]struct{}) map[string][]odcs.UniqueConstraint {
+	out := map[string][]odcs.UniqueConstraint{}
+	for _, u := range raw {
+		if anyExcluded(u.Columns, excluded) {
+			continue
+		}
+		out[u.Table] = append(out[u.Table], odcs.UniqueConstraint{Name: u.Name, Columns: u.Columns})
+	}
+	return out
+}
+
+// includedChecks groups the CHECK constraints by table, carrying each
+// expression VERBATIM and dropping a check whole when it constrains an excluded
+// column (conkey names exactly the constrained columns, so the drop is
+// precise). Both single-column and table-level multi-column checks are kept
+// (#155).
+func includedChecks(raw []pgintrospect.CheckConstraint, excluded map[string]struct{}) map[string][]odcs.CheckConstraint {
+	out := map[string][]odcs.CheckConstraint{}
+	for _, ck := range raw {
+		if anyExcluded(ck.Columns, excluded) {
+			continue
+		}
+		out[ck.Table] = append(out[ck.Table], odcs.CheckConstraint{Name: ck.Name, Expression: ck.Expression})
+	}
+	return out
+}
+
+// singleColumnForeignKeys groups the SINGLE-COLUMN foreign keys by referencing
+// table, carrying the structural triple only (local column, referenced table,
+// referenced column). A multi-column (composite) foreign key is not corrupted
+// into a single-column shape this cannot represent: it is skipped with a logged
+// note so the omission is visible. A foreign key whose local column is excluded
+// is dropped whole, the same fail-closed direction the unique and check
+// exclusion take.
+func singleColumnForeignKeys(raw []pgintrospect.ForeignKey, excluded map[string]struct{}) map[string][]odcs.ForeignKey {
+	out := map[string][]odcs.ForeignKey{}
+	for _, g := range raw {
+		if g.NumColumns != 1 || len(g.Columns) != 1 {
+			log.Printf("pgcontract: skipping multi-column foreign key %q on table %q (single-column foreign keys only)", g.Name, g.Table)
+			continue
+		}
+		if _, skip := excluded[g.Columns[0]]; skip {
+			continue
+		}
+		out[g.Table] = append(out[g.Table], odcs.ForeignKey{
+			Column:           g.Columns[0],
+			ReferencedTable:  g.ReferencedTable,
+			ReferencedColumn: g.ReferencedColumns[0],
+		})
+	}
+	return out
+}
+
+// nullInt converts a nullable integer scanned from a catalog column into a
+// *int: a NULL (an unconstrained numeric, an unbounded string) yields nil so
+// the column carries no bound, a present value yields a pointer to it.
+func nullInt(n sql.NullInt64) *int {
+	if !n.Valid {
+		return nil
+	}
+	v := int(n.Int64)
+	return &v
+}
+
+// toSet builds a lookup set from a name slice; nil yields an empty set.
+func toSet(names []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	return set
+}
+
+// anyExcluded reports whether any of a constraint's columns is excluded: the
+// shared drop-whole rule the primary-key, unique, and check grouping apply to a
+// constraint touching a withheld column.
+func anyExcluded(columns []string, excluded map[string]struct{}) bool {
+	for _, c := range columns {
+		if _, skip := excluded[c]; skip {
+			return true
+		}
+	}
+	return false
+}

--- a/pgcontract/assemble_test.go
+++ b/pgcontract/assemble_test.go
@@ -1,0 +1,362 @@
+package pgcontract
+
+// Fast-tier unit tests for the PURE assembly core: the exclusion filters, the
+// per-column mapping, and assemble itself all run on hand-built catalog facts
+// with no database, so the fast tier exercises the contract-shaping logic.
+// Generate and resolveEnumLabels (which issue live queries) are exercised in
+// the integration tier.
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/odcsdest"
+	"github.com/JacobJNilsson/data-contract-generator/pgintrospect"
+)
+
+// col builds a minimal catalog Column with the fields the faithful mapping
+// reads; unset fields default to their zero value (a non-array, non-numeric,
+// unbounded scalar).
+func col(table, name, dataType, nullable string) pgintrospect.Column {
+	return pgintrospect.Column{Table: table, Name: name, DataType: dataType, Nullable: nullable, ElementTypeMod: -1}
+}
+
+func nullInt64(v int64) sql.NullInt64 { return sql.NullInt64{Int64: v, Valid: true} }
+
+func TestNullInt(t *testing.T) {
+	if got := nullInt(sql.NullInt64{}); got != nil {
+		t.Errorf("nullInt(NULL) = %v, want nil", got)
+	}
+	got := nullInt(nullInt64(12))
+	if got == nil || *got != 12 {
+		t.Errorf("nullInt(12) = %v, want *12", got)
+	}
+}
+
+func TestToSetAndAnyExcluded(t *testing.T) {
+	if len(toSet(nil)) != 0 {
+		t.Errorf("toSet(nil) is not empty")
+	}
+	set := toSet([]string{"a", "b"})
+	if !anyExcluded([]string{"x", "b"}, set) {
+		t.Errorf("anyExcluded should report b excluded")
+	}
+	if anyExcluded([]string{"x", "y"}, set) {
+		t.Errorf("anyExcluded should report none excluded")
+	}
+}
+
+func TestIncludedTables(t *testing.T) {
+	got := includedTables([]string{"a", "skip", "b"}, toSet([]string{"skip"}))
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("includedTables = %v, want [a b] in order", got)
+	}
+}
+
+func TestIncludedPrimaryKeys(t *testing.T) {
+	raw := map[string][]string{"keep": {"id"}, "drop": {"id", "ext"}}
+	got := includedPrimaryKeys(raw, toSet([]string{"ext"}))
+	if _, ok := got["drop"]; ok {
+		t.Errorf("primary key over excluded column was kept: %v", got)
+	}
+	if want := []string{"id"}; len(got["keep"]) != 1 || got["keep"][0] != want[0] {
+		t.Errorf("keep primary key = %v, want %v", got["keep"], want)
+	}
+}
+
+func TestIncludedUniquesAndChecks(t *testing.T) {
+	uniques := includedUniques([]pgintrospect.UniqueConstraint{
+		{Table: "t", Name: "u_keep", Columns: []string{"a"}},
+		{Table: "t", Name: "u_drop", Columns: []string{"a", "ext"}},
+	}, toSet([]string{"ext"}))
+	if len(uniques["t"]) != 1 || uniques["t"][0].Name != "u_keep" {
+		t.Errorf("includedUniques = %+v, want only u_keep", uniques)
+	}
+
+	checks := includedChecks([]pgintrospect.CheckConstraint{
+		{Table: "t", Name: "ck_keep", Expression: "a > 0", Columns: []string{"a"}},
+		{Table: "t", Name: "ck_drop", Expression: "ext > 0", Columns: []string{"ext"}},
+		{Table: "t", Name: "ck_nocol", Expression: "true"},
+	}, toSet([]string{"ext"}))
+	if len(checks["t"]) != 2 {
+		t.Fatalf("includedChecks = %+v, want ck_keep and ck_nocol (ck_drop dropped)", checks)
+	}
+	if checks["t"][0].Name != "ck_keep" || checks["t"][0].Expression != "a > 0" || checks["t"][1].Name != "ck_nocol" {
+		t.Errorf("includedChecks kept the wrong checks / lost the verbatim expression: %+v", checks["t"])
+	}
+}
+
+func TestSingleColumnForeignKeys(t *testing.T) {
+	got := singleColumnForeignKeys([]pgintrospect.ForeignKey{
+		{Table: "orders", Name: "fk_single", NumColumns: 1, Columns: []string{"asset_id"}, ReferencedTable: "assets", ReferencedColumns: []string{"id"}},
+		{Table: "orders", Name: "fk_composite", NumColumns: 2, Columns: []string{"a", "b"}, ReferencedTable: "refs", ReferencedColumns: []string{"x", "y"}},
+		{Table: "orders", Name: "fk_excluded", NumColumns: 1, Columns: []string{"ext"}, ReferencedTable: "refs", ReferencedColumns: []string{"id"}},
+	}, toSet([]string{"ext"}))
+	if len(got["orders"]) != 1 {
+		t.Fatalf("singleColumnForeignKeys = %+v, want only the single-column, non-excluded FK", got)
+	}
+	fk := got["orders"][0]
+	if fk.Column != "asset_id" || fk.ReferencedTable != "assets" || fk.ReferencedColumn != "id" {
+		t.Errorf("FK = %+v, want asset_id -> assets(id) (structural triple only)", fk)
+	}
+}
+
+func TestMapColumnScalarAndWidths(t *testing.T) {
+	cases := []struct {
+		name     string
+		column   pgintrospect.Column
+		wantDDL  string
+		nullable bool
+	}{
+		{"bigint not null", col("t", "id", "bigint", "NO"), "bigint", false},
+		{"text nullable", col("t", "note", "text", "YES"), "text", true},
+		{"boolean", col("t", "ok", "boolean", "YES"), "boolean", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mapColumn(tc.column, nil)
+			if err != nil {
+				t.Fatalf("mapColumn() = %v", err)
+			}
+			if ddl, ok := odcsdest.PostgresDDLType(got); !ok || ddl != tc.wantDDL {
+				t.Errorf("DDL = (%q,%v), want %q", ddl, ok, tc.wantDDL)
+			}
+			if odcsdest.Nullable(got) != tc.nullable {
+				t.Errorf("nullable = %v, want %v (RAW destination nullability)", odcsdest.Nullable(got), tc.nullable)
+			}
+		})
+	}
+}
+
+func TestMapColumnVarcharCarriesLength(t *testing.T) {
+	c := col("t", "code", "character varying", "NO")
+	c.CharMaxLength = nullInt64(3)
+	got, err := mapColumn(c, nil)
+	if err != nil {
+		t.Fatalf("mapColumn() = %v", err)
+	}
+	if ddl, ok := odcsdest.PostgresDDLType(got); !ok || ddl != "varchar(3)" {
+		t.Errorf("DDL = (%q,%v), want varchar(3)", ddl, ok)
+	}
+	if w, ok := odcsdest.MaxCharacterLength(got); !ok || w != 3 {
+		t.Errorf("width = (%d,%v), want 3", w, ok)
+	}
+}
+
+func TestMapColumnNumericPrecisionScale(t *testing.T) {
+	c := col("t", "amount", "numeric", "NO")
+	c.NumericPrecision = nullInt64(12)
+	c.NumericScale = nullInt64(2)
+	got, err := mapColumn(c, nil)
+	if err != nil {
+		t.Fatalf("mapColumn() = %v", err)
+	}
+	if ddl, ok := odcsdest.PostgresDDLType(got); !ok || ddl != "numeric(12,2)" {
+		t.Errorf("DDL = (%q,%v), want numeric(12,2)", ddl, ok)
+	}
+}
+
+func TestMapColumnArray(t *testing.T) {
+	c := col("t", "tags", "ARRAY", "YES")
+	c.ElementDataType = "text"
+	c.ArrayDims = 1
+	got, err := mapColumn(c, nil)
+	if err != nil {
+		t.Fatalf("mapColumn() = %v", err)
+	}
+	if ddl, ok := odcsdest.PostgresDDLType(got); !ok || ddl != "text[]" {
+		t.Errorf("DDL = (%q,%v), want text[]", ddl, ok)
+	}
+}
+
+func TestMapColumnEnum(t *testing.T) {
+	c := col("t", "status", "USER-DEFINED", "NO")
+	c.UDTName = "order_status"
+	c.UDTSchema = "public"
+	enums := map[enumKey][]string{{"public", "order_status"}: {"pending", "shipped"}}
+	got, err := mapColumn(c, enums)
+	if err != nil {
+		t.Fatalf("mapColumn(enum) = %v", err)
+	}
+	if !odcsdest.IsEnum(got) || odcsdest.EnumName(got) != "order_status" {
+		t.Fatalf("mapColumn did not produce the enum: %+v", got)
+	}
+	if labels := odcsdest.EnumLabels(got); strings.Join(labels, ",") != "pending,shipped" {
+		t.Errorf("enum labels = %v, want [pending shipped]", labels)
+	}
+}
+
+func TestMapColumnFailsClosed(t *testing.T) {
+	cases := []struct {
+		name   string
+		column pgintrospect.Column
+		enums  map[enumKey][]string
+		want   string
+	}{
+		{"unsupported scalar", col("t", "blob", "bytea", "NO"), nil, `unsupported type "bytea"`},
+		{
+			name:   "non-enum user-defined (empty labels)",
+			column: pgintrospect.Column{Table: "t", Name: "where_at", DataType: "USER-DEFINED", UDTName: "addr", UDTSchema: "public", ElementTypeMod: -1},
+			enums:  map[enumKey][]string{{"public", "addr"}: {}},
+			want:   `unsupported USER-DEFINED type "addr"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := mapColumn(tc.column, tc.enums)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("mapColumn() = %v, want an error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestAssembleHappy builds a two-table contract from hand-built facts and
+// asserts the faithful shape round-trips through the accessors: exact widths,
+// primary key, unique, verbatim check, and single-column FK (structural triple).
+func TestAssembleHappy(t *testing.T) {
+	f := facts{
+		tables: []string{"assets", "orders"},
+		columns: []pgintrospect.Column{
+			col("assets", "id", "bigint", "NO"),
+			withLen(col("assets", "isin", "character varying", "NO"), 12),
+			col("orders", "order_id", "bigint", "NO"),
+			col("orders", "asset_id", "bigint", "NO"),
+			col("orders", "note", "text", "YES"),
+		},
+		pks: map[string][]string{"assets": {"id"}, "orders": {"order_id"}},
+		uniques: map[string][]odcs.UniqueConstraint{
+			"assets": {{Name: "assets_isin_unique", Columns: []string{"isin"}}},
+		},
+		checks: map[string][]odcs.CheckConstraint{
+			"orders": {{Name: "orders_note_rule", Expression: "note IS NOT NULL"}},
+		},
+		fks: map[string][]odcs.ForeignKey{
+			"orders": {{Column: "asset_id", ReferencedTable: "assets", ReferencedColumn: "id"}},
+		},
+	}
+	c, err := assemble(f, nil)
+	if err != nil {
+		t.Fatalf("assemble() = %v", err)
+	}
+
+	assets := tableOf(t, c, "assets")
+	if pk := odcsdest.PrimaryKeyColumns(assets); len(pk) != 1 || pk[0] != "id" {
+		t.Errorf("assets PK = %v, want [id]", pk)
+	}
+	if u := odcs.UniqueConstraints(assets.CustomProperties); len(u) != 1 || u[0].Name != "assets_isin_unique" {
+		t.Errorf("assets unique = %+v", u)
+	}
+	isin := propOf(t, assets, "isin")
+	if w, ok := odcsdest.MaxCharacterLength(isin); !ok || w != 12 {
+		t.Errorf("isin width = (%d,%v), want 12", w, ok)
+	}
+
+	orders := tableOf(t, c, "orders")
+	// Column ordinal order is preserved.
+	if len(orders.Properties) != 3 || orders.Properties[0].Name != "order_id" || orders.Properties[2].Name != "note" {
+		t.Errorf("orders columns = %v, want [order_id asset_id note] in order", names(orders))
+	}
+	if ck := odcs.CheckConstraints(orders.CustomProperties); len(ck) != 1 || ck[0].Expression != "note IS NOT NULL" {
+		t.Errorf("orders checks = %+v, want the verbatim expression", ck)
+	}
+	fks := odcs.ForeignKeys(orders.CustomProperties)
+	if len(fks) != 1 || fks[0].Column != "asset_id" || fks[0].ReferencedTable != "assets" || fks[0].ReferencedColumn != "id" {
+		t.Errorf("orders FK = %+v, want asset_id -> assets(id)", fks)
+	}
+}
+
+func TestAssembleSkipsExcludedColumn(t *testing.T) {
+	f := facts{
+		tables: []string{"t"},
+		columns: []pgintrospect.Column{
+			col("t", "id", "integer", "NO"),
+			col("t", "secret", "text", "YES"),
+		},
+		pks: map[string][]string{"t": {"id"}},
+	}
+	c, err := assemble(f, toSet([]string{"secret"}))
+	if err != nil {
+		t.Fatalf("assemble() = %v", err)
+	}
+	tbl := tableOf(t, c, "t")
+	for _, p := range tbl.Properties {
+		if p.Name == "secret" {
+			t.Fatalf("assemble kept the excluded column secret")
+		}
+	}
+}
+
+func TestAssembleFailsClosedOnUnsupportedType(t *testing.T) {
+	f := facts{
+		tables: []string{"t"},
+		columns: []pgintrospect.Column{
+			col("t", "id", "integer", "NO"),
+			col("t", "blob", "bytea", "NO"),
+		},
+	}
+	_, err := assemble(f, nil)
+	if err == nil {
+		t.Fatal("assemble() = nil, want a fail-closed type error")
+	}
+	for _, want := range []string{"t", "blob", "bytea"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func TestAssembleEmptyIsInvalid(t *testing.T) {
+	_, err := assemble(facts{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "at least one table") {
+		t.Fatalf("assemble(no tables) = %v, want an invalid-contract error", err)
+	}
+}
+
+func TestWrapRead(t *testing.T) {
+	if wrapRead("columns", nil) != nil {
+		t.Errorf("wrapRead(nil) should be nil")
+	}
+	err := wrapRead("columns", sql.ErrConnDone)
+	if err == nil || !strings.Contains(err.Error(), "read columns") {
+		t.Errorf("wrapRead(err) = %v, want it tagged with the read name", err)
+	}
+}
+
+// withLen returns c carrying a declared character length.
+func withLen(c pgintrospect.Column, n int64) pgintrospect.Column {
+	c.CharMaxLength = nullInt64(n)
+	return c
+}
+
+func tableOf(t *testing.T, c odcs.Contract, name string) odcs.SchemaObject {
+	t.Helper()
+	for _, tbl := range c.Schema {
+		if tbl.Name == name {
+			return tbl
+		}
+	}
+	t.Fatalf("contract has no table %q", name)
+	return odcs.SchemaObject{}
+}
+
+func propOf(t *testing.T, tbl odcs.SchemaObject, name string) odcs.Property {
+	t.Helper()
+	for _, p := range tbl.Properties {
+		if p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("table %q has no column %q", tbl.Name, name)
+	return odcs.Property{}
+}
+
+func names(tbl odcs.SchemaObject) []string {
+	var out []string
+	for _, p := range tbl.Properties {
+		out = append(out, p.Name)
+	}
+	return out
+}

--- a/pgcontract/pgcontract.go
+++ b/pgcontract/pgcontract.go
@@ -1,0 +1,150 @@
+// Package pgcontract generates a FAITHFUL destination data contract from a live
+// Postgres database: it introspects the public schema through pgintrospect and
+// composes those catalog facts, via the odcsdest builders and the B1 type
+// mapping, into an odcs.Contract that carries exactly the destination's shape —
+// tables, exact-width columns (a bounded varchar/char keeps its length, each
+// integer its width, a numeric its precision and scale), primary keys, unique
+// constraints, verbatim CHECK constraints, single-column foreign keys (the
+// structural triple), and enum labels.
+//
+// It is the FAITHFUL CORE only. The contract it returns describes what the
+// destination DECLARES and nothing more; the delivery- and mirror-shaped POLICY
+// a platform layers on a destination contract — producer-optionality folding
+// (MP-3), merge-key selection (MP-2), surrogate/generated-column and
+// destination-not-null markers, safe column defaults, and a foreign key's
+// natural-key resolution columns — is applied by the caller as a post-pass over
+// this faithful contract, never here. A column's producer-side signals
+// (identity, generated, default) ride through on the pgintrospect.Column facts
+// for that policy layer to read; this package reads only the destination's RAW
+// nullability.
+//
+// It fails CLOSED: a column whose Postgres type is outside the reproducible
+// vocabulary is an error naming the column, never a guessed or dropped column,
+// and the assembled contract is validated before it is returned. It targets the
+// "public" schema only, the deliberate choice that keeps a managed Postgres
+// (e.g. Supabase) safe to point at.
+package pgcontract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/pgintrospect"
+)
+
+// Options carries the caller's exclusion policy. ExcludeTables names
+// platform-internal tables to withhold from the contract by name (a shared
+// control-plane database passes its own bookkeeping tables here; a dedicated
+// destination passes none). ExcludeColumns names columns to withhold across
+// every table, dropping whole any key or constraint that spans one. Both are
+// values the caller supplies, never hardcoded here, so the same generator
+// serves a shared database and a dedicated one.
+type Options struct {
+	ExcludeTables  []string
+	ExcludeColumns []string
+}
+
+// Generate introspects a Postgres destination through q and returns the
+// faithful destination contract (see the package doc). q is the combined
+// read/exec surface a *sql.DB satisfies; Generate performs catalog READS only
+// (the exec surface is part of the signature because the pgintrospect gateway a
+// caller shares exposes it, but the faithful generation never writes). Every
+// introspection query is scoped to the public schema.
+//
+// It runs each introspection query and JOINS their errors, so a database that
+// has gone away surfaces every query failure at once rather than just the
+// first. An unsupported column type is reported separately, as a fail-closed
+// contract error listing every offending column, because it is a contract
+// problem an operator corrects rather than a database failure. The returned
+// contract is validated before it is returned, so a caller never receives one
+// that would be rejected downstream.
+func Generate(ctx context.Context, q pgintrospect.ExecQuerier, opts Options) (odcs.Contract, error) {
+	if q == nil {
+		return odcs.Contract{}, errors.New("pgcontract: querier must be non-nil")
+	}
+	excludedTable := toSet(opts.ExcludeTables)
+	excludedColumn := toSet(opts.ExcludeColumns)
+
+	// Run every introspection query and JOIN their errors (each tagged with the
+	// read it came from), so a database that has gone away surfaces every query
+	// failure at once rather than just the first.
+	rawTables, tablesErr := pgintrospect.BaseTables(ctx, q, "public")
+	columns, columnsErr := pgintrospect.Columns(ctx, q)
+	rawPKs, pkErr := pgintrospect.PrimaryKeys(ctx, q)
+	rawUniques, uniqueErr := pgintrospect.UniqueConstraints(ctx, q)
+	rawChecks, checkErr := pgintrospect.CheckConstraints(ctx, q)
+	rawFKs, fkErr := pgintrospect.ForeignKeys(ctx, q)
+	if err := errors.Join(
+		wrapRead("base tables", tablesErr),
+		wrapRead("columns", columnsErr),
+		wrapRead("primary keys", pkErr),
+		wrapRead("unique constraints", uniqueErr),
+		wrapRead("check constraints", checkErr),
+		wrapRead("foreign keys", fkErr),
+	); err != nil {
+		return odcs.Contract{}, err
+	}
+
+	// Resolve each enum column's labels with a second, DB-touching pass (the
+	// labels are not in information_schema.columns). A query failure here is a
+	// database error, distinct from the fail-closed "USER-DEFINED type is not an
+	// enum" the empty-label set drives inside assemble.
+	enums, err := resolveEnumLabels(ctx, q, columns, excludedTable, excludedColumn)
+	if err != nil {
+		return odcs.Contract{}, err
+	}
+
+	return assemble(facts{
+		tables:  includedTables(rawTables, excludedTable),
+		columns: columns,
+		pks:     includedPrimaryKeys(rawPKs, excludedColumn),
+		uniques: includedUniques(rawUniques, excludedColumn),
+		checks:  includedChecks(rawChecks, excludedColumn),
+		fks:     singleColumnForeignKeys(rawFKs, excludedColumn),
+		enums:   enums,
+	}, excludedColumn)
+}
+
+// resolveEnumLabels reads the ordered labels of every enum column, keyed by the
+// enum's (schema, name) so a type used on many columns is read once. It is
+// schema-qualified (see pgintrospect.EnumValues) so a same-named enum in
+// another schema never interleaves its labels. An excluded table's or column's
+// enum is not read (it never reaches the contract). A USER-DEFINED type that is
+// not an enum resolves to an empty set, which assemble turns into a fail-closed
+// type error; a genuine query failure is returned as an error here.
+func resolveEnumLabels(ctx context.Context, q pgintrospect.Querier, columns []pgintrospect.Column, excludedTable, excludedColumn map[string]struct{}) (map[enumKey][]string, error) {
+	out := map[enumKey][]string{}
+	for _, col := range columns {
+		if col.DataType != userDefinedDataType {
+			continue
+		}
+		if _, skip := excludedTable[col.Table]; skip {
+			continue
+		}
+		if _, skip := excludedColumn[col.Name]; skip {
+			continue
+		}
+		key := enumKey{col.UDTSchema, col.UDTName}
+		if _, done := out[key]; done {
+			continue
+		}
+		labels, err := pgintrospect.EnumValues(ctx, q, key.schema, key.name)
+		if err != nil {
+			return nil, fmt.Errorf("pgcontract: enum labels for %q.%q: %w", key.schema, key.name, err)
+		}
+		out[key] = labels
+	}
+	return out, nil
+}
+
+// wrapRead tags an introspection read's error with the read it came from,
+// keeping Generate's error prefixes uniform, and passes a nil error through so
+// errors.Join drops the successful reads.
+func wrapRead(name string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("pgcontract: read %s: %w", name, err)
+}

--- a/pgcontract/pgcontract_integration_test.go
+++ b/pgcontract/pgcontract_integration_test.go
@@ -1,0 +1,664 @@
+//go:build integration
+
+// Fidelity fixtures for the faithful generator, run against a REAL Postgres via
+// the internal/pgtest harness. They reproduce the exact cases the move must not
+// regress — exact integer/varchar/char widths (#124/#82), a multi-column CHECK
+// (#155), enums (schema-qualified), arrays (DC-4 fail-closed), and single-column
+// foreign keys — and assert the generated odcs.Contract through the B1
+// accessors. They also PIN THE SCOPE LINE: a NOT NULL identity/defaulted column
+// is encoded NOT NULL here (the faithful shape), never folded to optional, which
+// is the policy a caller layers on afterwards.
+package pgcontract_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/internal/pgtest"
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/odcsdest"
+	"github.com/JacobJNilsson/data-contract-generator/pgcontract"
+)
+
+var pg *pgtest.Postgres
+
+func TestMain(m *testing.M) { os.Exit(run(m)) }
+
+func run(m *testing.M) int {
+	ctx := context.Background()
+	got, err := pgtest.Start(ctx)
+	if errors.Is(err, pgtest.ErrNoDocker) {
+		fmt.Fprintln(os.Stderr, "pgcontract: skipping integration tier:", err)
+		return 0
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "pgcontract: start Postgres:", err)
+		return 1
+	}
+	defer func() { _ = got.Close(ctx) }()
+	pg = got
+	return m.Run()
+}
+
+func exec(t *testing.T, db *sql.DB, stmt string) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), stmt); err != nil {
+		t.Fatalf("exec %q: %v", stmt, err)
+	}
+}
+
+func generate(t *testing.T, db *sql.DB, opts pgcontract.Options) odcs.Contract {
+	t.Helper()
+	c, err := pgcontract.Generate(context.Background(), db, opts)
+	if err != nil {
+		t.Fatalf("Generate() = %v, want nil", err)
+	}
+	return c
+}
+
+func tableByName(t *testing.T, c odcs.Contract, name string) odcs.SchemaObject {
+	t.Helper()
+	for _, tbl := range c.Schema {
+		if tbl.Name == name {
+			return tbl
+		}
+	}
+	t.Fatalf("contract has no table %q (tables: %v)", name, odcsdest.SortedTableNames(c))
+	return odcs.SchemaObject{}
+}
+
+func columnByName(t *testing.T, tbl odcs.SchemaObject, name string) odcs.Property {
+	t.Helper()
+	for _, col := range tbl.Properties {
+		if col.Name == name {
+			return col
+		}
+	}
+	t.Fatalf("table %q has no column %q", tbl.Name, name)
+	return odcs.Property{}
+}
+
+// TestGenerateCapturesShapeAndConstraints: a known schema with every constraint
+// shape and every scalar type round-trips into a faithful contract that
+// captures its columns (exact DDL types), widths, primary key, unique
+// constraint, and verbatim check.
+func TestGenerateCapturesShapeAndConstraints(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE gen_orders (
+		order_id      bigint PRIMARY KEY,
+		sku           varchar(64) NOT NULL,
+		currency      char(3),
+		unbounded     varchar,
+		descr         text,
+		amount        numeric NOT NULL,
+		quantity      integer NOT NULL,
+		shipped       boolean,
+		placed_at     timestamptz NOT NULL,
+		external_id   uuid,
+		ordered_on    date,
+		metadata      jsonb,
+		captured_at   timestamp,
+		rating        double precision,
+		discount      real,
+		CONSTRAINT gen_orders_sku_unique UNIQUE (sku),
+		CONSTRAINT gen_orders_amount_nonneg CHECK (amount >= 0)
+	)`)
+	exec(t, db, `CREATE TABLE gen_customers (customer_id integer PRIMARY KEY, name text NOT NULL)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS gen_orders, gen_customers`) })
+
+	c := generate(t, db, pgcontract.Options{})
+	orders := tableByName(t, c, "gen_orders")
+
+	wantCols := []struct {
+		name     string
+		ddl      string
+		nullable bool
+	}{
+		{"order_id", "bigint", false},
+		{"sku", "varchar(64)", false},
+		{"currency", "char(3)", true},
+		{"unbounded", "varchar", true},
+		{"descr", "text", true},
+		{"amount", "numeric", false},
+		{"quantity", "integer", false},
+		{"shipped", "boolean", true},
+		{"placed_at", "timestamptz", false},
+		{"external_id", "uuid", true},
+		{"ordered_on", "date", true},
+		{"metadata", "jsonb", true},
+		{"captured_at", "timestamp", true},
+		{"rating", "double precision", true},
+		{"discount", "real", true},
+	}
+	if len(orders.Properties) != len(wantCols) {
+		t.Fatalf("gen_orders has %d columns, want %d", len(orders.Properties), len(wantCols))
+	}
+	for i, want := range wantCols {
+		col := orders.Properties[i]
+		if col.Name != want.name {
+			t.Errorf("gen_orders column %d = %q, want %q", i, col.Name, want.name)
+			continue
+		}
+		if ddl, ok := odcsdest.PostgresDDLType(col); !ok || ddl != want.ddl {
+			t.Errorf("gen_orders %q DDL = (%q,%v), want %q", col.Name, ddl, ok, want.ddl)
+		}
+		if odcsdest.Nullable(col) != want.nullable {
+			t.Errorf("gen_orders %q nullable = %v, want %v", col.Name, odcsdest.Nullable(col), want.nullable)
+		}
+	}
+
+	wantWidths := map[string]int{"sku": 64, "currency": 3}
+	for _, col := range orders.Properties {
+		width, ok := odcsdest.MaxCharacterLength(col)
+		want, bounded := wantWidths[col.Name]
+		if ok != bounded || (bounded && width != want) {
+			t.Errorf("gen_orders %q width = (%d,%v), want (%d,%v)", col.Name, width, ok, want, bounded)
+		}
+	}
+
+	if pk := odcsdest.PrimaryKeyColumns(orders); len(pk) != 1 || pk[0] != "order_id" {
+		t.Errorf("gen_orders PK = %v, want [order_id]", pk)
+	}
+	uniques := odcs.UniqueConstraints(orders.CustomProperties)
+	if len(uniques) != 1 || uniques[0].Name != "gen_orders_sku_unique" || len(uniques[0].Columns) != 1 || uniques[0].Columns[0] != "sku" {
+		t.Errorf("gen_orders unique = %+v", uniques)
+	}
+	checks := odcs.CheckConstraints(orders.CustomProperties)
+	if len(checks) != 1 || checks[0].Name != "gen_orders_amount_nonneg" || checks[0].Expression == "" {
+		t.Errorf("gen_orders checks = %+v", checks)
+	}
+	if pk := odcsdest.PrimaryKeyColumns(tableByName(t, c, "gen_customers")); len(pk) != 1 || pk[0] != "customer_id" {
+		t.Errorf("gen_customers PK = %v, want [customer_id]", pk)
+	}
+}
+
+// TestGenerateFaithfulNullabilityNotFolded PINS THE SCOPE LINE (MP-3 policy is
+// NOT applied here): a NOT NULL identity primary key and a NOT NULL DEFAULT
+// column are encoded NOT NULL in the FAITHFUL contract, exactly as the
+// destination declares them. The orchestrator folds these to producer-optional
+// as a post-pass in a later stage; the library must not.
+func TestGenerateFaithfulNullabilityNotFolded(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE faithful_null (
+		id         bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+		created_at timestamptz NOT NULL DEFAULT now(),
+		plain      text NOT NULL,
+		note       text
+	)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS faithful_null`) })
+
+	tbl := tableByName(t, generate(t, db, pgcontract.Options{}), "faithful_null")
+	wantNullable := map[string]bool{
+		"id":         false, // identity NOT NULL — faithful contract keeps NOT NULL
+		"created_at": false, // NOT NULL DEFAULT now() — kept NOT NULL, not folded
+		"plain":      false, // plain NOT NULL
+		"note":       true,  // genuinely nullable
+	}
+	for name, want := range wantNullable {
+		if got := odcsdest.Nullable(columnByName(t, tbl, name)); got != want {
+			t.Errorf("%q nullable = %v, want %v (faithful raw nullability, MP-3 folding is a later policy pass)", name, got, want)
+		}
+	}
+	// No policy custom-properties leaked in: the faithful contract carries no
+	// merge-key, generated-column, or destination-not-null markers.
+	for _, key := range []string{"dcgMergeKey", "dcgGeneratedColumns", "dcgDestinationNotNull"} {
+		if _, ok := odcs.CustomProp(tbl.CustomProperties, key); ok {
+			t.Errorf("faithful contract leaked the policy marker %q", key)
+		}
+	}
+}
+
+// TestGenerateCapturesSelfContainedTypesExactly (#124/#82): each bounded
+// string's declared length and each integer's exact width survive, so a
+// consumer reproduces the type that REJECTS values rather than a widened one.
+func TestGenerateCapturesSelfContainedTypesExactly(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE mf1cap_types (
+		code    varchar(3) NOT NULL,
+		free    varchar,
+		padded  char(2) NOT NULL,
+		tiny    smallint NOT NULL,
+		normal  integer NOT NULL,
+		big     bigint NOT NULL,
+		codes   varchar[]
+	)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS mf1cap_types`) })
+
+	tbl := tableByName(t, generate(t, db, pgcontract.Options{}), "mf1cap_types")
+	wantDDL := map[string]string{
+		"code": "varchar(3)", "free": "varchar", "padded": "char(2)",
+		"tiny": "smallint", "normal": "integer", "big": "bigint", "codes": "varchar[]",
+	}
+	for name, want := range wantDDL {
+		col := columnByName(t, tbl, name)
+		if ddl, ok := odcsdest.PostgresDDLType(col); !ok || ddl != want {
+			t.Errorf("%q DDL = (%q,%v), want %q (exact, never widened)", name, ddl, ok, want)
+		}
+	}
+}
+
+// TestGenerateFailsClosedOnUnreproducibleStringShapes (#82): the string shapes
+// the vocabulary cannot reproduce fail CLOSED, naming the column.
+func TestGenerateFailsClosedOnUnreproducibleStringShapes(t *testing.T) {
+	cases := []struct{ name, ddl, want string }{
+		{"bounded varchar array element", `CREATE TABLE mf1cap_bad (codes varchar(3)[])`, `column "codes" has unsupported array element type character varying(3)`},
+		{"char array element", `CREATE TABLE mf1cap_bad (pads char[])`, `column "pads" has unsupported array element type character(1)`},
+		{"bare bpchar scalar", `CREATE TABLE mf1cap_bad (pad bpchar)`, `column "pad" has unsupported bare bpchar type`},
+		{"bare bpchar array element", `CREATE TABLE mf1cap_bad (pads bpchar[])`, `column "pads" has unsupported bare bpchar array element type`},
+	}
+	db := pg.Open(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec(t, db, tc.ddl)
+			t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS mf1cap_bad`) })
+			_, err := pgcontract.Generate(context.Background(), db, pgcontract.Options{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Generate() = %v, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestGenerateCapturesMultiColumnCheck (#155): a table-level multi-column CHECK
+// (a conditional NOT NULL) is captured, and the synthetic per-column NOT NULL
+// checks never appear.
+func TestGenerateCapturesMultiColumnCheck(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE checked_rows (
+		id                  integer PRIMARY KEY,
+		asset_id            integer,
+		instrument_currency text,
+		amount              numeric NOT NULL,
+		CONSTRAINT checked_amount_nonneg CHECK (amount >= 0),
+		CONSTRAINT checked_currency_present CHECK ((asset_id IS NULL) OR (instrument_currency IS NOT NULL))
+	)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS checked_rows`) })
+
+	tbl := tableByName(t, generate(t, db, pgcontract.Options{}), "checked_rows")
+	byName := map[string]string{}
+	for _, ck := range odcs.CheckConstraints(tbl.CustomProperties) {
+		byName[ck.Name] = ck.Expression
+	}
+	if len(byName) != 2 {
+		t.Fatalf("checks = %+v, want exactly two (no synthetic NOT NULL)", byName)
+	}
+	multi, ok := byName["checked_currency_present"]
+	if !ok {
+		t.Fatalf("multi-column check dropped: %+v", byName)
+	}
+	for _, want := range []string{"asset_id", "instrument_currency", "IS NOT NULL"} {
+		if !strings.Contains(multi, want) {
+			t.Errorf("multi-column check %q does not mention %q", multi, want)
+		}
+	}
+}
+
+// TestGenerateCapturesEnum: a USER-DEFINED enum column is captured with its type
+// name and labels in declared order.
+func TestGenerateCapturesEnum(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TYPE order_status AS ENUM ('pending', 'shipped', 'delivered')`)
+	exec(t, db, `CREATE TABLE enum_orders (id integer PRIMARY KEY, status order_status NOT NULL)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS enum_orders`)
+		_, _ = db.ExecContext(context.Background(), `DROP TYPE IF EXISTS order_status`)
+	})
+
+	status := columnByName(t, tableByName(t, generate(t, db, pgcontract.Options{}), "enum_orders"), "status")
+	if !odcsdest.IsEnum(status) || odcsdest.EnumName(status) != "order_status" {
+		t.Fatalf("status is not the expected enum: %+v", status)
+	}
+	if got := strings.Join(odcsdest.EnumLabels(status), ","); got != "pending,shipped,delivered" {
+		t.Errorf("enum labels = %q, want the declared order", got)
+	}
+	if odcsdest.Nullable(status) {
+		t.Errorf("status should be NOT NULL")
+	}
+}
+
+// TestGenerateResolvesEnumByItsOwnSchema: the enum-label lookup is
+// schema-qualified, so a same-named enum in another schema never interleaves
+// its labels.
+func TestGenerateResolvesEnumByItsOwnSchema(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE SCHEMA decoy`)
+	exec(t, db, `CREATE TYPE decoy.mood AS ENUM ('aaa_decoy1', 'aaa_decoy2', 'zzz_decoy3')`)
+	exec(t, db, `CREATE TYPE public.mood AS ENUM ('happy', 'sad')`)
+	exec(t, db, `CREATE TABLE mood_rows (id integer PRIMARY KEY, feel public.mood NOT NULL)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS mood_rows`)
+		_, _ = db.ExecContext(context.Background(), `DROP TYPE IF EXISTS public.mood`)
+		_, _ = db.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS decoy CASCADE`)
+	})
+
+	feel := columnByName(t, tableByName(t, generate(t, db, pgcontract.Options{}), "mood_rows"), "feel")
+	if got := strings.Join(odcsdest.EnumLabels(feel), ","); got != "happy,sad" {
+		t.Errorf("feel labels = %q, want ONLY the public enum [happy sad]", got)
+	}
+}
+
+// TestGenerateFailsClosedOnNonEnumUserDefined and its shadowed sibling: a
+// USER-DEFINED type that is not an enum fails closed, even when a same-named
+// enum exists in another schema.
+func TestGenerateFailsClosedOnNonEnumUserDefined(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TYPE addr AS (street text, city text)`)
+	exec(t, db, `CREATE TABLE has_composite (id integer PRIMARY KEY, where_at addr)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS has_composite`)
+		_, _ = db.ExecContext(context.Background(), `DROP TYPE IF EXISTS addr`)
+	})
+	_, err := pgcontract.Generate(context.Background(), db, pgcontract.Options{})
+	if err == nil {
+		t.Fatal("Generate() = nil, want fail-closed for a non-enum USER-DEFINED type")
+	}
+	for _, want := range []string{"has_composite", "where_at", "addr"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func TestGenerateFailsClosedOnCompositeShadowedBySameNamedEnum(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE SCHEMA decoy`)
+	exec(t, db, `CREATE TYPE decoy.mood AS ENUM ('aaa_decoy1', 'zzz_decoy2')`)
+	exec(t, db, `CREATE TYPE public.mood AS (a text, b text)`)
+	exec(t, db, `CREATE TABLE shadowed (id integer PRIMARY KEY, feel public.mood)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS shadowed`)
+		_, _ = db.ExecContext(context.Background(), `DROP TYPE IF EXISTS public.mood`)
+		_, _ = db.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS decoy CASCADE`)
+	})
+	_, err := pgcontract.Generate(context.Background(), db, pgcontract.Options{})
+	if err == nil {
+		t.Fatal("Generate() = nil, want fail-closed for a composite shadowed by a same-named enum")
+	}
+	for _, want := range []string{"shadowed", "feel", "mood"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestGenerateCapturesNumericPrecisionScale: a numeric(12,2) money column keeps
+// its precision and scale; an unconstrained numeric renders bare.
+func TestGenerateCapturesNumericPrecisionScale(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE numeric_ledger (
+		id integer PRIMARY KEY, amount numeric(12,2) NOT NULL, whole numeric(8), freeform numeric
+	)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS numeric_ledger`) })
+
+	ledger := tableByName(t, generate(t, db, pgcontract.Options{}), "numeric_ledger")
+	for _, tc := range []struct{ col, ddl string }{
+		{"amount", "numeric(12,2)"}, {"whole", "numeric(8,0)"}, {"freeform", "numeric"},
+	} {
+		if ddl, ok := odcsdest.PostgresDDLType(columnByName(t, ledger, tc.col)); !ok || ddl != tc.ddl {
+			t.Errorf("%s DDL = (%q,%v), want %q", tc.col, ddl, ok, tc.ddl)
+		}
+	}
+}
+
+// TestGenerateCapturesArray and its fail-closed sibling (DC-4): a
+// one-dimensional array of a supported scalar is captured; the array shapes the
+// contract cannot faithfully reproduce fail closed.
+func TestGenerateCapturesArray(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE array_orders (id integer PRIMARY KEY, tags text[] NOT NULL, costs numeric[])`)
+	t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS array_orders`) })
+
+	orders := tableByName(t, generate(t, db, pgcontract.Options{}), "array_orders")
+	if ddl, ok := odcsdest.PostgresDDLType(columnByName(t, orders, "tags")); !ok || ddl != "text[]" {
+		t.Errorf("tags DDL = (%q,%v), want text[]", ddl, ok)
+	}
+	if ddl, ok := odcsdest.PostgresDDLType(columnByName(t, orders, "costs")); !ok || ddl != "numeric[]" {
+		t.Errorf("costs DDL = (%q,%v), want numeric[]", ddl, ok)
+	}
+}
+
+func TestGenerateFailsClosedOnUnfaithfulArrays(t *testing.T) {
+	cases := []struct{ name, ddl, wantCol, wantMsg string }{
+		{"multi-dimensional", `CREATE TABLE bad_arr (id integer PRIMARY KEY, grid int[][] NOT NULL)`, "grid", "multi-dimensional"},
+		{"array of enum", `CREATE TYPE palette AS ENUM ('r','g','b'); CREATE TABLE bad_arr (id integer PRIMARY KEY, colors palette[] NOT NULL)`, "colors", "array element type"},
+		{"array of unsupported scalar", `CREATE TABLE bad_arr (id integer PRIMARY KEY, blobs bytea[] NOT NULL)`, "blobs", "array element type"},
+		{"array of numeric with precision", `CREATE TABLE bad_arr (id integer PRIMARY KEY, amounts numeric(12,2)[] NOT NULL)`, "amounts", "numeric(12,2)"},
+	}
+	db := pg.Open(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec(t, db, tc.ddl)
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS bad_arr`)
+				_, _ = db.ExecContext(context.Background(), `DROP TYPE IF EXISTS palette`)
+			})
+			_, err := pgcontract.Generate(context.Background(), db, pgcontract.Options{})
+			if err == nil {
+				t.Fatalf("Generate() = nil, want fail-closed for %s", tc.name)
+			}
+			for _, want := range []string{tc.wantCol, tc.wantMsg} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not mention %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestGenerateFailsClosedOnUnsupportedTypes: a type outside the vocabulary
+// (bytea) and a deliberately-excluded common type (json) both fail closed.
+func TestGenerateFailsClosedOnUnsupportedTypes(t *testing.T) {
+	cases := []struct {
+		name, ddl, drop string
+		want            []string
+	}{
+		{"bytea", `CREATE TABLE unsupported (id integer PRIMARY KEY, payload bytea NOT NULL)`, `DROP TABLE IF EXISTS unsupported`, []string{"unsupported", "payload", "bytea"}},
+		{"json", `CREATE TABLE has_json (id integer PRIMARY KEY, doc json NOT NULL)`, `DROP TABLE IF EXISTS has_json`, []string{"has_json", "doc", "json"}},
+	}
+	db := pg.Open(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec(t, db, tc.ddl)
+			t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), tc.drop) })
+			_, err := pgcontract.Generate(context.Background(), db, pgcontract.Options{})
+			if err == nil {
+				t.Fatalf("Generate() = nil, want fail-closed for %s", tc.name)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not mention %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestGenerateForeignKeysStructuralTripleOnly: a single-column FK is captured as
+// the structural triple (local column, referenced table, referenced column) and
+// carries NO policy extras (no natural-key match columns — that resolution is a
+// later policy pass). A composite FK is skipped; a control table is FK-free.
+func TestGenerateForeignKeysStructuralTripleOnly(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE assets (id bigserial PRIMARY KEY, isin text UNIQUE NOT NULL, name text NOT NULL)`)
+	exec(t, db, `CREATE TABLE venues (id bigserial PRIMARY KEY, note text)`)
+	exec(t, db, `CREATE TABLE transactions (
+		id bigserial PRIMARY KEY,
+		asset_id bigint NOT NULL REFERENCES assets(id),
+		venue_id bigint REFERENCES venues(id),
+		amount numeric NOT NULL
+	)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS transactions, assets, venues`)
+	})
+
+	c := generate(t, db, pgcontract.Options{})
+	tx := tableByName(t, c, "transactions")
+	fks := odcs.ForeignKeys(tx.CustomProperties)
+	byColumn := map[string]odcs.ForeignKey{}
+	for _, fk := range fks {
+		byColumn[fk.Column] = fk
+	}
+	if len(fks) != 2 {
+		t.Fatalf("transactions FKs = %+v, want two", fks)
+	}
+	if a := byColumn["asset_id"]; a.ReferencedTable != "assets" || a.ReferencedColumn != "id" {
+		t.Errorf("asset_id FK = %+v, want -> assets(id)", a)
+	}
+	if v := byColumn["venue_id"]; v.ReferencedTable != "venues" || v.ReferencedColumn != "id" {
+		t.Errorf("venue_id FK = %+v, want -> venues(id)", v)
+	}
+	// The faithful FK carries the structural triple ONLY: odcs.ForeignKey has no
+	// natural-key/attested/constant fields at all, so a policy extra is
+	// unrepresentable here by construction (a later policy pass re-adds them).
+	if got := odcs.ForeignKeys(tableByName(t, c, "assets").CustomProperties); got != nil {
+		t.Errorf("assets FKs = %+v, want nil", got)
+	}
+}
+
+func TestGenerateSkipsMultiColumnForeignKeys(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TABLE parts (maker text NOT NULL, code text NOT NULL, isin text UNIQUE NOT NULL, PRIMARY KEY (maker, code))`)
+	exec(t, db, `CREATE TABLE assemblies (
+		id bigserial PRIMARY KEY, part_maker text NOT NULL, part_code text NOT NULL,
+		FOREIGN KEY (part_maker, part_code) REFERENCES parts(maker, code)
+	)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS assemblies, parts`) })
+
+	asm := tableByName(t, generate(t, db, pgcontract.Options{}), "assemblies")
+	if got := odcs.ForeignKeys(asm.CustomProperties); len(got) != 0 {
+		t.Errorf("assemblies FKs = %+v, want none (composite skipped)", got)
+	}
+}
+
+// TestGenerateExclusions covers the Options exclusion policy end to end: an
+// excluded table, and an excluded column that drops the constraints spanning it
+// (unique, primary key, check, foreign key) whole.
+func TestGenerateExclusions(t *testing.T) {
+	t.Run("excluded table (a value, not a hardcode)", func(t *testing.T) {
+		db := pg.Open(t)
+		exec(t, db, `CREATE TABLE keep_me (id integer PRIMARY KEY)`)
+		exec(t, db, `CREATE TABLE pipeline_cache (id uuid PRIMARY KEY, blob jsonb)`)
+		t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS keep_me, pipeline_cache`) })
+		c := generate(t, db, pgcontract.Options{ExcludeTables: []string{"pipeline_cache"}})
+		for _, tbl := range c.Schema {
+			if tbl.Name == "pipeline_cache" {
+				t.Errorf("excluded table leaked")
+			}
+		}
+		_ = tableByName(t, c, "keep_me")
+	})
+
+	t.Run("excluded column drops its constraints whole", func(t *testing.T) {
+		db := pg.Open(t)
+		exec(t, db, `CREATE TABLE assets (id bigserial PRIMARY KEY, isin text UNIQUE NOT NULL)`)
+		exec(t, db, `CREATE TABLE keyed (
+			id      integer PRIMARY KEY,
+			ext_tag text NOT NULL,
+			ref_id  bigint REFERENCES assets(id),
+			CONSTRAINT keyed_ext_unique UNIQUE (ext_tag),
+			CONSTRAINT keyed_ext_len CHECK (length(ext_tag) > 0),
+			CONSTRAINT keyed_id_pos CHECK (id > 0)
+		)`)
+		exec(t, db, `CREATE TABLE pk_keyed (a integer NOT NULL, b integer NOT NULL, PRIMARY KEY (a, b))`)
+		t.Cleanup(func() { _, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS keyed, pk_keyed, assets`) })
+
+		c := generate(t, db, pgcontract.Options{ExcludeColumns: []string{"ext_tag", "b", "ref_id"}})
+		keyed := tableByName(t, c, "keyed")
+		if u := odcs.UniqueConstraints(keyed.CustomProperties); len(u) != 0 {
+			t.Errorf("unique over excluded column kept: %+v", u)
+		}
+		checks := odcs.CheckConstraints(keyed.CustomProperties)
+		if len(checks) != 1 || checks[0].Name != "keyed_id_pos" {
+			t.Errorf("checks = %+v, want only keyed_id_pos (excluded-column check dropped)", checks)
+		}
+		if fk := odcs.ForeignKeys(keyed.CustomProperties); len(fk) != 0 {
+			t.Errorf("FK over excluded column kept: %+v", fk)
+		}
+		if pk := odcsdest.PrimaryKeyColumns(tableByName(t, c, "pk_keyed")); len(pk) != 0 {
+			t.Errorf("primary key over excluded column kept: %v", pk)
+		}
+	})
+}
+
+// TestGenerateIntrospectsPublicSchemaOnly: a non-public schema and its tables
+// (deliberately using a type outside the vocabulary) never enter the contract,
+// so a nil error is itself proof those columns were never read.
+func TestGenerateIntrospectsPublicSchemaOnly(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE SCHEMA auth`)
+	exec(t, db, `CREATE TABLE auth.users (id uuid PRIMARY KEY, secret bytea NOT NULL)`)
+	exec(t, db, `CREATE TABLE app_users (id integer PRIMARY KEY, email text NOT NULL)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS app_users`)
+		_, _ = db.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS auth CASCADE`)
+	})
+
+	c := generate(t, db, pgcontract.Options{})
+	for _, tbl := range c.Schema {
+		if tbl.Name == "users" {
+			t.Errorf("leaked non-public auth.users")
+		}
+	}
+	if got := odcsdest.SortedTableNames(c); len(got) != 1 || got[0] != "app_users" {
+		t.Fatalf("tables = %v, want only [app_users]", got)
+	}
+}
+
+// TestGenerateNilQuerier: a nil handle is rejected, never a panic.
+func TestGenerateNilQuerier(t *testing.T) {
+	_, err := pgcontract.Generate(context.Background(), nil, pgcontract.Options{})
+	if err == nil || !strings.Contains(err.Error(), "non-nil") {
+		t.Fatalf("Generate(nil) = %v, want a non-nil-handle error", err)
+	}
+}
+
+// TestGenerateQueryError: a closed database surfaces a wrapped query error, not
+// an empty contract.
+func TestGenerateQueryError(t *testing.T) {
+	db := pg.Open(t)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	_, err := pgcontract.Generate(context.Background(), db, pgcontract.Options{})
+	if err == nil || !strings.Contains(err.Error(), "pgcontract") {
+		t.Fatalf("Generate(closed db) = %v, want a wrapped query error", err)
+	}
+}
+
+// TestGenerateEmptyIsInvalid: a database with no included tables yields a
+// fail-closed invalid-contract error, never an empty contract.
+func TestGenerateEmptyIsInvalid(t *testing.T) {
+	db := pg.Open(t)
+	_, err := pgcontract.Generate(context.Background(), db, pgcontract.Options{ExcludeTables: allPublicTables(t, db)})
+	if err == nil || !strings.Contains(err.Error(), "at least one table") {
+		t.Fatalf("Generate(no included tables) = %v, want an invalid-contract error", err)
+	}
+}
+
+// allPublicTables lists every public BASE TABLE so a test can exclude them all.
+func allPublicTables(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'`)
+	if err != nil {
+		t.Fatalf("list public tables: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		names = append(names, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+	return names
+}

--- a/pgcontract/pgcontract_integration_test.go
+++ b/pgcontract/pgcontract_integration_test.go
@@ -630,6 +630,96 @@ func TestGenerateQueryError(t *testing.T) {
 	}
 }
 
+// TestGenerateResolveEnumLabelsExclusionsAndCaching drives the enum-resolution
+// pass's remaining branches against a real server: an enum column in an
+// EXCLUDED table and an EXCLUDED enum column are both skipped by the pass (no
+// wasted read, and neither reaches the contract), and two columns sharing ONE
+// enum type read that type once (the cache hit) and resolve to the same labels.
+func TestGenerateResolveEnumLabelsExclusionsAndCaching(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TYPE status_a AS ENUM ('a1', 'a2')`)
+	exec(t, db, `CREATE TYPE status_b AS ENUM ('b1', 'b2')`)
+	exec(t, db, `CREATE TYPE status_c AS ENUM ('c1', 'c2')`)
+	exec(t, db, `CREATE TABLE enum_excluded_table (id integer PRIMARY KEY, s status_a NOT NULL)`)
+	exec(t, db, `CREATE TABLE enum_excluded_col (id integer PRIMARY KEY, dropme status_b NOT NULL)`)
+	exec(t, db, `CREATE TABLE enum_shared (id integer PRIMARY KEY, first status_c NOT NULL, second status_c NOT NULL)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS enum_excluded_table, enum_excluded_col, enum_shared`)
+		_, _ = db.ExecContext(context.Background(), `DROP TYPE IF EXISTS status_a, status_b, status_c`)
+	})
+
+	c := generate(t, db, pgcontract.Options{
+		ExcludeTables:  []string{"enum_excluded_table"},
+		ExcludeColumns: []string{"dropme"},
+	})
+
+	// The excluded table never appears, so its enum was skipped in the pass.
+	for _, tbl := range c.Schema {
+		if tbl.Name == "enum_excluded_table" {
+			t.Errorf("excluded enum table leaked")
+		}
+	}
+	// The excluded enum column is gone, but its table remains.
+	colExcluded := tableByName(t, c, "enum_excluded_col")
+	for _, p := range colExcluded.Properties {
+		if p.Name == "dropme" {
+			t.Errorf("excluded enum column dropme leaked")
+		}
+	}
+	// The two columns of one shared enum type both resolve to the same labels.
+	shared := tableByName(t, c, "enum_shared")
+	first := columnByName(t, shared, "first")
+	second := columnByName(t, shared, "second")
+	if !odcsdest.IsEnum(first) || !odcsdest.IsEnum(second) {
+		t.Fatalf("enum_shared columns are not both enums")
+	}
+	if strings.Join(odcsdest.EnumLabels(first), ",") != "c1,c2" || strings.Join(odcsdest.EnumLabels(second), ",") != "c1,c2" {
+		t.Errorf("shared enum labels differ: first=%v second=%v", odcsdest.EnumLabels(first), odcsdest.EnumLabels(second))
+	}
+}
+
+// failEnumQuerier delegates every read to a real *sql.DB EXCEPT the pg_enum
+// label lookup, which it fails with a real error. It exercises the enum-pass
+// error path (a healthy server never fails mid-flow, so this is the only way to
+// reach it) without faking any coverage: the six catalog reads run for real,
+// and only the injected enum failure is synthetic.
+type failEnumQuerier struct {
+	*sql.DB
+	err error
+}
+
+func (f failEnumQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if strings.Contains(query, "pg_enum") {
+		return nil, f.err
+	}
+	return f.DB.QueryContext(ctx, query, args...)
+}
+
+// TestGenerateEnumLabelQueryError proves the enum-label pass surfaces a genuine
+// query failure (not a fail-closed type error, and never a label-less enum): the
+// six catalog reads succeed against the real server, and the injected pg_enum
+// failure propagates out of Generate tagged with the enum context.
+func TestGenerateEnumLabelQueryError(t *testing.T) {
+	db := pg.Open(t)
+	exec(t, db, `CREATE TYPE boom_status AS ENUM ('x', 'y')`)
+	exec(t, db, `CREATE TABLE enum_boom (id integer PRIMARY KEY, s boom_status NOT NULL)`)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), `DROP TABLE IF EXISTS enum_boom`)
+		_, _ = db.ExecContext(context.Background(), `DROP TYPE IF EXISTS boom_status`)
+	})
+
+	q := failEnumQuerier{DB: db, err: errors.New("enum boom")}
+	_, err := pgcontract.Generate(context.Background(), q, pgcontract.Options{})
+	if err == nil {
+		t.Fatal("Generate() = nil, want the enum-label query error")
+	}
+	for _, want := range []string{"enum labels", "enum boom"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
 // TestGenerateEmptyIsInvalid: a database with no included tables yields a
 // fail-closed invalid-contract error, never an empty contract.
 func TestGenerateEmptyIsInvalid(t *testing.T) {

--- a/pgcontract/validate.go
+++ b/pgcontract/validate.go
@@ -1,0 +1,179 @@
+package pgcontract
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/odcsdest"
+)
+
+// maxIdentifierLength is the byte budget for a single SQL identifier the
+// faithful contract accepts. Postgres truncates identifiers at 63 bytes
+// (NAMEDATALEN-1); the contract rejects anything longer rather than let two
+// distinct names silently collapse to one, which would corrupt fidelity.
+const maxIdentifierLength = 63
+
+// identifierPattern is the conservative grammar for a contract identifier: an
+// ASCII letter or underscore followed by ASCII letters, digits, or
+// underscores. It is deliberately narrower than what Postgres would
+// quote-accept — a generated contract has no need for spaces, punctuation, or
+// Unicode in identifiers — and is a defence-in-depth barrier behind quoting.
+var identifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// validate checks the FAITHFUL contract fails closed, joining every violation
+// so a malformed contract surfaces all its problems at once. It enforces the
+// structural invariants a faithfully introspected contract must hold: at least
+// one table; unique, valid table identifiers; per table at least one column,
+// unique valid column identifiers, and a faithfully representable type; enum
+// label consistency; and unique/foreign-key column references that resolve to
+// real columns.
+//
+// It validates the faithful shape ONLY. The policy-layer markers a caller adds
+// afterwards (merge key, generated columns, destination-not-null, foreign-key
+// natural-key resolution) carry their own validation with that policy; they are
+// out of scope here.
+func validate(c odcs.Contract) error {
+	var errs []error
+	if len(c.Schema) == 0 {
+		errs = append(errs, errors.New("contract must declare at least one table"))
+	}
+	seenTables := make(map[string]struct{}, len(c.Schema))
+	for _, table := range c.Schema {
+		if err := validIdentifier("table", table.Name); err != nil {
+			errs = append(errs, err)
+		} else if _, dup := seenTables[table.Name]; dup {
+			errs = append(errs, fmt.Errorf("duplicate table name %q", table.Name))
+		} else {
+			seenTables[table.Name] = struct{}{}
+		}
+		errs = append(errs, validateTable(table)...)
+	}
+	errs = append(errs, validateEnumConsistency(c)...)
+	return errors.Join(errs...)
+}
+
+// validateTable checks one schema object, returning every violation (not
+// joined, so validate can join across tables): column presence and uniqueness,
+// valid column identifiers, a faithfully representable type per column, and
+// unique/foreign-key references that resolve to real columns.
+func validateTable(t odcs.SchemaObject) []error {
+	var errs []error
+	if len(t.Properties) == 0 {
+		errs = append(errs, fmt.Errorf("table %q must declare at least one column", t.Name))
+	}
+	cols := make(map[string]struct{}, len(t.Properties))
+	for _, col := range t.Properties {
+		if err := validIdentifier("column", col.Name); err != nil {
+			errs = append(errs, fmt.Errorf("table %q: %w", t.Name, err))
+			continue
+		}
+		if _, dup := cols[col.Name]; dup {
+			errs = append(errs, fmt.Errorf("table %q: duplicate column name %q", t.Name, col.Name))
+			continue
+		}
+		cols[col.Name] = struct{}{}
+		if err := validateProperty(t.Name, col); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// A unique constraint must span real columns, so the mirror never renders a
+	// UNIQUE over a column the table lacks. The introspected path always names
+	// real columns (an excluded-column constraint is dropped whole), so this is
+	// a defensive fail-closed guard against a hand-edited contract.
+	for _, u := range odcs.UniqueConstraints(t.CustomProperties) {
+		for _, c := range u.Columns {
+			if _, ok := cols[c]; !ok {
+				errs = append(errs, fmt.Errorf("table %q: unique constraint %q references unknown column %q", t.Name, u.Name, c))
+			}
+		}
+	}
+
+	// A foreign key's local (referencing) column must exist on the table. Only
+	// the LOCAL column is reference-checked: the referenced table may
+	// legitimately lie outside the public-schema scope, so its presence is not
+	// required (an unresolvable FK is represented faithfully, not rejected).
+	for _, fk := range odcs.ForeignKeys(t.CustomProperties) {
+		if _, ok := cols[fk.Column]; !ok {
+			errs = append(errs, fmt.Errorf("table %q: foreign key references unknown column %q", t.Name, fk.Column))
+		}
+	}
+	return errs
+}
+
+// validateProperty checks one property's type is faithfully representable by
+// the B1 accessors a consumer reads: an enum must name a valid type and carry
+// at least one non-empty label; every other column must resolve to a Postgres
+// DDL type. The check IS the accessor — odcsdest.PostgresDDLType returns
+// ok=false for exactly the shapes a consumer cannot render — so a contract that
+// validates is one every accessor can place.
+func validateProperty(table string, col odcs.Property) error {
+	if odcsdest.IsEnum(col) {
+		if err := validIdentifier("enum type", odcsdest.EnumName(col)); err != nil {
+			return fmt.Errorf("table %q column %q: %w", table, col.Name, err)
+		}
+		labels := odcsdest.EnumLabels(col)
+		if len(labels) == 0 {
+			return fmt.Errorf("table %q column %q: enum must declare at least one label", table, col.Name)
+		}
+		for _, label := range labels {
+			if label == "" {
+				return fmt.Errorf("table %q column %q: enum label must be non-empty", table, col.Name)
+			}
+		}
+		return nil
+	}
+	if _, ok := odcsdest.PostgresDDLType(col); !ok {
+		return fmt.Errorf("table %q column %q: unsupported column type (logicalType %q, physicalType %q)", table, col.Name, col.LogicalType, col.PhysicalType)
+	}
+	return nil
+}
+
+// validateEnumConsistency rejects a contract in which two enum columns share an
+// enum type name but declare DIFFERENT ordered label sets: a consumer stands
+// one type up per distinct enum NAME, so two columns naming the same enum must
+// agree on its labels or the second would silently get the wrong values. A
+// faithfully introspected public-schema contract never trips this (its enum
+// names are unique); the guard fails a cross-schema-collision or hand-edited
+// contract closed.
+func validateEnumConsistency(c odcs.Contract) []error {
+	labels := map[string][]string{}
+	var errs []error
+	for _, table := range c.Schema {
+		for _, col := range table.Properties {
+			if !odcsdest.IsEnum(col) {
+				continue
+			}
+			name := odcsdest.EnumName(col)
+			got := odcsdest.EnumLabels(col)
+			if first, seen := labels[name]; seen {
+				if !slices.Equal(first, got) {
+					errs = append(errs, fmt.Errorf("table %q column %q: enum %q declares labels %v, conflicting with the same-named enum's labels %v elsewhere in the contract", table.Name, col.Name, name, got, first))
+				}
+				continue
+			}
+			labels[name] = got
+		}
+	}
+	return errs
+}
+
+// validIdentifier checks that name is a usable contract identifier: non-empty,
+// within the length budget, and matching the conservative grammar. It is the
+// single gate every table, column, and enum name passes, so a name Postgres
+// would truncate or one smuggling punctuation is rejected at validation.
+func validIdentifier(kind, name string) error {
+	if name == "" {
+		return fmt.Errorf("%s name must be non-empty", kind)
+	}
+	if len(name) > maxIdentifierLength {
+		return fmt.Errorf("%s name %q exceeds %d bytes", kind, name, maxIdentifierLength)
+	}
+	if !identifierPattern.MatchString(name) {
+		return fmt.Errorf("%s name %q must match %s", kind, name, identifierPattern.String())
+	}
+	return nil
+}

--- a/pgcontract/validate_test.go
+++ b/pgcontract/validate_test.go
@@ -1,0 +1,144 @@
+package pgcontract
+
+// Fast-tier unit tests for the pure faithful validator, driving each violation
+// branch with a hand-built contract (no database).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/odcs"
+	"github.com/JacobJNilsson/data-contract-generator/odcsdest"
+)
+
+// okTable builds a minimal valid one-column table.
+func okTable(name string) odcs.SchemaObject {
+	return odcsdest.Table(name, []odcs.Property{odcsdest.IntegerColumn("id", false)}, []string{"id"})
+}
+
+func TestValidateHappy(t *testing.T) {
+	c := odcsdest.NewContract(
+		okTable("assets"),
+		odcsdest.Table("orders",
+			[]odcs.Property{odcsdest.BigintColumn("order_id", false), odcsdest.EnumColumn("status", false, "order_status", []string{"pending", "shipped"})},
+			[]string{"order_id"}),
+	)
+	if err := validate(c); err != nil {
+		t.Fatalf("validate(valid) = %v, want nil", err)
+	}
+}
+
+func TestValidateEmpty(t *testing.T) {
+	if err := validate(odcs.Contract{}); err == nil || !strings.Contains(err.Error(), "at least one table") {
+		t.Fatalf("validate(empty) = %v, want an at-least-one-table error", err)
+	}
+}
+
+func TestValidateStructuralViolations(t *testing.T) {
+	cases := []struct {
+		name     string
+		contract odcs.Contract
+		want     string
+	}{
+		{
+			name:     "duplicate table",
+			contract: odcs.Contract{Schema: []odcs.SchemaObject{okTable("dup"), okTable("dup")}},
+			want:     `duplicate table name "dup"`,
+		},
+		{
+			name:     "invalid table identifier",
+			contract: odcs.Contract{Schema: []odcs.SchemaObject{okTable("bad name")}},
+			want:     "table name",
+		},
+		{
+			name:     "table with no columns",
+			contract: odcs.Contract{Schema: []odcs.SchemaObject{{Name: "empty"}}},
+			want:     `table "empty" must declare at least one column`,
+		},
+		{
+			name: "duplicate column",
+			contract: odcs.Contract{Schema: []odcs.SchemaObject{{Name: "t", Properties: []odcs.Property{
+				odcsdest.IntegerColumn("id", false), odcsdest.TextColumn("id", true),
+			}}}},
+			want: `duplicate column name "id"`,
+		},
+		{
+			name: "invalid column identifier",
+			contract: odcs.Contract{Schema: []odcs.SchemaObject{{Name: "t", Properties: []odcs.Property{
+				odcsdest.IntegerColumn("bad col", false),
+			}}}},
+			want: "column name",
+		},
+		{
+			name: "unsupported column type",
+			contract: odcs.Contract{Schema: []odcs.SchemaObject{{Name: "t", Properties: []odcs.Property{
+				{Name: "weird", LogicalType: odcs.LogicalString, PhysicalType: "nonsense"},
+			}}}},
+			want: "unsupported column type",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validate(tc.contract)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("validate() = %v, want an error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateEnumViolations(t *testing.T) {
+	cases := []struct {
+		name string
+		col  odcs.Property
+		want string
+	}{
+		{"invalid enum name", odcsdest.EnumColumn("s", false, "bad type", []string{"a"}), "enum type name"},
+		{"enum with no labels", odcsdest.EnumColumn("s", false, "mood", nil), "at least one label"},
+		{"enum with empty label", odcsdest.EnumColumn("s", false, "mood", []string{""}), "label must be non-empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := odcs.Contract{Schema: []odcs.SchemaObject{{Name: "t", Properties: []odcs.Property{tc.col}}}}
+			err := validate(c)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("validate() = %v, want an error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateEnumConsistencyConflict(t *testing.T) {
+	c := odcs.Contract{Schema: []odcs.SchemaObject{
+		{Name: "a", Properties: []odcs.Property{odcsdest.EnumColumn("s", false, "mood", []string{"happy", "sad"})}},
+		{Name: "b", Properties: []odcs.Property{odcsdest.EnumColumn("s", false, "mood", []string{"up", "down"})}},
+	}}
+	err := validate(c)
+	if err == nil || !strings.Contains(err.Error(), "conflicting with the same-named enum") {
+		t.Fatalf("validate(enum conflict) = %v, want a conflict error", err)
+	}
+}
+
+func TestValidateConstraintReferenceViolations(t *testing.T) {
+	unique := odcsdest.WithUnique(okTable("t"), odcs.UniqueConstraint{Name: "u_ghost", Columns: []string{"ghost"}})
+	if err := validate(odcs.Contract{Schema: []odcs.SchemaObject{unique}}); err == nil || !strings.Contains(err.Error(), `unique constraint "u_ghost" references unknown column "ghost"`) {
+		t.Errorf("validate(unique over unknown column) = %v, want a reference error", err)
+	}
+
+	fk := odcsdest.WithForeignKeys(okTable("t"), odcs.ForeignKey{Column: "ghost", ReferencedTable: "other", ReferencedColumn: "id"})
+	if err := validate(odcs.Contract{Schema: []odcs.SchemaObject{fk}}); err == nil || !strings.Contains(err.Error(), `foreign key references unknown column "ghost"`) {
+		t.Errorf("validate(FK over unknown column) = %v, want a reference error", err)
+	}
+}
+
+func TestValidIdentifier(t *testing.T) {
+	if err := validIdentifier("table", ""); err == nil || !strings.Contains(err.Error(), "non-empty") {
+		t.Errorf("validIdentifier(empty) = %v", err)
+	}
+	if err := validIdentifier("table", strings.Repeat("x", maxIdentifierLength+1)); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("validIdentifier(too long) = %v", err)
+	}
+	if err := validIdentifier("table", "ok_name1"); err != nil {
+		t.Errorf("validIdentifier(valid) = %v, want nil", err)
+	}
+}

--- a/pgintrospect/pgintrospect.go
+++ b/pgintrospect/pgintrospect.go
@@ -1,0 +1,676 @@
+// Package pgintrospect is the live-Postgres catalog gateway: every
+// information_schema and pg_constraint read the destination-contract path
+// performs against a relational database, plus the identifier quoting that
+// renders catalog-sourced names into SQL, live here and nowhere else.
+//
+// Each function returns the catalog's FACTS and nothing more. What a fact
+// MEANS for a generated contract — which tables to exclude, which foreign keys
+// a contract represents, how a column's producer-side signals fold into its
+// nullability — is POLICY that lives with the caller (pgcontract and, beyond
+// it, an orchestrator layering delivery/mirror conventions), never here. The
+// queries were consolidated from a single relational consumer verbatim: each
+// method's SQL is the exact text that consumer carried.
+//
+// Why one home: catalog reads encode information_schema quirks and identifier
+// quoting, and quoting bugs are injection bugs. A single package makes the next
+// tightening land everywhere at once rather than leaving a duplicated copy
+// exploitable.
+//
+// The read surface is an interface (Querier) satisfied by *sql.DB and *sql.Tx
+// alike, so a caller reading on a pool and a caller reading inside a
+// transaction share one gateway. NormalizeCheckExpression additionally writes
+// (a savepoint-scoped scratch constraint), so it takes the combined
+// ExecQuerier and needs a live server — it cannot be faithfully faked.
+package pgintrospect
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Querier is the read surface every catalog query runs through, satisfied by
+// *sql.DB and *sql.Tx alike: a fidelity check reads inside transactions while
+// the contract generator reads on a pool.
+type Querier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// Execer is the statement surface the non-read catalog operations
+// (PinSearchPath and NormalizeCheckExpression's savepoint-scoped scratch
+// constraint) run through, satisfied by *sql.DB and *sql.Tx. It is separate
+// from Querier because almost every catalog operation is a pure read.
+type Execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// ExecQuerier is the combined surface NormalizeCheckExpression needs: it
+// executes the savepoint-scoped scratch DDL AND reads the resulting
+// pg_constraint row on the SAME transaction (a transaction sees its own DDL),
+// so the two surfaces must be one handle. *sql.Tx satisfies it.
+type ExecQuerier interface {
+	Execer
+	Querier
+}
+
+// QuoteIdentifier renders a SQL identifier safely by wrapping it in double
+// quotes and doubling any embedded double quote, the Postgres rule for a
+// quoted identifier. It is the single choke point through which every
+// catalog-sourced schema, table, column, and constraint name passes before it
+// is concatenated into SQL, so an untrusted identifier can never break out of
+// its quotes into executable SQL. Identifiers are still grammar-validated by
+// the contract layer; quoting is the belt-and-braces second barrier.
+func QuoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// QuoteLiteral renders a string as a SQL string literal, doubling embedded
+// single quotes. It quotes VALUES (never identifiers); every NAME is quoted
+// with QuoteIdentifier instead.
+//
+// It doubles single quotes ONLY and so relies on standard_conforming_strings
+// = on (the Postgres default since 9.1), under which a backslash in a regular
+// '...' literal is an ordinary character with no escape meaning. That GUC is
+// the default and is not changed anywhere this code runs, so this is safe
+// today. If a future deployment ever turned standard_conforming_strings off,
+// this would need to emit an E'...' literal with backslashes doubled too; it
+// is left as plain single-quote doubling to avoid the added rendering surface
+// while the GUC dependency holds.
+func QuoteLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+// BaseTables returns one schema's BASE TABLE names, sorted. The schema name is
+// a bound parameter (a value comparison, never an identifier position), so the
+// catalog query carries no injection surface.
+func BaseTables(ctx context.Context, q Querier, schema string) ([]string, error) {
+	const query = `SELECT table_name FROM information_schema.tables
+	                WHERE table_schema = $1 AND table_type = 'BASE TABLE'
+	                ORDER BY table_name`
+	var tables []string
+	err := forEachRow(ctx, q, query, []any{schema}, func(rows *sql.Rows) error {
+		var name string
+		err := rows.Scan(&name)
+		if err == nil {
+			tables = append(tables, name)
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tables, nil
+}
+
+// SchemaExists reports whether a schema is present. The schema name is a bound
+// parameter, so the lookup carries no injection surface.
+func SchemaExists(ctx context.Context, q Querier, schema string) (bool, error) {
+	const query = `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.schemata WHERE schema_name = $1
+		)`
+	exists := false
+	err := forEachRow(ctx, q, query, []any{schema}, func(rows *sql.Rows) error {
+		return rows.Scan(&exists)
+	})
+	return exists, err
+}
+
+// Column is one row of the contract generator's column introspection: the
+// column's identity and nullability plus the signals compound-type resolution
+// needs (the enum type name via UDTName, the array element's friendly
+// data_type and the declared array dimension count) and the producer-side
+// signals that a POLICY layer reads to decide whether a NOT NULL column is
+// populated by the pipeline or by the database (IsIdentity, IsGenerated,
+// HasDefault). What the signals MEAN is the caller's policy; this struct only
+// carries the catalog's facts.
+type Column struct {
+	// Table and Name identify the column.
+	Table string
+	Name  string
+
+	// DataType is information_schema.columns.data_type.
+	DataType string
+
+	// Nullable is is_nullable ("YES"/"NO").
+	Nullable string
+
+	// IsIdentity is is_identity ("YES" for an identity column), IsGenerated
+	// is is_generated ("ALWAYS" for a generated column), and HasDefault is
+	// (column_default IS NOT NULL) scanned as a bool.
+	IsIdentity  string
+	IsGenerated string
+	HasDefault  bool
+
+	// IsSequenceDefault is true when column_default is a nextval(...) call,
+	// the shape a SERIAL/BIGSERIAL column carries.
+	IsSequenceDefault bool
+
+	// Default is the column's raw normalised DEFAULT expression
+	// (information_schema.columns.column_default), NULL when the column
+	// declares none.
+	Default sql.NullString
+
+	// UDTName and UDTSchema name the column's underlying type and the schema
+	// it lives in (an enum column's own type).
+	UDTName   string
+	UDTSchema string
+
+	// ElementDataType is the array element's friendly data_type (empty for a
+	// non-array column) and ArrayDims the declared dimension count
+	// (pg_attribute.attndims, 0 for a non-array column).
+	ElementDataType string
+	ArrayDims       int
+
+	// CharMaxLength carries a bounded string column's declared length
+	// (character_maximum_length); Postgres reports it NULL for text, for an
+	// unbounded varchar, and for every non-string column.
+	CharMaxLength sql.NullInt64
+
+	// NumericPrecision and NumericScale carry a numeric column's declared
+	// precision and scale; NULL for an unconstrained numeric and for every
+	// non-numeric column.
+	NumericPrecision sql.NullInt64
+	NumericScale     sql.NullInt64
+
+	// ElementTypeMod is the type modifier (pg_attribute.atttypmod) of the
+	// column's own pg_attribute row: -1 when the type is unconstrained, the
+	// packed precision/scale when it is constrained. For an ARRAY column the
+	// array's atttypmod carries the ELEMENT's modifier.
+	ElementTypeMod int
+}
+
+// Columns returns every public-schema column in (table, ordinal) order.
+//
+// The query joins two extra catalogs onto information_schema.columns so an
+// array column is resolved in one pass: element_types gives the element's
+// friendly data_type (the same vocabulary the scalar map keys on),
+// pg_attribute.attndims gives the declared dimension count so a
+// multi-dimensional array (attndims > 1) fails closed, and
+// pg_attribute.atttypmod carries the array element's type modifier so a
+// precision-bearing numeric element (numeric(p,s)[]) fails closed rather than
+// being silently widened. A non-array column's element data_type is NULL, its
+// attndims is 0, and its scalar numeric precision is read from
+// c.numeric_precision instead, so the array joins are inert for scalars and
+// enums.
+//
+// It targets the "public" schema ONLY, the deliberate choice that keeps a
+// managed Postgres safe to point at: a provider's internal schemas hold types
+// outside the vocabulary, so introspecting only public returns only the
+// customer's own tables.
+func Columns(ctx context.Context, q Querier) ([]Column, error) {
+	const query = `SELECT c.table_name, c.column_name, c.data_type, c.is_nullable,
+	                      c.is_identity, c.is_generated, (c.column_default IS NOT NULL) AS has_default,
+	                      COALESCE(c.column_default LIKE 'nextval(%', false) AS is_sequence_default,
+	                      c.column_default,
+	                      c.udt_name, c.udt_schema,
+	                      COALESCE(et.data_type, '') AS element_data_type,
+	                      COALESCE(at.attndims, 0) AS array_dims,
+	                      c.character_maximum_length,
+	                      c.numeric_precision, c.numeric_scale,
+	                      COALESCE(at.atttypmod, -1) AS element_type_mod
+	                 FROM information_schema.columns c
+	                 LEFT JOIN information_schema.element_types et
+	                   ON c.table_catalog = et.object_catalog
+	                  AND c.table_schema = et.object_schema
+	                  AND c.table_name = et.object_name
+	                  AND et.object_type = 'TABLE'
+	                  AND c.dtd_identifier = et.collection_type_identifier
+	                 LEFT JOIN pg_namespace ns ON ns.nspname = c.table_schema
+	                 LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = ns.oid
+	                 LEFT JOIN pg_attribute at ON at.attrelid = cl.oid AND at.attname = c.column_name
+	                WHERE c.table_schema = 'public'
+	                ORDER BY c.table_name, c.ordinal_position`
+	var out []Column
+	err := forEachRow(ctx, q, query, nil, func(rows *sql.Rows) error {
+		var c Column
+		err := rows.Scan(&c.Table, &c.Name, &c.DataType, &c.Nullable, &c.IsIdentity, &c.IsGenerated, &c.HasDefault, &c.IsSequenceDefault, &c.Default, &c.UDTName, &c.UDTSchema, &c.ElementDataType, &c.ArrayDims, &c.CharMaxLength, &c.NumericPrecision, &c.NumericScale, &c.ElementTypeMod)
+		if err == nil {
+			out = append(out, c)
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// EnumValues returns an enum type's allowed labels in declared order
+// (enumsortorder), the order Postgres uses for the enum's comparisons. A
+// (schema, name) with no rows in pg_enum (a USER-DEFINED type that is not an
+// enum, or a dropped type) returns an empty slice, which the contract
+// generator treats as a fail-closed unsupported type rather than an empty
+// enum.
+//
+// The lookup is SCHEMA-QUALIFIED on purpose. An enum name alone is not unique
+// across a database: a managed Postgres (e.g. Supabase) defines enums in its
+// own auth/storage/realtime schemas, so a same-named enum in another schema
+// would, with a name-only filter, make pg_enum return the interleaved union of
+// both enums' labels (ordered by enumsortorder across types) and corrupt the
+// contract. Joining pg_namespace and filtering on the column's own udt_schema
+// resolves the EXACT type the column references.
+func EnumValues(ctx context.Context, q Querier, schema, typeName string) ([]string, error) {
+	const query = `SELECT e.enumlabel
+	                 FROM pg_enum e
+	                 JOIN pg_type t ON t.oid = e.enumtypid
+	                 JOIN pg_namespace n ON n.oid = t.typnamespace
+	                WHERE t.typname = $1 AND n.nspname = $2
+	                ORDER BY e.enumsortorder`
+	var labels []string
+	err := forEachRow(ctx, q, query, []any{typeName, schema}, func(rows *sql.Rows) error {
+		var label string
+		err := rows.Scan(&label)
+		if err == nil {
+			labels = append(labels, label)
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return labels, nil
+}
+
+// PrimaryKeys returns each public-schema table's primary-key column names in
+// key order, keyed by table name. A table with no primary key is simply
+// absent.
+func PrimaryKeys(ctx context.Context, q Querier) (map[string][]string, error) {
+	const query = `SELECT tc.table_name, kcu.column_name
+	                 FROM information_schema.table_constraints tc
+	                 JOIN information_schema.key_column_usage kcu
+	                   ON kcu.constraint_name = tc.constraint_name
+	                  AND kcu.constraint_schema = tc.constraint_schema
+	                WHERE tc.table_schema = 'public' AND tc.constraint_type = 'PRIMARY KEY'
+	                ORDER BY tc.table_name, kcu.ordinal_position`
+	pks := map[string][]string{}
+	err := forEachRow(ctx, q, query, nil, func(rows *sql.Rows) error {
+		var table, column string
+		err := rows.Scan(&table, &column)
+		if err == nil {
+			pks[table] = append(pks[table], column)
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pks, nil
+}
+
+// UniqueConstraint is one public-schema UNIQUE constraint: its table, name,
+// and spanned columns in key order.
+type UniqueConstraint struct {
+	Table   string
+	Name    string
+	Columns []string
+}
+
+// UniqueConstraints returns every public-schema non-primary UNIQUE constraint
+// in deterministic (table, constraint name, ordinal) encounter order.
+func UniqueConstraints(ctx context.Context, q Querier) ([]UniqueConstraint, error) {
+	const query = `SELECT tc.table_name, tc.constraint_name, kcu.column_name
+	                 FROM information_schema.table_constraints tc
+	                 JOIN information_schema.key_column_usage kcu
+	                   ON kcu.constraint_name = tc.constraint_name
+	                  AND kcu.constraint_schema = tc.constraint_schema
+	                WHERE tc.table_schema = 'public' AND tc.constraint_type = 'UNIQUE'
+	                ORDER BY tc.table_name, tc.constraint_name, kcu.ordinal_position`
+	var out []UniqueConstraint
+	idx := map[[2]string]int{}
+	err := forEachRow(ctx, q, query, nil, func(rows *sql.Rows) error {
+		var table, constraint, column string
+		err := rows.Scan(&table, &constraint, &column)
+		if err != nil {
+			return err
+		}
+		k := [2]string{table, constraint}
+		i, ok := idx[k]
+		if !ok {
+			i = len(out)
+			idx[k] = i
+			out = append(out, UniqueConstraint{Table: table, Name: constraint})
+		}
+		out[i].Columns = append(out[i].Columns, column)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ForeignKey is one public-schema FOREIGN KEY constraint: its referencing
+// table and columns, the referenced table and columns (pairwise, in
+// constraint order), and the constraint's declared column count so a consumer
+// can tell a composite key from a single-column one.
+type ForeignKey struct {
+	Table             string
+	Name              string
+	NumColumns        int
+	Columns           []string
+	ReferencedTable   string
+	ReferencedColumns []string
+}
+
+// ForeignKeys returns every public-schema FOREIGN KEY in deterministic
+// (table, constraint name, ordinal) encounter order. It reads pg_constraint
+// (contype = 'f') and unnests conkey/confkey against pg_attribute to recover
+// the local referencing columns and the referenced columns, scoping BOTH the
+// referencing and the referenced table to the public schema so a cross-schema
+// FK (a reference into a provider's internal schema on a managed Postgres)
+// never enters the public-only contract.
+func ForeignKeys(ctx context.Context, q Querier) ([]ForeignKey, error) {
+	const query = `SELECT rel.relname AS table_name,
+	                      con.conname,
+	                      att.attname AS column_name,
+	                      frel.relname AS referenced_table,
+	                      fatt.attname AS referenced_column,
+	                      array_length(con.conkey, 1) AS num_cols
+	                 FROM pg_constraint con
+	                 JOIN pg_class rel ON rel.oid = con.conrelid
+	                 JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+	                 JOIN pg_class frel ON frel.oid = con.confrelid
+	                 JOIN pg_namespace fns ON fns.oid = frel.relnamespace
+	                 JOIN LATERAL unnest(con.conkey, con.confkey) WITH ORDINALITY
+	                        AS k(local_attnum, ref_attnum, ord) ON true
+	                 JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.local_attnum
+	                 JOIN pg_attribute fatt ON fatt.attrelid = con.confrelid AND fatt.attnum = k.ref_attnum
+	                WHERE con.contype = 'f'
+	                  AND ns.nspname = 'public'
+	                  AND fns.nspname = 'public'
+	                ORDER BY rel.relname, con.conname, k.ord`
+	var out []ForeignKey
+	idx := map[[2]string]int{}
+	err := forEachRow(ctx, q, query, nil, func(rows *sql.Rows) error {
+		var table, constraint, column, refTable, refColumn string
+		var numCols int
+		if err := rows.Scan(&table, &constraint, &column, &refTable, &refColumn, &numCols); err != nil {
+			return err
+		}
+		k := [2]string{table, constraint}
+		i, ok := idx[k]
+		if !ok {
+			i = len(out)
+			idx[k] = i
+			out = append(out, ForeignKey{Table: table, Name: constraint, ReferencedTable: refTable, NumColumns: numCols})
+		}
+		out[i].Columns = append(out[i].Columns, column)
+		out[i].ReferencedColumns = append(out[i].ReferencedColumns, refColumn)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CheckConstraint is one public-schema CHECK constraint: its table, name, the
+// verbatim expression as pg_get_expr renders it, and the columns it
+// constrains (empty when the check constrains no column).
+type CheckConstraint struct {
+	Table      string
+	Name       string
+	Expression string
+	Columns    []string
+}
+
+// CheckConstraints returns every public-schema CHECK constraint in
+// deterministic (table, constraint name) encounter order, capturing BOTH
+// single-column and table-level multi-column checks. It reads pg_constraint
+// (contype = 'c') directly, taking the expression from pg_get_expr(conbin,
+// conrelid) and the constrained columns from conkey unnested against
+// pg_attribute.
+//
+// Reading pg_constraint rather than information_schema.check_constraints is
+// what makes a multi-column check faithful: information_schema fabricates
+// SYNTHETIC per-column NOT NULL checks that would need a lossy substring
+// filter, while pg_constraint carries only real CHECK constraints under
+// contype = 'c' (a column's NOT NULL is attnotnull, not a 'c' row).
+func CheckConstraints(ctx context.Context, q Querier) ([]CheckConstraint, error) {
+	// One row per (constraint, constrained column): the conkey columns are
+	// LEFT-unnested so a check that constrains no column still yields one row
+	// (with a NULL column). The expression is identical on every row of a
+	// constraint.
+	const query = `SELECT rel.relname AS table_name,
+	                      con.conname,
+	                      pg_get_expr(con.conbin, con.conrelid) AS expr,
+	                      att.attname AS column_name
+	                 FROM pg_constraint con
+	                 JOIN pg_class rel ON rel.oid = con.conrelid
+	                 JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+	                 LEFT JOIN LATERAL unnest(con.conkey) AS k(attnum) ON true
+	                 LEFT JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.attnum
+	                WHERE con.contype = 'c' AND ns.nspname = 'public'
+	                ORDER BY rel.relname, con.conname`
+	var out []CheckConstraint
+	idx := map[[2]string]int{}
+	err := forEachRow(ctx, q, query, nil, func(rows *sql.Rows) error {
+		var table, constraint string
+		var expr, column sql.NullString
+		if err := rows.Scan(&table, &constraint, &expr, &column); err != nil {
+			return err
+		}
+		k := [2]string{table, constraint}
+		i, ok := idx[k]
+		if !ok {
+			i = len(out)
+			idx[k] = i
+			out = append(out, CheckConstraint{Table: table, Name: constraint, Expression: expr.String})
+		}
+		if column.Valid {
+			out[i].Columns = append(out[i].Columns, column.String)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// PinSearchPath pins the current transaction's search_path to one schema, so
+// pg_get_expr renders a schema-local type (a run-scoped enum in a CHECK cast)
+// UNQUALIFIED, exactly as the destination renders its own public-schema types.
+// set_config(..., true) is transaction-local, so the pin dies with the
+// caller's transaction and never leaks into a pooled session.
+func PinSearchPath(ctx context.Context, e Execer, schema string) error {
+	_, err := e.ExecContext(ctx, `SELECT set_config('search_path', $1, true)`, schema)
+	return err
+}
+
+// ColumnFacts is one column's rejection-deciding catalog facts, a fidelity
+// snapshot unit: exactly the self-contained facts that decide whether a value
+// is REJECTED (data type, declared length, numeric precision and scale,
+// nullability, and the underlying type name that distinguishes one enum or
+// array element from another). Absent numeric facts are normalised to -1 (the
+// catalog reports them NULL) so the struct stays comparable.
+type ColumnFacts struct {
+	Table            string
+	Column           string
+	DataType         string
+	CharMax          int64
+	NumericPrecision int64
+	NumericScale     int64
+	Nullable         string
+	UDTName          string
+}
+
+// ColumnFactsOf reads every column's rejection-deciding facts for one schema
+// from information_schema, in (table, ordinal) order. The absent-fact
+// COALESCEs keep the scan NULL-free so ColumnFacts stays a plain comparable
+// struct.
+func ColumnFactsOf(ctx context.Context, q Querier, schema string) ([]ColumnFacts, error) {
+	const query = `SELECT table_name, column_name, data_type,
+	       COALESCE(character_maximum_length, -1),
+	       COALESCE(numeric_precision, -1),
+	       COALESCE(numeric_scale, -1),
+	       is_nullable, udt_name
+	  FROM information_schema.columns
+	 WHERE table_schema = $1
+	 ORDER BY table_name, ordinal_position`
+	var out []ColumnFacts
+	err := forEachRow(ctx, q, query, []any{schema}, func(rows *sql.Rows) error {
+		var f ColumnFacts
+		if err := rows.Scan(&f.Table, &f.Column, &f.DataType, &f.CharMax, &f.NumericPrecision, &f.NumericScale, &f.Nullable, &f.UDTName); err != nil {
+			return err
+		}
+		out = append(out, f)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ConstraintFacts is one constraint's catalog facts for the fidelity
+// snapshot: its table, its contype ('c'/'u'/'p'), the expression text for a
+// CHECK (pg_get_expr, which re-renders the parsed tree, so byte-equal text on
+// both sides means semantically equal constraints over equally typed
+// columns), and the ordered constrained column names for a key.
+type ConstraintFacts struct {
+	Table      string
+	Type       string
+	Expression string
+	Columns    string
+}
+
+// ConstraintFactsOf reads one schema's CHECK, UNIQUE, and PRIMARY KEY
+// constraints from pg_constraint, in (table, constraint name) order. contype
+// 'f' (FOREIGN KEY) is deliberately outside the filter: a fidelity check that
+// keeps FKs out of scope must not see them.
+func ConstraintFactsOf(ctx context.Context, q Querier, schema string) ([]ConstraintFacts, error) {
+	const query = `SELECT rel.relname,
+	       con.contype::text,
+	       COALESCE(pg_get_expr(con.conbin, con.conrelid), ''),
+	       COALESCE((SELECT string_agg(att.attname, ', ' ORDER BY k.ord)
+	          FROM unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord)
+	          JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.attnum), '')
+	  FROM pg_constraint con
+	  JOIN pg_class rel ON rel.oid = con.conrelid
+	  JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+	 WHERE ns.nspname = $1 AND con.contype IN ('c', 'u', 'p')
+	 ORDER BY rel.relname, con.conname`
+	var out []ConstraintFacts
+	err := forEachRow(ctx, q, query, []any{schema}, func(rows *sql.Rows) error {
+		var f ConstraintFacts
+		if err := rows.Scan(&f.Table, &f.Type, &f.Expression, &f.Columns); err != nil {
+			return err
+		}
+		out = append(out, f)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// normCheckConstraint is the scratch constraint name NormalizeCheckExpression
+// applies and rolls back. The leading underscore is an identifier the contract
+// grammar never produces, so the scratch name can never collide with a real
+// constraint on the relation it is briefly attached to.
+const normCheckConstraint = "_pgintrospect_check_norm"
+
+// NormalizeCheckExpression parses one CHECK expression on the EXECUTING server
+// and returns that server's own deparse of it (issue #192): the expression is
+// applied to the named relation as a savepoint-scoped scratch constraint, its
+// stored tree is read back through pg_get_expr, and the savepoint is rolled
+// back so the caller's transaction keeps exactly the state it had.
+//
+// Why this exists: pg_get_expr's deparse does not round-trip through the
+// parser textually. The destination deparses an IN-authored varchar CHECK with
+// a WHOLE-ARRAY cast ("(ARRAY['buy'::character varying, ...])::text[]");
+// re-parsing that text folds the cast onto each element, so a copy created
+// FROM the deparsed text deparses differently ("ARRAY[('buy'::character
+// varying)::text, ...]") — same constraint, two renderings, no version skew.
+// Comparing deparsed strings from TWO servers is therefore unsound; pushing
+// both sides through ONE server's parse-and-deparse first makes string
+// equality mean tree equality on that server.
+//
+// The expression is rendered verbatim into the scratch DDL. It is pg_get_expr
+// output read from a trusted catalog (the destination's or the mirror's own);
+// schema and table are quoted identifiers.
+//
+// An expression the server cannot apply to the relation (a column the relation
+// lacks, an unknown function or type) is returned VERBATIM with no error: the
+// caller's textual comparison then still sees the two sides differ and fails
+// closed, naming the expression — the same fail-open-parse, fail-closed-compare
+// posture the membership reduction takes. Plumbing failures a healthy server
+// never produces (a failed savepoint, a failed read-back) are errors.
+func NormalizeCheckExpression(ctx context.Context, q ExecQuerier, schema, table, expr string) (string, error) {
+	// The savepoint scopes the scratch constraint: rolling back to it removes
+	// the constraint whether the ALTER succeeded or not (and clears the
+	// aborted-subtransaction state a failed ALTER leaves), so the caller's
+	// transaction commits none of this.
+	if _, err := q.ExecContext(ctx, "SAVEPOINT "+normCheckConstraint); err != nil {
+		return "", fmt.Errorf("savepoint for CHECK normalization: %w", err)
+	}
+	// NOT VALID skips validating existing rows: only the parsed tree is
+	// wanted, never a data scan.
+	alter := fmt.Sprintf("ALTER TABLE %s.%s ADD CONSTRAINT %s CHECK (%s) NOT VALID",
+		QuoteIdentifier(schema), QuoteIdentifier(table), QuoteIdentifier(normCheckConstraint), expr)
+	_, alterErr := q.ExecContext(ctx, alter)
+	normalized, readErr := "", error(nil)
+	if alterErr == nil {
+		normalized, readErr = normalizedCheckOf(ctx, q, schema, table)
+	}
+	if _, err := q.ExecContext(ctx, "ROLLBACK TO SAVEPOINT "+normCheckConstraint); err != nil {
+		return "", fmt.Errorf("roll back CHECK normalization savepoint: %w", err)
+	}
+	if alterErr != nil {
+		return expr, nil
+	}
+	if readErr != nil {
+		return "", readErr
+	}
+	return normalized, nil
+}
+
+// normalizedCheckOf reads the scratch constraint's deparse back from
+// pg_constraint on the same transaction that just applied it. A missing row is
+// an error, never an empty pass: the caller only reads after a successful
+// ALTER, so an absent constraint means the read went to the wrong place.
+func normalizedCheckOf(ctx context.Context, q Querier, schema, table string) (string, error) {
+	const query = `SELECT pg_get_expr(con.conbin, con.conrelid)
+	  FROM pg_constraint con
+	  JOIN pg_class rel ON rel.oid = con.conrelid
+	  JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+	 WHERE ns.nspname = $1 AND rel.relname = $2 AND con.conname = $3`
+	expr, found := "", false
+	err := forEachRow(ctx, q, query, []any{schema, table, normCheckConstraint}, func(rows *sql.Rows) error {
+		found = true
+		return rows.Scan(&expr)
+	})
+	if err != nil {
+		return "", fmt.Errorf("read back normalized CHECK: %w", err)
+	}
+	if !found {
+		return "", errors.New("read back normalized CHECK: scratch constraint not found in pg_constraint")
+	}
+	return expr, nil
+}
+
+// forEachRow runs one query with its bind arguments and feeds every row
+// through scan: the single query-iterate-scan choke point every catalog read
+// shares, so the error paths are exercised once. The scan error short-circuits
+// the loop and wins over rows.Err, because the first failure is the one worth
+// reporting.
+func forEachRow(ctx context.Context, q Querier, query string, args []any, scan func(rows *sql.Rows) error) error {
+	rows, err := q.QueryContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	scanErr := error(nil)
+	for scanErr == nil && rows.Next() {
+		scanErr = scan(rows)
+	}
+	if scanErr == nil {
+		scanErr = rows.Err()
+	}
+	return scanErr
+}

--- a/pgintrospect/pgintrospect_integration_test.go
+++ b/pgintrospect/pgintrospect_integration_test.go
@@ -1,0 +1,446 @@
+//go:build integration
+
+// These tests run every pgintrospect query against a REAL Postgres (via the
+// internal/pgtest harness), so the SQL's meaning is asserted where only a live
+// server can prove it: that the catalog joins resolve real widths, arrays, and
+// enums; and — the fidelity-critical case — that NormalizeCheckExpression
+// (issue #192) really collapses two textually-different deparse renderings of
+// ONE constraint to a single string on the executing server. #192 cannot be
+// faked: the round-trip depends on the server's own parser folding a
+// whole-array cast onto its elements, so this is the only place it is proven.
+package pgintrospect_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/internal/pgtest"
+	"github.com/JacobJNilsson/data-contract-generator/pgintrospect"
+)
+
+// pg is the shared Postgres for this test binary, started in TestMain.
+var pg *pgtest.Postgres
+
+func TestMain(m *testing.M) { os.Exit(run(m)) }
+
+func run(m *testing.M) int {
+	ctx := context.Background()
+	got, err := pgtest.Start(ctx)
+	if errors.Is(err, pgtest.ErrNoDocker) {
+		fmt.Fprintln(os.Stderr, "pgintrospect: skipping integration tier:", err)
+		return 0
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "pgintrospect: start Postgres:", err)
+		return 1
+	}
+	defer func() { _ = got.Close(ctx) }()
+	pg = got
+	return m.Run()
+}
+
+// execAll runs each statement in order, failing the test on the first error.
+func execAll(t *testing.T, db *sql.DB, stmts ...string) {
+	t.Helper()
+	for _, s := range stmts {
+		if _, err := db.ExecContext(context.Background(), s); err != nil {
+			t.Fatalf("exec %q: %v", s, err)
+		}
+	}
+}
+
+// TestCatalogReadsAgainstRealPostgres exercises the shape-and-constraint reads
+// against a live server on one rich schema: exact widths and an array (Columns),
+// a primary key, a unique constraint, a single-column and a composite foreign
+// key, and a multi-column CHECK (#155). It asserts the raw catalog facts the
+// contract layer builds on, not the contract itself.
+func TestCatalogReadsAgainstRealPostgres(t *testing.T) {
+	db := pg.Open(t)
+	ctx := context.Background()
+
+	execAll(t, db,
+		`CREATE TABLE cat_assets (
+			id   bigint PRIMARY KEY,
+			isin varchar(12) NOT NULL,
+			CONSTRAINT cat_assets_isin_unique UNIQUE (isin)
+		)`,
+		`CREATE TABLE cat_orders (
+			order_id   bigint PRIMARY KEY,
+			asset_id   bigint NOT NULL REFERENCES cat_assets(id),
+			code       varchar(3) NOT NULL,
+			tags       text[],
+			amount     numeric(12,2) NOT NULL,
+			note       text,
+			CONSTRAINT cat_orders_amount_nonneg CHECK (amount >= 0),
+			CONSTRAINT cat_orders_note_rule CHECK ((code IS NULL) OR (note IS NOT NULL))
+		)`,
+	)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS cat_orders, cat_assets`)
+	})
+
+	tables, err := pgintrospect.BaseTables(ctx, db, "public")
+	if err != nil {
+		t.Fatalf("BaseTables() = %v", err)
+	}
+	if !contains(tables, "cat_assets") || !contains(tables, "cat_orders") {
+		t.Fatalf("BaseTables() = %v, want it to include cat_assets and cat_orders", tables)
+	}
+
+	cols, err := pgintrospect.Columns(ctx, db)
+	if err != nil {
+		t.Fatalf("Columns() = %v", err)
+	}
+	byName := map[string]pgintrospect.Column{}
+	for _, c := range cols {
+		if c.Table == "cat_orders" {
+			byName[c.Name] = c
+		}
+	}
+	if got := byName["code"]; !got.CharMaxLength.Valid || got.CharMaxLength.Int64 != 3 || got.DataType != "character varying" || got.Nullable != "NO" {
+		t.Errorf("cat_orders.code = %+v, want varchar(3) NOT NULL", got)
+	}
+	if got := byName["amount"]; got.DataType != "numeric" || !got.NumericPrecision.Valid || got.NumericPrecision.Int64 != 12 || !got.NumericScale.Valid || got.NumericScale.Int64 != 2 {
+		t.Errorf("cat_orders.amount = %+v, want numeric(12,2)", got)
+	}
+	if got := byName["tags"]; got.DataType != "ARRAY" || got.ElementDataType != "text" || got.ArrayDims != 1 {
+		t.Errorf("cat_orders.tags = %+v, want a one-dimensional text[]", got)
+	}
+
+	pks, err := pgintrospect.PrimaryKeys(ctx, db)
+	if err != nil {
+		t.Fatalf("PrimaryKeys() = %v", err)
+	}
+	if want := []string{"order_id"}; !reflect.DeepEqual(pks["cat_orders"], want) {
+		t.Errorf("cat_orders primary key = %v, want %v", pks["cat_orders"], want)
+	}
+
+	uniques, err := pgintrospect.UniqueConstraints(ctx, db)
+	if err != nil {
+		t.Fatalf("UniqueConstraints() = %v", err)
+	}
+	foundUnique := false
+	for _, u := range uniques {
+		if u.Table == "cat_assets" && u.Name == "cat_assets_isin_unique" && reflect.DeepEqual(u.Columns, []string{"isin"}) {
+			foundUnique = true
+		}
+	}
+	if !foundUnique {
+		t.Errorf("UniqueConstraints() = %+v, want cat_assets_isin_unique over [isin]", uniques)
+	}
+
+	fks, err := pgintrospect.ForeignKeys(ctx, db)
+	if err != nil {
+		t.Fatalf("ForeignKeys() = %v", err)
+	}
+	foundFK := false
+	for _, fk := range fks {
+		if fk.Table == "cat_orders" && fk.NumColumns == 1 && reflect.DeepEqual(fk.Columns, []string{"asset_id"}) &&
+			fk.ReferencedTable == "cat_assets" && reflect.DeepEqual(fk.ReferencedColumns, []string{"id"}) {
+			foundFK = true
+		}
+	}
+	if !foundFK {
+		t.Errorf("ForeignKeys() = %+v, want cat_orders.asset_id -> cat_assets(id)", fks)
+	}
+
+	checks, err := pgintrospect.CheckConstraints(ctx, db)
+	if err != nil {
+		t.Fatalf("CheckConstraints() = %v", err)
+	}
+	// The multi-column check (#155) is captured with BOTH its columns, proving
+	// pg_constraint (not information_schema's synthetic per-column NOT NULL
+	// rows) is the source.
+	var multi pgintrospect.CheckConstraint
+	for _, ck := range checks {
+		if ck.Name == "cat_orders_note_rule" {
+			multi = ck
+		}
+	}
+	if multi.Name == "" || multi.Expression == "" {
+		t.Fatalf("CheckConstraints() dropped the multi-column check cat_orders_note_rule: %+v", checks)
+	}
+	if !reflect.DeepEqual(multi.Columns, []string{"code", "note"}) {
+		t.Errorf("cat_orders_note_rule columns = %v, want [code note]", multi.Columns)
+	}
+}
+
+// TestEnumValuesSchemaQualified proves EnumValues resolves the EXACT type the
+// column references: a same-named enum in another schema must not interleave
+// its labels into the public enum's.
+func TestEnumValuesSchemaQualified(t *testing.T) {
+	db := pg.Open(t)
+	ctx := context.Background()
+
+	execAll(t, db,
+		`CREATE SCHEMA enum_decoy`,
+		`CREATE TYPE enum_decoy.mood AS ENUM ('aaa_decoy', 'zzz_decoy')`,
+		`CREATE TYPE public.mood AS ENUM ('happy', 'sad')`,
+	)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DROP TYPE IF EXISTS public.mood`)
+		_, _ = db.ExecContext(ctx, `DROP SCHEMA IF EXISTS enum_decoy CASCADE`)
+	})
+
+	got, err := pgintrospect.EnumValues(ctx, db, "public", "mood")
+	if err != nil {
+		t.Fatalf("EnumValues() = %v", err)
+	}
+	if want := []string{"happy", "sad"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("EnumValues(public, mood) = %v, want ONLY the public enum's labels %v", got, want)
+	}
+	// A USER-DEFINED type that is not an enum resolves to an empty set (the
+	// contract layer treats that as a fail-closed unsupported type).
+	empty, err := pgintrospect.EnumValues(ctx, db, "public", "does_not_exist")
+	if err != nil || len(empty) != 0 {
+		t.Errorf("EnumValues(missing) = %v, %v; want an empty set and no error", empty, err)
+	}
+}
+
+// TestSchemaExistsAndFacts proves SchemaExists and the fidelity-snapshot facts
+// reads (ColumnFactsOf, ConstraintFactsOf) run against a real server.
+func TestSchemaExistsAndFacts(t *testing.T) {
+	db := pg.Open(t)
+	ctx := context.Background()
+
+	if ok, err := pgintrospect.SchemaExists(ctx, db, "public"); err != nil || !ok {
+		t.Fatalf("SchemaExists(public) = %v, %v; want true, nil", ok, err)
+	}
+	if ok, err := pgintrospect.SchemaExists(ctx, db, "no_such_schema"); err != nil || ok {
+		t.Fatalf("SchemaExists(absent) = %v, %v; want false, nil", ok, err)
+	}
+
+	execAll(t, db, `CREATE TABLE facts_t (
+		id     integer PRIMARY KEY,
+		code   varchar(3) NOT NULL,
+		CONSTRAINT facts_t_code_len CHECK (length((code)::text) > 0)
+	)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS facts_t`) })
+
+	colFacts, err := pgintrospect.ColumnFactsOf(ctx, db, "public")
+	if err != nil {
+		t.Fatalf("ColumnFactsOf() = %v", err)
+	}
+	var codeFact pgintrospect.ColumnFacts
+	for _, f := range colFacts {
+		if f.Table == "facts_t" && f.Column == "code" {
+			codeFact = f
+		}
+	}
+	if codeFact.DataType != "character varying" || codeFact.CharMax != 3 || codeFact.Nullable != "NO" {
+		t.Errorf("facts_t.code facts = %+v, want character varying, CharMax 3, NOT NULL", codeFact)
+	}
+
+	conFacts, err := pgintrospect.ConstraintFactsOf(ctx, db, "public")
+	if err != nil {
+		t.Fatalf("ConstraintFactsOf() = %v", err)
+	}
+	sawCheck := false
+	for _, f := range conFacts {
+		if f.Table == "facts_t" && f.Type == "c" && strings.Contains(f.Expression, "length") {
+			sawCheck = true
+		}
+	}
+	if !sawCheck {
+		t.Errorf("ConstraintFactsOf() = %+v, want the facts_t CHECK expression", conFacts)
+	}
+}
+
+// TestNormalizeCheckExpressionRoundTrip is the #192 fidelity proof against a
+// LIVE server. A varchar membership CHECK authored as IN(...) deparses with a
+// WHOLE-ARRAY cast; a copy created FROM that deparsed text re-parses with the
+// cast folded onto each element, so the two renderings are byte-different yet
+// the same constraint. NormalizeCheckExpression must collapse both to ONE
+// string on the executing server, so string equality of the normalized forms
+// means tree equality. This cannot be faked — it depends on the server's own
+// parser folding the cast.
+func TestNormalizeCheckExpressionRoundTrip(t *testing.T) {
+	db := pg.Open(t)
+	ctx := context.Background()
+
+	execAll(t, db, `CREATE TABLE norm_src (
+		side varchar(8) NOT NULL,
+		CONSTRAINT norm_src_side_in CHECK (side IN ('buy', 'sell'))
+	)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS norm_src, norm_copy`) })
+
+	// D1: the destination's own deparse of the IN check — a whole-array cast.
+	d1 := checkExpr(t, db, "norm_src", "norm_src_side_in")
+	if !strings.Contains(d1, "::text[]") {
+		t.Fatalf("norm_src deparse %q does not carry the whole-array cast the round-trip needs", d1)
+	}
+
+	// A copy created FROM D1 re-parses it: Postgres folds the whole-array cast
+	// onto each element, so its deparse D2 differs textually from D1.
+	execAll(t, db, fmt.Sprintf(`CREATE TABLE norm_copy (
+		side varchar(8) NOT NULL,
+		CONSTRAINT norm_copy_side_in CHECK (%s)
+	)`, d1))
+	d2 := checkExpr(t, db, "norm_copy", "norm_copy_side_in")
+	if d1 == d2 {
+		t.Fatalf("the fixture no longer isolates the round-trip: D1 and D2 are byte-equal (%q)", d1)
+	}
+	if strings.Contains(d2, "::text[]") {
+		t.Fatalf("D2 %q still carries the whole-array cast; the copy did not fold it", d2)
+	}
+
+	// Normalizing each rendering on ONE server collapses them to one string.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	n1, err := pgintrospect.NormalizeCheckExpression(ctx, tx, "public", "norm_src", d1)
+	if err != nil {
+		t.Fatalf("NormalizeCheckExpression(D1) = %v", err)
+	}
+	n2, err := pgintrospect.NormalizeCheckExpression(ctx, tx, "public", "norm_copy", d2)
+	if err != nil {
+		t.Fatalf("NormalizeCheckExpression(D2) = %v", err)
+	}
+	if n1 != n2 {
+		t.Errorf("normalized forms differ: N1 = %q, N2 = %q; #192 requires them equal", n1, n2)
+	}
+	if n1 == d1 {
+		t.Errorf("normalization was a no-op on D1 (%q); the fixture is not exercising #192", d1)
+	}
+
+	// The savepoint rolled back: norm_src still carries only its original
+	// constraint, no scratch constraint leaked into the transaction.
+	checks, err := pgintrospect.CheckConstraints(ctx, tx)
+	if err != nil {
+		t.Fatalf("CheckConstraints() after normalize = %v", err)
+	}
+	for _, ck := range checks {
+		if strings.Contains(ck.Name, "_pgintrospect_check_norm") {
+			t.Errorf("scratch constraint leaked: %+v", ck)
+		}
+	}
+}
+
+// TestNormalizeCheckExpressionInapplicableLive proves the fail-open-parse
+// posture against a real server: an expression the relation cannot satisfy (a
+// column it lacks) returns VERBATIM with no error, so a caller's comparison
+// still fails closed on it, and the transaction stays usable afterwards.
+func TestNormalizeCheckExpressionInapplicableLive(t *testing.T) {
+	db := pg.Open(t)
+	ctx := context.Background()
+
+	execAll(t, db, `CREATE TABLE norm_inapplicable (side text NOT NULL)`)
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS norm_inapplicable`) })
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const expr = `(missing_column > 0)`
+	got, err := pgintrospect.NormalizeCheckExpression(ctx, tx, "public", "norm_inapplicable", expr)
+	if err != nil {
+		t.Fatalf("NormalizeCheckExpression(inapplicable) = %v, want nil (fail-open parse)", err)
+	}
+	if got != expr {
+		t.Errorf("NormalizeCheckExpression(inapplicable) = %q, want the verbatim %q", got, expr)
+	}
+	// The savepoint absorbed the failed ALTER: the transaction is still usable.
+	var one int
+	if err := tx.QueryRowContext(ctx, `SELECT 1`).Scan(&one); err != nil || one != 1 {
+		t.Fatalf("transaction unusable after inapplicable normalize: %v", err)
+	}
+}
+
+// TestPinSearchPathRendersUnqualified proves PinSearchPath makes pg_get_expr
+// render a schema-local type UNQUALIFIED: without the pin the destination
+// deparses a run-scoped enum cast schema-qualified; with the pin it renders
+// bare, exactly as the destination renders its own public-schema types.
+func TestPinSearchPathRendersUnqualified(t *testing.T) {
+	db := pg.Open(t)
+	ctx := context.Background()
+
+	execAll(t, db,
+		`CREATE SCHEMA run_pin`,
+		`CREATE TYPE run_pin.color AS ENUM ('r', 'g')`,
+		`CREATE TABLE run_pin.t (
+			c run_pin.color,
+			CONSTRAINT t_color_rule CHECK (c = 'r'::run_pin.color)
+		)`,
+	)
+	t.Cleanup(func() { _, _ = db.ExecContext(ctx, `DROP SCHEMA IF EXISTS run_pin CASCADE`) })
+
+	// Unpinned (default search_path): the enum cast renders schema-qualified.
+	unpinned := runPinCheckExpr(t, db, ctx, false)
+	if !strings.Contains(unpinned, "run_pin.color") {
+		t.Fatalf("unpinned deparse %q, want the schema-qualified run_pin.color", unpinned)
+	}
+
+	// Pinned to run_pin: the same cast renders bare.
+	pinned := runPinCheckExpr(t, db, ctx, true)
+	if strings.Contains(pinned, "run_pin.") {
+		t.Errorf("pinned deparse %q still schema-qualifies the type; the pin did not take", pinned)
+	}
+	if !strings.Contains(pinned, "color") {
+		t.Errorf("pinned deparse %q dropped the type name entirely", pinned)
+	}
+}
+
+// runPinCheckExpr reads run_pin.t's CHECK expression inside a transaction,
+// optionally pinning search_path to run_pin first, so the two calls differ only
+// in whether PinSearchPath ran.
+func runPinCheckExpr(t *testing.T, db *sql.DB, ctx context.Context, pin bool) string {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if pin {
+		if err := pgintrospect.PinSearchPath(ctx, tx, "run_pin"); err != nil {
+			t.Fatalf("PinSearchPath() = %v", err)
+		}
+	}
+	facts, err := pgintrospect.ConstraintFactsOf(ctx, tx, "run_pin")
+	if err != nil {
+		t.Fatalf("ConstraintFactsOf() = %v", err)
+	}
+	for _, f := range facts {
+		if f.Table == "t" && f.Type == "c" {
+			return f.Expression
+		}
+	}
+	t.Fatalf("ConstraintFactsOf(run_pin) has no CHECK on t: %+v", facts)
+	return ""
+}
+
+// checkExpr reads one table's named CHECK expression as the server deparses it.
+func checkExpr(t *testing.T, db *sql.DB, table, constraint string) string {
+	t.Helper()
+	checks, err := pgintrospect.CheckConstraints(context.Background(), db)
+	if err != nil {
+		t.Fatalf("CheckConstraints() = %v", err)
+	}
+	for _, ck := range checks {
+		if ck.Table == table && ck.Name == constraint {
+			return ck.Expression
+		}
+	}
+	t.Fatalf("no CHECK %q on table %q: %+v", constraint, table, checks)
+	return ""
+}
+
+// contains reports whether s holds v.
+func contains(s []string, v string) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}

--- a/pgintrospect/pgintrospect_test.go
+++ b/pgintrospect/pgintrospect_test.go
@@ -1,0 +1,459 @@
+package pgintrospect_test
+
+// The gateway's own fast-tier tests drive every method over an in-process
+// scripted driver: a happy path per method pins the row folding and grouping,
+// and two generic sweeps pin the shared error paths (a failed query, a
+// malformed row a healthy Postgres never produces). Conformance against a REAL
+// Postgres — that the SQL means what these tests assume, and that
+// NormalizeCheckExpression's deparse really is the server's own — lives in the
+// integration tier (pgintrospect_integration_test.go), so the SQL's meaning is
+// asserted where only a live server can prove it.
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/JacobJNilsson/data-contract-generator/pgintrospect"
+)
+
+// script scripts the fake connection: whether every ExecContext fails, and the
+// one result set every QueryContext returns (or its error). execErrs scripts
+// SUCCESSIVE ExecContext results in call order (nil is a success) for the
+// multi-statement NormalizeCheckExpression flow; once exhausted, execErr
+// applies to every further call, so the single-statement tests keep their
+// one-knob scripting.
+type script struct {
+	execErr  error
+	execErrs []error
+	queryErr error
+	cols     []string
+	rows     [][]driver.Value
+}
+
+type scriptedRows struct {
+	cols []string
+	rows [][]driver.Value
+	next int
+}
+
+func (r *scriptedRows) Columns() []string { return r.cols }
+func (r *scriptedRows) Close() error      { return nil }
+func (r *scriptedRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.next])
+	r.next++
+	return nil
+}
+
+type scriptedConn struct{ s *script }
+
+func (c *scriptedConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("pgintrospect test: scripted conn does not prepare")
+}
+func (c *scriptedConn) Close() error              { return nil }
+func (c *scriptedConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+func (c *scriptedConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	if len(c.s.execErrs) > 0 {
+		err := c.s.execErrs[0]
+		c.s.execErrs = c.s.execErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+		return driver.RowsAffected(0), nil
+	}
+	if c.s.execErr != nil {
+		return nil, c.s.execErr
+	}
+	return driver.RowsAffected(0), nil
+}
+func (c *scriptedConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	if c.s.queryErr != nil {
+		return nil, c.s.queryErr
+	}
+	return &scriptedRows{cols: c.s.cols, rows: c.s.rows}, nil
+}
+
+type scriptedDriver struct{}
+
+func (scriptedDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("pgintrospect test: use sql.OpenDB with scriptedConnector")
+}
+
+type scriptedConnector struct{ s *script }
+
+func (c scriptedConnector) Connect(context.Context) (driver.Conn, error) {
+	return &scriptedConn{s: c.s}, nil
+}
+func (scriptedConnector) Driver() driver.Driver { return scriptedDriver{} }
+
+// scriptDB opens an in-process *sql.DB over one scripted connection.
+func scriptDB(t *testing.T, s *script) *sql.DB {
+	t.Helper()
+	db := sql.OpenDB(scriptedConnector{s: s})
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", `"plain"`},
+		{"MiXed", `"MiXed"`},
+		{`emb"edded`, `"emb""edded"`},
+		{`"; DROP TABLE x; --`, `"""; DROP TABLE x; --"`},
+		{"", `""`},
+	}
+	for _, tc := range cases {
+		if got := pgintrospect.QuoteIdentifier(tc.in); got != tc.want {
+			t.Errorf("QuoteIdentifier(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestQuoteLiteral(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", `'plain'`},
+		{"it's", `'it''s'`},
+		{`'; DROP TABLE x; --`, `'''; DROP TABLE x; --'`},
+		{"", `''`},
+	}
+	for _, tc := range cases {
+		if got := pgintrospect.QuoteLiteral(tc.in); got != tc.want {
+			t.Errorf("QuoteLiteral(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBaseTables(t *testing.T) {
+	db := scriptDB(t, &script{cols: []string{"table_name"}, rows: [][]driver.Value{{"accounts"}, {"transactions"}}})
+	got, err := pgintrospect.BaseTables(t.Context(), db, "public")
+	if err != nil {
+		t.Fatalf("BaseTables() = %v, want nil", err)
+	}
+	if want := []string{"accounts", "transactions"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("BaseTables() = %v, want %v", got, want)
+	}
+}
+
+func TestSchemaExists(t *testing.T) {
+	for _, want := range []bool{true, false} {
+		db := scriptDB(t, &script{cols: []string{"exists"}, rows: [][]driver.Value{{want}}})
+		got, err := pgintrospect.SchemaExists(t.Context(), db, "run_x")
+		if err != nil {
+			t.Fatalf("SchemaExists() = %v, want nil", err)
+		}
+		if got != want {
+			t.Errorf("SchemaExists() = %v, want %v", got, want)
+		}
+	}
+}
+
+// columnsCols is the 17-column shape of the contract generator's column
+// introspection result set, for scripting rows.
+var columnsCols = []string{
+	"table_name", "column_name", "data_type", "is_nullable",
+	"is_identity", "is_generated", "has_default", "is_sequence_default",
+	"column_default", "udt_name", "udt_schema", "element_data_type",
+	"array_dims", "character_maximum_length", "numeric_precision",
+	"numeric_scale", "element_type_mod",
+}
+
+func TestColumns(t *testing.T) {
+	db := scriptDB(t, &script{cols: columnsCols, rows: [][]driver.Value{
+		{"t", "id", "bigint", "NO", "YES", "NEVER", true, false, "identity", "int8", "public", "", int64(0), nil, int64(64), int64(0), int64(-1)},
+		{"t", "code", "character varying", "YES", "NO", "NEVER", false, false, nil, "varchar", "public", "", int64(0), int64(3), nil, nil, int64(-1)},
+	}})
+	got, err := pgintrospect.Columns(t.Context(), db)
+	if err != nil {
+		t.Fatalf("Columns() = %v, want nil", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Columns() returned %d rows, want 2", len(got))
+	}
+	id := got[0]
+	if id.Table != "t" || id.Name != "id" || id.DataType != "bigint" || id.Nullable != "NO" ||
+		id.IsIdentity != "YES" || !id.HasDefault || id.IsSequenceDefault ||
+		!id.Default.Valid || id.Default.String != "identity" ||
+		id.UDTName != "int8" || id.UDTSchema != "public" ||
+		id.CharMaxLength.Valid || !id.NumericPrecision.Valid || id.NumericPrecision.Int64 != 64 ||
+		id.ElementTypeMod != -1 {
+		t.Errorf("Columns()[0] = %+v, want the scripted identity column's facts", id)
+	}
+	code := got[1]
+	if code.Name != "code" || code.Default.Valid || !code.CharMaxLength.Valid || code.CharMaxLength.Int64 != 3 || code.NumericPrecision.Valid {
+		t.Errorf("Columns()[1] = %+v, want the scripted varchar(3) column's facts", code)
+	}
+}
+
+func TestEnumValues(t *testing.T) {
+	db := scriptDB(t, &script{cols: []string{"enumlabel"}, rows: [][]driver.Value{{"open"}, {"closed"}}})
+	got, err := pgintrospect.EnumValues(t.Context(), db, "public", "status")
+	if err != nil {
+		t.Fatalf("EnumValues() = %v, want nil", err)
+	}
+	if want := []string{"open", "closed"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("EnumValues() = %v, want %v (declared order)", got, want)
+	}
+}
+
+func TestPrimaryKeys(t *testing.T) {
+	db := scriptDB(t, &script{cols: []string{"table_name", "column_name"}, rows: [][]driver.Value{
+		{"t", "user_id"}, {"t", "source"}, {"u", "id"},
+	}})
+	got, err := pgintrospect.PrimaryKeys(t.Context(), db)
+	if err != nil {
+		t.Fatalf("PrimaryKeys() = %v, want nil", err)
+	}
+	want := map[string][]string{"t": {"user_id", "source"}, "u": {"id"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("PrimaryKeys() = %v, want %v (key order preserved)", got, want)
+	}
+}
+
+func TestUniqueConstraints(t *testing.T) {
+	db := scriptDB(t, &script{cols: []string{"table_name", "constraint_name", "column_name"}, rows: [][]driver.Value{
+		{"t", "t_key", "account_id"}, {"t", "t_key", "date"}, {"u", "u_isin", "isin"},
+	}})
+	got, err := pgintrospect.UniqueConstraints(t.Context(), db)
+	if err != nil {
+		t.Fatalf("UniqueConstraints() = %v, want nil", err)
+	}
+	want := []pgintrospect.UniqueConstraint{
+		{Table: "t", Name: "t_key", Columns: []string{"account_id", "date"}},
+		{Table: "u", Name: "u_isin", Columns: []string{"isin"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UniqueConstraints() = %v, want %v (grouped in encounter order)", got, want)
+	}
+}
+
+func TestForeignKeys(t *testing.T) {
+	db := scriptDB(t, &script{
+		cols: []string{"table_name", "conname", "column_name", "referenced_table", "referenced_column", "num_cols"},
+		rows: [][]driver.Value{
+			{"orders", "orders_pair_fk", "a", "refs", "x", int64(2)},
+			{"orders", "orders_pair_fk", "b", "refs", "y", int64(2)},
+			{"orders", "orders_ref_fk", "ref_id", "refs", "id", int64(1)},
+		},
+	})
+	got, err := pgintrospect.ForeignKeys(t.Context(), db)
+	if err != nil {
+		t.Fatalf("ForeignKeys() = %v, want nil", err)
+	}
+	want := []pgintrospect.ForeignKey{
+		{Table: "orders", Name: "orders_pair_fk", NumColumns: 2, Columns: []string{"a", "b"}, ReferencedTable: "refs", ReferencedColumns: []string{"x", "y"}},
+		{Table: "orders", Name: "orders_ref_fk", NumColumns: 1, Columns: []string{"ref_id"}, ReferencedTable: "refs", ReferencedColumns: []string{"id"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ForeignKeys() = %v, want %v (pairwise columns, grouped per constraint)", got, want)
+	}
+}
+
+func TestCheckConstraints(t *testing.T) {
+	db := scriptDB(t, &script{
+		cols: []string{"table_name", "conname", "expr", "column_name"},
+		rows: [][]driver.Value{
+			{"t", "t_multi_check", "((a IS NULL) OR (b IS NOT NULL))", "a"},
+			{"t", "t_multi_check", "((a IS NULL) OR (b IS NOT NULL))", "b"},
+			{"t", "t_no_column_check", nil, nil},
+		},
+	})
+	got, err := pgintrospect.CheckConstraints(t.Context(), db)
+	if err != nil {
+		t.Fatalf("CheckConstraints() = %v, want nil", err)
+	}
+	want := []pgintrospect.CheckConstraint{
+		{Table: "t", Name: "t_multi_check", Expression: "((a IS NULL) OR (b IS NOT NULL))", Columns: []string{"a", "b"}},
+		{Table: "t", Name: "t_no_column_check", Expression: ""},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CheckConstraints() = %v, want %v (columns gathered, NULL column skipped)", got, want)
+	}
+}
+
+func TestColumnFactsOf(t *testing.T) {
+	db := scriptDB(t, &script{
+		cols: []string{"table_name", "column_name", "data_type", "char_max", "num_prec", "num_scale", "is_nullable", "udt_name"},
+		rows: [][]driver.Value{{"t", "code", "character varying", int64(3), int64(-1), int64(-1), "NO", "varchar"}},
+	})
+	got, err := pgintrospect.ColumnFactsOf(t.Context(), db, "public")
+	if err != nil {
+		t.Fatalf("ColumnFactsOf() = %v, want nil", err)
+	}
+	want := []pgintrospect.ColumnFacts{{Table: "t", Column: "code", DataType: "character varying", CharMax: 3, NumericPrecision: -1, NumericScale: -1, Nullable: "NO", UDTName: "varchar"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ColumnFactsOf() = %v, want %v", got, want)
+	}
+}
+
+func TestConstraintFactsOf(t *testing.T) {
+	db := scriptDB(t, &script{
+		cols: []string{"relname", "contype", "expr", "cols"},
+		rows: [][]driver.Value{{"t", "u", "", "account_id, date"}},
+	})
+	got, err := pgintrospect.ConstraintFactsOf(t.Context(), db, "public")
+	if err != nil {
+		t.Fatalf("ConstraintFactsOf() = %v, want nil", err)
+	}
+	want := []pgintrospect.ConstraintFacts{{Table: "t", Type: "u", Expression: "", Columns: "account_id, date"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ConstraintFactsOf() = %v, want %v", got, want)
+	}
+}
+
+func TestPinSearchPath(t *testing.T) {
+	if err := pgintrospect.PinSearchPath(t.Context(), scriptDB(t, &script{}), "run_x"); err != nil {
+		t.Errorf("PinSearchPath() = %v, want nil", err)
+	}
+	wantErr := errors.New("pin refused")
+	err := pgintrospect.PinSearchPath(t.Context(), scriptDB(t, &script{execErr: wantErr}), "run_x")
+	if !errors.Is(err, wantErr) {
+		t.Errorf("PinSearchPath(exec failure) = %v, want the driver's error", err)
+	}
+}
+
+// TestNormalizeCheckExpression pins the savepoint-scoped normalization flow
+// (issue #192) over the scripted driver: the happy path returns the server's
+// read-back deparse (not the caller's text), an inapplicable expression falls
+// back to its VERBATIM text with no error (the caller's comparison then fails
+// closed on it), and every plumbing failure a healthy server never produces (a
+// failed savepoint or rollback, a failed, empty, or malformed read-back)
+// surfaces as an error. The conformance half — that the returned deparse really
+// is the one the server's own catalog renders — lives in the integration tier
+// against a real Postgres, since it cannot be faked.
+func TestNormalizeCheckExpression(t *testing.T) {
+	boom := errors.New("boom")
+	const verbatim = `((c)::text = ANY ((ARRAY['a'::character varying])::text[]))`
+	const normalized = `((c)::text = ANY (ARRAY[('a'::character varying)::text]))`
+	exprCols := []string{"pg_get_expr"}
+	oneRow := [][]driver.Value{{normalized}}
+
+	t.Run("returns the server's own deparse", func(t *testing.T) {
+		db := scriptDB(t, &script{cols: exprCols, rows: oneRow})
+		got, err := pgintrospect.NormalizeCheckExpression(t.Context(), db, "run_x", "t", verbatim)
+		if err != nil || got != normalized {
+			t.Fatalf("NormalizeCheckExpression() = %q, %v; want the read-back deparse %q, nil", got, err, normalized)
+		}
+	})
+
+	t.Run("inapplicable expression keeps its verbatim text", func(t *testing.T) {
+		// The savepoint succeeds, the ALTER fails (a column the relation
+		// lacks), the rollback succeeds: the caller gets the verbatim text back
+		// so its own comparison still fails closed on the divergence.
+		db := scriptDB(t, &script{execErrs: []error{nil, boom}})
+		got, err := pgintrospect.NormalizeCheckExpression(t.Context(), db, "run_x", "t", verbatim)
+		if err != nil || got != verbatim {
+			t.Fatalf("NormalizeCheckExpression(inapplicable) = %q, %v; want the verbatim text back, nil", got, err)
+		}
+	})
+
+	plumbing := []struct {
+		name   string
+		script *script
+		want   string
+	}{
+		{"savepoint fails", &script{execErrs: []error{boom}}, "savepoint for CHECK normalization"},
+		{"rollback fails", &script{execErrs: []error{nil, nil, boom}, cols: exprCols, rows: oneRow}, "roll back CHECK normalization savepoint"},
+		{"read-back query fails", &script{queryErr: boom}, "read back normalized CHECK"},
+		{"read-back finds no constraint", &script{cols: exprCols}, "scratch constraint not found"},
+		{"read-back row malformed", &script{cols: exprCols, rows: [][]driver.Value{{nil}}}, "read back normalized CHECK"},
+	}
+	for _, tc := range plumbing {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := pgintrospect.NormalizeCheckExpression(t.Context(), scriptDB(t, tc.script), "run_x", "t", verbatim)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("NormalizeCheckExpression(%s) = %v, want an error containing %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+// methods enumerates every row-reading gateway method with the column shape of
+// its result set, so the two generic error sweeps below (a failed query, a
+// malformed row) cover each one without repeating the scaffolding.
+var methods = []struct {
+	name string
+	cols []string
+	call func(ctx context.Context, db *sql.DB) error
+}{
+	{"BaseTables", []string{"table_name"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.BaseTables(ctx, db, "public")
+		return err
+	}},
+	{"SchemaExists", []string{"exists"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.SchemaExists(ctx, db, "run_x")
+		return err
+	}},
+	{"Columns", columnsCols, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.Columns(ctx, db)
+		return err
+	}},
+	{"EnumValues", []string{"enumlabel"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.EnumValues(ctx, db, "public", "status")
+		return err
+	}},
+	{"PrimaryKeys", []string{"table_name", "column_name"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.PrimaryKeys(ctx, db)
+		return err
+	}},
+	{"UniqueConstraints", []string{"table_name", "constraint_name", "column_name"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.UniqueConstraints(ctx, db)
+		return err
+	}},
+	{"ForeignKeys", []string{"table_name", "conname", "column_name", "referenced_table", "referenced_column", "num_cols"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.ForeignKeys(ctx, db)
+		return err
+	}},
+	{"CheckConstraints", []string{"table_name", "conname", "expr", "column_name"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.CheckConstraints(ctx, db)
+		return err
+	}},
+	{"ColumnFactsOf", []string{"table_name", "column_name", "data_type", "char_max", "num_prec", "num_scale", "is_nullable", "udt_name"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.ColumnFactsOf(ctx, db, "public")
+		return err
+	}},
+	{"ConstraintFactsOf", []string{"relname", "contype", "expr", "cols"}, func(ctx context.Context, db *sql.DB) error {
+		_, err := pgintrospect.ConstraintFactsOf(ctx, db, "public")
+		return err
+	}},
+}
+
+// TestMethodsReportQueryFailure: every gateway method surfaces its query's
+// failure rather than swallowing it, so a destination that has gone away is a
+// loud error at every consumer.
+func TestMethodsReportQueryFailure(t *testing.T) {
+	for _, m := range methods {
+		t.Run(m.name, func(t *testing.T) {
+			wantErr := errors.New("connection refused")
+			err := m.call(t.Context(), scriptDB(t, &script{queryErr: wantErr}))
+			if !errors.Is(err, wantErr) {
+				t.Errorf("%s(query failure) = %v, want the driver's error", m.name, err)
+			}
+		})
+	}
+}
+
+// TestMethodsReportMalformedRow: every gateway method surfaces a row-scan
+// failure rather than swallowing it. The real catalog queries can never
+// produce such a row (a NULL in a NOT NULL catalog position), so the fake row
+// is the only way to exercise the defensive scan guard.
+func TestMethodsReportMalformedRow(t *testing.T) {
+	for _, m := range methods {
+		t.Run(m.name, func(t *testing.T) {
+			// A row of the right width whose every value is NULL: the scan into
+			// the method's non-nullable string/bool/int fields fails.
+			row := make([]driver.Value, len(m.cols))
+			err := m.call(t.Context(), scriptDB(t, &script{cols: m.cols, rows: [][]driver.Value{row}}))
+			if err == nil {
+				t.Errorf("%s(malformed row) = nil, want a scan error", m.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stage B2 of moving destination-contract generation into this library — the DB layer. Adds pgintrospect (live catalog reads: tables/columns/PK/unique/FK/multi-column-CHECK #155/enum + NormalizeCheckExpression #192, behind the Querier/Execer seam) and pgcontract with the public Generate(ctx, ExecQuerier, Options) (odcs.Contract, error) entry point the orchestrator will call. Composes the live facts with B1's odcsdest builders into a FAITHFUL contract at exact widths (#82/#124). Reintroduces Postgres to the library behind the //go:build integration gate (stage A's harness); the fast developer path stays pure-Go.

FAITHFUL CORE ONLY: no delivery policy moved (MP-2 merge-key, MP-3 surrogate folding, FK match-columns, the WithMergeKey/WithGeneratedColumns/WithDestinationNotNull/WithColumnDefaults post-passes, nullability folding all stay in the orchestrator for stage C). Generate emits RAW nullability and the FK structural triple; the orchestrator layers policy on top later.

Adversarially reviewed pre-PR: READY AFTER FIXES, all applied. The mandatory cross-repo crux passed: a go.mod-replace harness ran BOTH the orchestrator's GeneratePostgres and pgcontract.Generate against one real Postgres schema (#82/#124/#155/#192 + enum/array/single-column-FK/NOT-NULL-identity) and diffed field-by-field — every faithful field byte-identical, every delta classified as expected policy. Both behavior-preservation claims (CHECK verbatim without membership sets; raw nullability folded only as a post-pass) verified against orchestrator source. #192 proven by a live whole-array-cast vs per-element-fold normalization round-trip. Fixes: README/AGENTS gate docs synced; CI now enforces the new packages' coverage (fast-tier 100% for odcsdest/pgcheck/pgintrospect, integration-tier genuine 100% for pgcontract — the 97.2%->100% gap closed with real fixtures + an injected-real-error fake, not faked coverage).