### PR TITLE
Add a safe-grammar classifier for CHECK expressions

### DIFF
--- a/pgcheck/checklex.go
+++ b/pgcheck/checklex.go
@@ -1,0 +1,477 @@
+package pgcheck
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// tokenKind names one lexical class the CT-1 tokenizer produces. The safe
+// grammar is closed over these kinds only: a byte the tokenizer cannot place
+// in one of them fails the expression closed before parsing starts.
+type tokenKind int
+
+const (
+	tokEOF tokenKind = iota
+	tokIdent
+	tokNumber
+	tokString
+	tokOp
+	tokLParen
+	tokRParen
+	tokLBracket
+	tokRBracket
+	tokComma
+	tokDoubleColon
+)
+
+// token is one lexical unit. text carries the token's content for every
+// kind: the identifier or operator spelling, the number's literal digits,
+// the string literal's UNESCAPED value, or the punctuation character itself
+// (so describe needs no per-kind switch). quoted is set only for an
+// identifier that was double-quoted in the source: a quoted identifier is
+// never a keyword, a literal (TRUE/FALSE/NULL), or a type name, no matter
+// how it is spelled, because Postgres itself treats a quoted word as a
+// plain name, not as syntax.
+type token struct {
+	kind   tokenKind
+	text   string
+	quoted bool
+}
+
+// describe renders t for a rejection message. tokEOF has no text (there is
+// nothing to quote), every other kind carries its own text.
+func (t token) describe() string {
+	if t.kind == tokEOF {
+		return "end of input"
+	}
+	return fmt.Sprintf("%q", t.text)
+}
+
+// tokenizeCheckExpression turns a CHECK expression's SQL text into a token
+// stream ending in one tokEOF, or a *UnsafeExpressionError when a byte
+// matches no token the safe grammar recognizes. A double-quoted identifier
+// is a real token this grammar accepts (client-destination-trust.md
+// CT-1(d)): Postgres deparses a quoted or non-ASCII column name that way, so
+// tokenizeCheckExpression decodes UTF-8 properly rather than reading one
+// byte at a time.
+func tokenizeCheckExpression(expr string) ([]token, error) {
+	if err := rejectCommentIntroducer(expr); err != nil {
+		return nil, err
+	}
+	var tokens []token
+	i := 0
+	for i < len(expr) {
+		c := expr[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		case c == '\'':
+			value, next, ok := scanStringLiteral(expr, i)
+			if !ok {
+				return nil, lexError(expr, "string literal", "unterminated string literal")
+			}
+			if err := rejectNulByte(expr, value, "string literal"); err != nil {
+				return nil, err
+			}
+			tokens = append(tokens, token{kind: tokString, text: value})
+			i = next
+		case c == '"':
+			name, next, ok := scanQuotedIdent(expr, i)
+			if !ok {
+				return nil, lexError(expr, "quoted identifier", "unterminated double-quoted identifier")
+			}
+			if name == "" {
+				return nil, lexError(expr, "quoted identifier", "a double-quoted identifier cannot be empty")
+			}
+			if err := rejectNulByte(expr, name, "quoted identifier"); err != nil {
+				return nil, err
+			}
+			tokens = append(tokens, token{kind: tokIdent, text: name, quoted: true})
+			i = next
+		case isDigit(c) || (c == '.' && i+1 < len(expr) && isDigit(expr[i+1])):
+			text, next, ok := scanNumber(expr, i)
+			if !ok {
+				return nil, lexError(expr, "number", "malformed numeric literal")
+			}
+			tokens = append(tokens, token{kind: tokNumber, text: text})
+			i = next
+		case isIdentStartByte(c) || c >= utf8.RuneSelf:
+			next, ok := scanIdent(expr, i)
+			if !ok {
+				r, _ := utf8.DecodeRuneInString(expr[i:])
+				return nil, lexError(expr, "character", fmt.Sprintf("unrecognized character %q", string(r)))
+			}
+			tokens = append(tokens, token{kind: tokIdent, text: expr[i:next]})
+			i = next
+		case c == '(':
+			tokens = append(tokens, token{kind: tokLParen, text: "("})
+			i++
+		case c == ')':
+			tokens = append(tokens, token{kind: tokRParen, text: ")"})
+			i++
+		case c == '[':
+			tokens = append(tokens, token{kind: tokLBracket, text: "["})
+			i++
+		case c == ']':
+			tokens = append(tokens, token{kind: tokRBracket, text: "]"})
+			i++
+		case c == ',':
+			tokens = append(tokens, token{kind: tokComma, text: ","})
+			i++
+		case c == ':':
+			if i+1 < len(expr) && expr[i+1] == ':' {
+				tokens = append(tokens, token{kind: tokDoubleColon, text: "::"})
+				i += 2
+				continue
+			}
+			return nil, lexError(expr, "cast", "a single ':' is not a recognized operator")
+		case isPgOperatorChar(c):
+			op, next, ok := scanOperatorRun(expr, i)
+			if !ok {
+				return nil, lexError(expr, "operator", fmt.Sprintf("an operator run longer than %d characters cannot be a recognized operator", maxOperatorRunLength))
+			}
+			if !isKnownCheckOperator(op) {
+				return nil, lexError(expr, "operator", fmt.Sprintf("%q is not a recognized operator", op))
+			}
+			tokens = append(tokens, token{kind: tokOp, text: op})
+			i = next
+		default:
+			return nil, lexError(expr, "character", fmt.Sprintf("unrecognized character %q", string(c)))
+		}
+	}
+	tokens = append(tokens, token{kind: tokEOF})
+	return tokens, nil
+}
+
+// rejectCommentIntroducer reports a lexError when expr contains a SQL
+// comment introducer anywhere in its text. This covers a line comment
+// ('--') or a block comment ('/*'), including inside a string literal.
+// client-destination-trust.md CT-1(a): Postgres reunites a comment-split
+// token once the same text reaches its own parser. A '--' between a
+// function name and its opening parenthesis becomes one function call, not
+// two '-' operators. No token-level tokenizer can reason about a
+// comment-shaped byte sequence correctly. Rejecting the whole expression is
+// the only sound fix. It has a real cost: an ordinary, harmless constraint
+// can compare against the text "--" or "/*". A literal like '--'::text, or
+// a LIKE pattern containing "--", is dropped too, not only an attack. This
+// check runs before any tokenizing. A comment can therefore never reach the
+// parser in any position; the dropped-but-safe case is the price CT-1 pays
+// to keep that guarantee total.
+func rejectCommentIntroducer(expr string) error {
+	if strings.Contains(expr, "--") {
+		return lexError(expr, "comment", "a SQL line comment introducer ('--') is not allowed in a CHECK expression")
+	}
+	if strings.Contains(expr, "/*") {
+		return lexError(expr, "comment", "a SQL block comment introducer ('/*') is not allowed in a CHECK expression")
+	}
+	return nil
+}
+
+// rejectNulByte reports a lexError when value contains a NUL byte. Postgres
+// answers a NUL byte inside a statement in one of two unsafe ways. pgx
+// (this repo's driver) fails the whole statement closed ("invalid message
+// format", SQLSTATE 08P01). libpq truncates the statement at the NUL and
+// silently runs whatever text came before it. Neither outcome is a
+// recorded CT-6 drop, so rejecting a NUL here keeps it one
+// (client-destination-trust.md CT-1).
+//
+// This is the ONE place that check runs, called from every token kind
+// whose scanner copies arbitrary source bytes into its text (§4.2:
+// enumerate the set exhaustively). Today that is exactly two kinds: a
+// string literal (scanStringLiteral) and a double-quoted identifier
+// (scanQuotedIdent). Every OTHER token kind is built from a fixed,
+// known-safe byte or character class instead, so a NUL byte there is
+// already caught earlier, before this function would ever run:
+//
+//   - an unquoted identifier (scanIdent) accepts only a Unicode letter,
+//     digit, underscore, or '$'. A NUL byte is none of those, so scanIdent
+//     stops there the same way it stops at any other character it does
+//     not recognize.
+//   - a number (scanNumber) accepts only digits, '.', and an exponent
+//     marker with its sign.
+//   - an operator (scanOperatorRun) accepts only pgOperatorChars.
+//   - every punctuation token ('(', ')', '[', ']', ',', '::') is one fixed
+//     character, chosen by the tokenizer's own switch, never copied from
+//     a scanned run.
+//   - a bare NUL byte reached by none of the above falls through to the
+//     tokenizer's own default case ("unrecognized character") and rejects
+//     there instead.
+func rejectNulByte(expr, value, construct string) error {
+	if strings.IndexByte(value, 0) >= 0 {
+		return lexError(expr, construct, fmt.Sprintf("a %s cannot contain a NUL byte", construct))
+	}
+	return nil
+}
+
+// lexError builds the *UnsafeExpressionError a tokenizer failure returns.
+// Every tokenizer rejection is ErrUnsupportedConstruct: a byte the grammar
+// cannot place is an unrecognized construct, never a function call.
+func lexError(expr, construct, detail string) error {
+	return &UnsafeExpressionError{
+		Expression: expr,
+		Construct:  construct,
+		Reason:     fmt.Sprintf("CT-1 safe-grammar check rejects CHECK expression %q: %s", expr, detail),
+		kind:       ErrUnsupportedConstruct,
+	}
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+// isIdentStartByte reports whether the ASCII byte c may start an unquoted
+// identifier on its own: an underscore or an ASCII letter. A byte at or
+// above utf8.RuneSelf (0x80) also starts an identifier when it decodes to a
+// Unicode letter; scanIdent, not this function, checks that case.
+func isIdentStartByte(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// isIdentStartRune reports whether r may start an unquoted identifier: an
+// underscore or any Unicode letter. Postgres identifiers are not limited to
+// ASCII, and neither is this tokenizer: it decodes UTF-8 properly instead of
+// reading one byte at a time, so a Swedish column name like "årsmängd"
+// tokenizes as one identifier rather than a run of rejected bytes
+// (client-destination-trust.md CT-1(d)).
+func isIdentStartRune(r rune) bool { return r == '_' || unicode.IsLetter(r) }
+
+// isIdentContinueRune reports whether r may continue an identifier after its
+// first character: everything isIdentStartRune allows, plus a digit or a
+// dollar sign.
+func isIdentContinueRune(r rune) bool {
+	return isIdentStartRune(r) || unicode.IsDigit(r) || r == '$'
+}
+
+// scanIdent consumes one unquoted identifier starting at i, returning the
+// index just past it. The caller has already confirmed expr[i] begins one
+// (an ASCII letter or underscore, or a byte that may start a multibyte
+// rune). ok=false reports that the byte at i, once decoded, does not start a
+// valid identifier: a lone UTF-8 continuation byte, invalid UTF-8, or a
+// Unicode character that is not a letter or underscore.
+func scanIdent(expr string, i int) (next int, ok bool) {
+	r, size := utf8.DecodeRuneInString(expr[i:])
+	if r == utf8.RuneError && size <= 1 {
+		return 0, false
+	}
+	if !isIdentStartRune(r) {
+		return 0, false
+	}
+	i += size
+	for i < len(expr) {
+		r, size := utf8.DecodeRuneInString(expr[i:])
+		if r == utf8.RuneError && size <= 1 {
+			break
+		}
+		if !isIdentContinueRune(r) {
+			break
+		}
+		i += size
+	}
+	return i, true
+}
+
+// maxNumericExponent bounds the magnitude of a numeric literal's exponent
+// (the digits after 'e'/'E', either sign). Postgres accepts an unbounded
+// exponent on a numeric literal, but it stores the FULL expanded value and
+// pg_get_expr later deparses that value back out at full length: the
+// reviewer measured a literal as short as "1e131071" (8 bytes) expand to
+// over 59 million deparsed bytes, a 14,500x amplification, when
+// pgintrospect.NormalizeCheckExpression installs the constraint and reads
+// the deparse back (client-destination-trust.md CT-1). 1,000 matches the
+// NUMERIC precision bound maxTypeModifier already documents elsewhere in
+// this package, admits every realistic constraint literal (1e6, 1.5e-3,
+// and any ordinary scientific notation), and keeps the worst-case expanded
+// value in the low kilobytes rather than tens of megabytes.
+const maxNumericExponent = 1000
+
+// scanNumber consumes one numeric literal starting at i: digits, an
+// optional '.' and fractional digits, and an optional exponent. An
+// exponent marker ('e'/'E') not followed by at least one digit (with an
+// optional leading sign), or whose digits spell a magnitude over
+// maxNumericExponent, is malformed rather than silently accepted: a number
+// the tokenizer cannot fully read, or whose exponent this grammar bounds,
+// must fail the expression closed. The exponent's digits may contain '_'
+// as Postgres 16+'s digit separator: Postgres reads "1e1_31071" as the
+// exponent 131071, not 1, so this scan must skip '_' the same way Postgres
+// does before it measures the magnitude, or the bound reads the wrong
+// number entirely (client-destination-trust.md CT-1(h)).
+func scanNumber(expr string, i int) (text string, next int, ok bool) {
+	start := i
+	for i < len(expr) && isDigit(expr[i]) {
+		i++
+	}
+	if i < len(expr) && expr[i] == '.' {
+		i++
+		for i < len(expr) && isDigit(expr[i]) {
+			i++
+		}
+	}
+	if i < len(expr) && (expr[i] == 'e' || expr[i] == 'E') {
+		j := i + 1
+		if j < len(expr) && (expr[j] == '+' || expr[j] == '-') {
+			j++
+		}
+		digitsStart := j
+		if j >= len(expr) || !isDigit(expr[j]) {
+			return "", 0, false
+		}
+		for j < len(expr) && (isDigit(expr[j]) || expr[j] == '_') {
+			j++
+		}
+		magnitude, err := strconv.Atoi(strings.ReplaceAll(expr[digitsStart:j], "_", ""))
+		if err != nil || magnitude > maxNumericExponent {
+			return "", 0, false
+		}
+		i = j
+	}
+	return expr[start:i], i, true
+}
+
+// scanStringLiteral consumes one single-quoted SQL literal starting at i
+// (expr[i] is the opening quote), unescaping a doubled quote to one literal
+// quote. ok=false reports a literal never closed before the input ends.
+func scanStringLiteral(expr string, i int) (value string, next int, ok bool) {
+	var b []byte
+	j := i + 1
+	for j < len(expr) {
+		if expr[j] != '\'' {
+			b = append(b, expr[j])
+			j++
+			continue
+		}
+		if j+1 < len(expr) && expr[j+1] == '\'' {
+			b = append(b, '\'')
+			j += 2
+			continue
+		}
+		return string(b), j + 1, true
+	}
+	return "", 0, false
+}
+
+// scanQuotedIdent consumes one double-quoted SQL identifier starting at i
+// (expr[i] is the opening '"'), unescaping a doubled '"' to one literal '"'
+// character — the same rule scanStringLiteral applies to a doubled "'".
+// ok=false reports an identifier never closed before the input ends.
+func scanQuotedIdent(expr string, i int) (name string, next int, ok bool) {
+	var b []byte
+	j := i + 1
+	for j < len(expr) {
+		if expr[j] != '"' {
+			b = append(b, expr[j])
+			j++
+			continue
+		}
+		if j+1 < len(expr) && expr[j+1] == '"' {
+			b = append(b, '"')
+			j += 2
+			continue
+		}
+		return string(b), j + 1, true
+	}
+	return "", 0, false
+}
+
+// pgOperatorChars lists every character Postgres allows in an operator
+// name (Postgres 16's lexer, "operator" rule). This tokenizer scans a
+// maximal run of these — the same "longest match" rule Postgres's own
+// lexer applies — rather than recognizing each known operator by a
+// fixed-width lookahead: a fixed-width scan draws the token boundary in
+// the wrong place whenever a recognized operator sits directly against
+// another operator character with no space, which is exactly the
+// divergence client-destination-trust.md CT-1 (NIT 6) reports.
+const pgOperatorChars = "+-*/<>=~!@#%^&|`?"
+
+// specialOperatorChars are the operator characters that let a multi-
+// character operator name end in '+' or '-'. Postgres trims a trailing run
+// of '+'/'-' off an operator name UNLESS the remaining characters contain
+// at least one of these — Postgres 16's own set, "~!@#^&|`?%"
+// (client-destination-trust.md CT-1). "~~-" keeps its trailing '-': the
+// prefix "~~" contains '~'. "=-" does not: the prefix "=" contains none of
+// these. So Postgres reads "=-" as two tokens, "=" and "-". It reads "~~-"
+// as one operator this grammar does not know, so this grammar rejects it
+// rather than silently reading "~~" and stranding a '-'. The '%' character
+// belongs in this set too: Postgres reads "%-" as one operator token, not
+// "%" followed by "-". This grammar must reject "%-" and its kin ("%+",
+// "%++", "%+-", "%-+") the same way Postgres does, instead of silently
+// trimming them down to the recognized "%" operator.
+const specialOperatorChars = "~!@#^&|`?%"
+
+// isPgOperatorChar reports whether c may appear in a Postgres operator
+// name.
+func isPgOperatorChar(c byte) bool {
+	return strings.IndexByte(pgOperatorChars, c) >= 0
+}
+
+// isKnownCheckOperator reports whether op is one of the fixed operator
+// spellings the safe grammar recognizes: the comparison operators, the
+// four LIKE-family spellings pg_get_expr deparses LIKE/ILIKE to
+// (client-destination-trust.md CT-1(d)), and the arithmetic operators. Any
+// other operator token — Postgres accepts many the safe grammar does not,
+// custom or built-in alike — rejects: the safe grammar names an exact,
+// finite set of operator spellings, never a pattern.
+func isKnownCheckOperator(op string) bool {
+	switch op {
+	case "=", "<>", "!=", "<", "<=", ">", ">=",
+		"~~", "~~*", "!~~", "!~~*",
+		"+", "-", "*", "/", "%":
+		return true
+	default:
+		return false
+	}
+}
+
+// maxOperatorRunLength bounds how many characters scanOperatorRun ever
+// reads as one candidate operator token (client-destination-trust.md
+// CT-1(g)). The longest operator this grammar recognizes is four
+// characters ("!~~*"); this bound gives eight times that much headroom for
+// any legitimate run of adjacent hand-written operators, so a run that
+// reaches it can never be a known operator. Capping the SCAN itself, not
+// only the work scanOperatorRun does per character, keeps one call's cost
+// a small constant, never a function of how long an adversarial input
+// repeats an operator character.
+const maxOperatorRunLength = 32
+
+// scanOperatorRun consumes the maximal run of pgOperatorChars starting at
+// i, up to maxOperatorRunLength characters. It then trims a trailing run of
+// '+'/'-' characters, per Postgres's own rule. While the run is longer than
+// one character and ends in '+' or '-', it trims that last character. It
+// does not trim when what remains still holds a specialOperatorChars
+// character. This is Postgres's own operator-tokenizing rule
+// (client-destination-trust.md CT-1), not an approximation of it. A
+// fixed-width lookahead for each known operator spelling draws the token
+// boundary wrong. That happens whenever a recognized operator sits directly
+// against another operator character with no space between them.
+//
+// ok=false reports that the run continues past maxOperatorRunLength. The
+// full run is then longer than any operator this grammar can recognize.
+// The caller rejects the expression outright instead of reading a
+// truncated, misleading token. Finding the last specialOperatorChars
+// character runs ONCE, backward, over the run — not once per trim step.
+// The whole function therefore costs time proportional to the run's own
+// length, never its square (client-destination-trust.md CT-1(g)). A prior
+// version rescanned the shrinking prefix on every trim step. Combined with
+// the tokenizer re-entering at each trimmed position, that made a 4 KB
+// adversarial input — a long run of alternating '+' and '-' — cost 4.22
+// CPU-seconds instead of a fraction of a millisecond.
+func scanOperatorRun(expr string, i int) (op string, next int, ok bool) {
+	start := i
+	for i < len(expr) && isPgOperatorChar(expr[i]) && i-start < maxOperatorRunLength {
+		i++
+	}
+	if i-start == maxOperatorRunLength && i < len(expr) && isPgOperatorChar(expr[i]) {
+		return "", 0, false
+	}
+	lastSpecial := -1
+	for k := i - 1; k >= start; k-- {
+		if strings.IndexByte(specialOperatorChars, expr[k]) >= 0 {
+			lastSpecial = k
+			break
+		}
+	}
+	for i-start > 1 && (expr[i-1] == '+' || expr[i-1] == '-') && (lastSpecial == -1 || lastSpecial >= i-1) {
+		i--
+	}
+	return expr[start:i], i, true
+}

--- a/pgcheck/mutation_pins_test.go
+++ b/pgcheck/mutation_pins_test.go
@@ -1,0 +1,72 @@
+package pgcheck
+
+// Pins a CT-1 finding an external, black-box test cannot reach
+// (client-destination-trust.md CT-1): scanOperatorRun is unexported, so
+// only a test inside this package can call it directly.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestScanOperatorRun_MaxRunLengthBoundary pins scanOperatorRun's own bound
+// (client-destination-trust.md CT-1(g)) at a HARDCODED length, 32, rather
+// than at maxOperatorRunLength: a test built from the same constant it is
+// checking cannot catch that constant's own value changing, only a change
+// to the comparison around it. A run of exactly 32 known-operator
+// characters still tokenizes (though a run that long is never a
+// recognized operator spelling, so it still rejects on THAT separate
+// ground), while a run one character longer must reject specifically as
+// "too long", not fall through to being read as a truncated, shorter
+// operator.
+func TestScanOperatorRun_MaxRunLengthBoundary(t *testing.T) {
+	const documentedBound = 32
+
+	atLimit := "(a " + strings.Repeat("~", documentedBound) + " b)"
+	if _, _, ok := scanOperatorRun(atLimit, 3); !ok {
+		t.Errorf("scanOperatorRun(%d tildes) ok = false, want true (at the bound, not over it)", documentedBound)
+	}
+
+	overLimit := "(a " + strings.Repeat("~", documentedBound+1) + " b)"
+	if _, _, ok := scanOperatorRun(overLimit, 3); ok {
+		t.Errorf("scanOperatorRun(%d tildes) ok = true, want false (one character over the bound)", documentedBound+1)
+	}
+}
+
+// TestIsKnownCheckOperator_PinsExhaustiveSet pins isKnownCheckOperator's
+// COMPLETE accepted-operator set at a hardcoded copy, independent of the
+// switch statement the source defines, the same way
+// TestSafeCheckExpression_RejectsEveryReservedWord pins reservedWords and
+// TestSafeCheckExpression_PinsAllowlistedTypeNames pins the type lists
+// (client-destination-trust.md §4.2): a test that instead iterated the
+// source's own case list could never catch an operator ADDED to it. Every
+// operator Postgres itself recognizes but this grammar does not — starting
+// with "~" and "!~", one character short of the LIKE-family spellings this
+// grammar already accepts — must keep rejecting.
+func TestIsKnownCheckOperator_PinsExhaustiveSet(t *testing.T) {
+	known := []string{
+		"=", "<>", "!=", "<", "<=", ">", ">=",
+		"~~", "~~*", "!~~", "!~~*",
+		"+", "-", "*", "/", "%",
+	}
+	for _, op := range known {
+		t.Run(op, func(t *testing.T) {
+			if !isKnownCheckOperator(op) {
+				t.Errorf("isKnownCheckOperator(%q) = false, want true", op)
+			}
+		})
+	}
+
+	unknown := []string{
+		"~", "!~", "~*", "!~*", "^", "&", "|", "@>", "<@", "&&", "||",
+		"<<", ">>", "#", "@", "?", "?|", "?&", "->", "->>", "#>", "#>>",
+		"==", "!", "~~~", "!~~~", "@@", "@@@",
+	}
+	for _, op := range unknown {
+		t.Run(op, func(t *testing.T) {
+			if isKnownCheckOperator(op) {
+				t.Errorf("isKnownCheckOperator(%q) = true, want false", op)
+			}
+		})
+	}
+}

--- a/pgcheck/safe_expression.go
+++ b/pgcheck/safe_expression.go
@@ -1,0 +1,1498 @@
+// Package pgcheck reads Postgres CHECK constraint expression text without
+// executing it. MembershipSet recovers a value set from the common
+// single-column membership shape; SafeCheckExpression (CT-1) classifies
+// whether a CHECK expression is safe to install on a mirror database at
+// all. Both fail CLOSED: an expression outside what they explicitly
+// recognize contributes nothing, never a guess.
+package pgcheck
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ErrFunctionCall and ErrUnsupportedConstruct are the two sentinel kinds a
+// *UnsafeExpressionError wraps. A caller tells them apart with
+// errors.Is(err, pgcheck.ErrFunctionCall) or
+// errors.Is(err, pgcheck.ErrUnsupportedConstruct), without parsing
+// UnsafeExpressionError.Reason's prose.
+var (
+	ErrFunctionCall         = errors.New("function call in CHECK expression")
+	ErrUnsupportedConstruct = errors.New("construct outside the CT-1 safe grammar")
+)
+
+// UnsafeExpressionError reports that a CHECK expression falls outside CT-1's
+// safe grammar (client-destination-trust.md, decision CT-1). It is the
+// typed surface a caller uses instead of parsing the refusal prose: recover
+// it with errors.As(err, &unsafeErr) to read Expression and Construct, or
+// use errors.Is against ErrFunctionCall / ErrUnsupportedConstruct to tell a
+// function call apart from any other rejected construct.
+type UnsafeExpressionError struct {
+	// Expression is the full CHECK expression text that was rejected.
+	Expression string
+	// Construct names the offending piece: the called function's name for
+	// ErrFunctionCall, or a short label for the unrecognized construct.
+	Construct string
+	// Reason is the human-readable sentence Error() returns.
+	Reason string
+	kind   error
+}
+
+// Error implements error, returning Reason verbatim.
+func (e *UnsafeExpressionError) Error() string { return e.Reason }
+
+// Unwrap exposes the sentinel kind (ErrFunctionCall or
+// ErrUnsupportedConstruct) so errors.Is can match it.
+func (e *UnsafeExpressionError) Unwrap() error { return e.kind }
+
+// maxExpressionLength bounds a CHECK expression's byte length. The
+// CarbonCloud trial's longest real constraint is under 250 bytes. It is
+// also only a few levels deep. 4096 bytes gives wide headroom above that.
+// It also sits far below the roughly 580,000 bytes that fatally overflow
+// the Go stack. recover() cannot catch that fault
+// (client-destination-trust.md CT-1(c)). This byte cap bounds recursion
+// depth and total token count. It does not by itself bound the
+// classifier's own CPU cost. CT-1(g) requires every tokenizer and parser
+// scan to cost time proportional to the expression's length, never more.
+// The byte cap and the linear-cost bound must both hold. A prior version
+// of the operator scanner broke the linear-cost rule: it cost the CUBE of
+// a 4 KB input's length, 4.22 CPU-seconds. checklex.go's scanOperatorRun
+// documents that fix and its own added bound.
+const maxExpressionLength = 4096
+
+// oversizeExpressionError builds the rejection for an expression longer
+// than maxExpressionLength.
+func oversizeExpressionError(expr string) error {
+	return &UnsafeExpressionError{
+		Expression: expr,
+		Construct:  "length",
+		Reason:     fmt.Sprintf("CT-1 safe-grammar check rejects this CHECK expression: it is %d bytes long, which exceeds the %d-byte limit", len(expr), maxExpressionLength),
+		kind:       ErrUnsupportedConstruct,
+	}
+}
+
+// SafeCheckExpression reports whether expr, a Postgres CHECK constraint's
+// expression text exactly as pg_get_expr renders it, lies entirely inside
+// CT-1's safe grammar (client-destination-trust.md, decision CT-1):
+//
+//   - a column reference, including a double-quoted or non-ASCII identifier
+//     ("Order", "årsmängd")
+//   - NULL, string, number, and boolean literals
+//   - comparison operators (=, <>, !=, <, <=, >, >=); the LIKE-family
+//     operators pg_get_expr deparses LIKE/ILIKE/NOT LIKE/NOT ILIKE to (~~,
+//     ~~*, !~~, !~~*); boolean operators (AND, OR, NOT); and arithmetic
+//     operators (+, -, *, /, %)
+//   - IS [NOT] NULL, IS [NOT] TRUE/FALSE/UNKNOWN, and IS [NOT] DISTINCT FROM
+//   - IN (…literals…) and BETWEEN … AND … (hand-spelled forms: Postgres
+//     deparses IN to "= ANY (ARRAY[…])" and BETWEEN to a pair of
+//     comparisons, both already covered above)
+//   - LIKE / ILIKE (hand-spelled forms; see the deparsed operator spellings
+//     above for the form the platform actually receives)
+//   - "= ANY (ARRAY[…literals…])" and "<> ALL (ARRAY[…literals…])", including
+//     a per-element parenthesized cast ("(1)::numeric"), a whole-array cast
+//     pushed down per element ("('x'::character varying)::text"), a whole-
+//     array cast pushed OUTSIDE the constructor ("ARRAY['x'::text])::text[]")
+//     and a single string literal cast to a non-temporal array type
+//     ("'{a,b}'::text[]") — every shape pg_get_expr uses to deparse an IN
+//     list or an ARRAY literal
+//   - parentheses
+//   - a cast, with '::', of a literal or column to a built-in type from
+//     CT-1's explicit allowlist (parseTypeName documents it), with a
+//     precision, scale, or length bounded per type (maxModifierFor,
+//     CT-1(f)); a string literal cast to a temporal type is rejected when
+//     the literal is one of Postgres's special date/time input strings
+//     (specialTemporalLiterals), and a string literal cast to a numeric
+//     type is rejected when its text spells an exponent beyond
+//     maxNumericExponent — both checks fire wherever the cast is reached,
+//     through any number of parentheses, a prior cast in the chain, an
+//     ARRAY/ANY/ALL wrapper, or a cast pushed outside an ARRAY[...]
+//     constructor onto every element (checkCastSafety and
+//     parseArrayCastSuffix, CT-1(h))
+//   - COLLATE followed by a double-quoted collation name
+//
+// A qualified name (t.a), an array subscript (a[1]), and field selection on
+// a composite ((a).f) all fall outside the grammar and reject rather than
+// being silently misread. So does a bare use of one of Postgres's
+// parenthesis-less SQL value functions (CURRENT_USER and its kin,
+// reservedWords documents the full list): CT-1(e). So does a division or
+// modulo whose divisor is a single literal zero (literalValue.isZero),
+// through any number of parentheses or a cast that preserves it, and so
+// does one whose divisor combines more than one literal with no column
+// reference anywhere in it (literalValue.hasColumnRef): this grammar does
+// not evaluate what such a constant combination reduces to, so it refuses
+// the divisor outright instead (CT-1(h)).
+//
+// It returns nil when expr is safe; an oversize- or too-deep-expression
+// error when expr exceeds the documented length or nesting bound
+// (client-destination-trust.md CT-1(c)); or a *UnsafeExpressionError naming
+// the offending construct otherwise.
+//
+// The grammar is a strict ALLOWLIST of node kinds, never a denylist of
+// function names: any function call is rejected regardless of which
+// function, and so is any construct the grammar does not name — including a
+// SQL comment ('--' or '/*') anywhere in the text (CT-1(a)). An expression
+// the parser cannot read in full — including trailing text after an
+// otherwise-valid expression — is also rejected: SafeCheckExpression never
+// accepts a partial parse.
+//
+// A nil return means expr lies INSIDE the safe grammar. It does not mean
+// Postgres will install or evaluate expr successfully: an expression built
+// entirely from safe constructs can still fail at ADD CONSTRAINT (a numeric
+// literal too large to represent, an input function that rejects its
+// argument) or at evaluation time (integer overflow) without executing
+// anything CT-1 exists to stop. A caller that installs an accepted
+// expression on a mirror must treat that installation's own outcome as a
+// separate, real result — including a failure — never assume ACCEPT already
+// proved the constraint will run (client-destination-trust.md CT-1).
+func SafeCheckExpression(expr string) error {
+	if len(expr) > maxExpressionLength {
+		return oversizeExpressionError(expr)
+	}
+	tokens, err := tokenizeCheckExpression(expr)
+	if err != nil {
+		return err
+	}
+	p := &checkParser{tokens: tokens, expr: expr}
+	if _, err := p.parseOr(); err != nil {
+		return err
+	}
+	if p.peek().kind != tokEOF {
+		return p.unsupported("trailing input", fmt.Sprintf("unexpected %s after a complete expression", p.peek().describe()))
+	}
+	return nil
+}
+
+// checkParser walks a token stream with one token of lookahead. Every
+// parse method reports whether the construct starting at the current
+// position lies in the safe grammar; on success it leaves pos just past
+// what it consumed, on failure pos is unspecified because the caller
+// abandons the parse.
+type checkParser struct {
+	tokens []token
+	pos    int
+	expr   string // the original text, carried for error messages only
+	depth  int    // current recursion depth into a nested construct; see enterDepth
+}
+
+func (p *checkParser) peek() token { return p.tokens[p.pos] }
+
+// next returns the current token and advances, except past the final
+// tokEOF sentinel: repeated calls at end of input keep returning it, so a
+// caller never reads past the slice.
+func (p *checkParser) next() token {
+	t := p.tokens[p.pos]
+	if p.pos < len(p.tokens)-1 {
+		p.pos++
+	}
+	return t
+}
+
+// isOp reports whether the current token is a tokOp whose text matches one
+// of ops, without consuming it.
+func (p *checkParser) isOp(ops ...string) bool {
+	t := p.peek()
+	if t.kind != tokOp {
+		return false
+	}
+	for _, op := range ops {
+		if t.text == op {
+			return true
+		}
+	}
+	return false
+}
+
+// isKeyword reports whether the current token is the unquoted keyword kw
+// (case-insensitive), without consuming it. A double-quoted identifier
+// never matches: a column literally named "and" is a name, not the AND
+// keyword, because Postgres treats a quoted word as a plain identifier.
+func (p *checkParser) isKeyword(kw string) bool {
+	t := p.peek()
+	return t.kind == tokIdent && !t.quoted && strings.EqualFold(t.text, kw)
+}
+
+// maxParseDepth bounds how many levels deep the parser may recurse into a
+// nested construct: a parenthesized group, a chained NOT, or a
+// parenthesized ARRAY-literal wrapper. The recursive descent costs roughly
+// nine stack frames per level. Postgres's own deparser never nests a CHECK
+// expression more than a handful of levels; the CarbonCloud trial's
+// deepest constraint is shallow. 200 sits far below the roughly 560,000
+// levels the reviewer measured before the plain, uncapped recursion
+// overflows the Go stack fatally — a fault recover() cannot catch
+// (client-destination-trust.md CT-1(c)).
+const maxParseDepth = 200
+
+// enterDepth records one more level of recursion into a nested construct,
+// rejecting once maxParseDepth is exceeded so the parser returns an
+// ordinary error instead of exhausting the stack. Every call that succeeds
+// must be paired with exitDepth, normally via defer.
+func (p *checkParser) enterDepth() error {
+	p.depth++
+	if p.depth > maxParseDepth {
+		return p.unsupported("nesting", fmt.Sprintf("expression nests more than %d levels deep", maxParseDepth))
+	}
+	return nil
+}
+
+// exitDepth undoes one enterDepth call.
+func (p *checkParser) exitDepth() { p.depth-- }
+
+// unsupported builds the *UnsafeExpressionError for a construct the safe
+// grammar does not name (as opposed to a recognized function call, which
+// uses functionCall instead).
+func (p *checkParser) unsupported(construct, detail string) error {
+	return &UnsafeExpressionError{
+		Expression: p.expr,
+		Construct:  construct,
+		Reason:     fmt.Sprintf("CT-1 safe-grammar check rejects CHECK expression %q: %s", p.expr, detail),
+		kind:       ErrUnsupportedConstruct,
+	}
+}
+
+// functionCall builds the *UnsafeExpressionError for a call to the named
+// function. CT-1 never inspects name against a list: this fires for every
+// identifier immediately followed by '(', regardless of which function.
+func (p *checkParser) functionCall(name string) error {
+	return &UnsafeExpressionError{
+		Expression: p.expr,
+		Construct:  name,
+		Reason:     fmt.Sprintf("CT-1 safe-grammar check rejects CHECK expression %q: function call %q is not in the safe grammar", p.expr, name),
+		kind:       ErrFunctionCall,
+	}
+}
+
+// literalValue carries a literal's original text through any number of
+// wrapping parentheses and a chain of casts, together with whether it
+// started as a string and whether a cast to an array type has already been
+// applied to it. This is the choke point client-destination-trust.md
+// CT-1(h) requires: every level of the expression grammar below forwards a
+// literalValue unchanged when nothing else combines with the literal, and
+// clears its text once an operator, a predicate, or a second operand
+// touches it. checkCastSafety and isZero both key off the SAME threaded
+// value, instead of each re-deriving it from the token stream at whichever
+// shape happens to reach them first.
+//
+// A zero-value literalValue means "not a single trackable literal" — a
+// column reference, or any construct built from two or more values.
+type literalValue struct {
+	text     string
+	isString bool
+	// isArrayLiteral is true once a cast whose target type carries a "[]"
+	// suffix has been applied directly to this value's own text. From that
+	// point on, text is Postgres's OWN array-literal string syntax
+	// ("{now}"), parsed by array_in, not by this grammar. This grammar
+	// cannot see inside it to check what array_in will extract
+	// (client-destination-trust.md CT-1(h)). It is deliberately NOT set
+	// when parseArrayCastSuffix pushes an array-typed cast onto an
+	// already-parsed ARRAY[...] element: pg_get_expr's "ARRAY[...]::type[]"
+	// form casts each element individually, as a plain scalar, never
+	// re-parsing the element's text as a fresh array literal.
+	isArrayLiteral bool
+	// isLiteral is true exactly when this value is a single NUMBER or
+	// STRING token, forwarded unchanged through any number of wrapping
+	// parentheses, a leading unary sign, and a chain of casts. It turns
+	// false the instant a binary operator combines this value with
+	// another, or when the position holds a column reference, TRUE/FALSE/
+	// NULL, or anything else that is not one literal token. isZero only
+	// ever means something when isLiteral is true: a value this grammar
+	// cannot see as a single literal must never be read as if its (empty)
+	// text meant zero.
+	isLiteral bool
+	// hasColumnRef is true when a column reference appears anywhere in
+	// this value's own sub-expression, threaded through the same
+	// arithmetic chain (parseAdd, parseMul, parseUnary, parseCast,
+	// parsePrimary) isLiteral is. parseMul's division-by-zero check
+	// (CT-1(h)) uses it once isLiteral is false: a sub-expression that
+	// reaches a column is a genuinely dynamic, per-row value, trusted the
+	// same way a bare column divisor always is; a sub-expression built
+	// from more than one literal with NO column reference anywhere in it
+	// is a pure constant computation, which this grammar refuses
+	// outright instead of evaluating (isZero's own doc comment explains
+	// why evaluating one is unsound).
+	hasColumnRef bool
+}
+
+// isZero reports whether v's text spells zero, for a v this grammar has
+// already confirmed is a SINGLE literal (v.isLiteral): a bare "0", "(0)",
+// "+(0)", "0::numeric", or "'0'::numeric" all divide by zero at evaluation
+// (client-destination-trust.md CT-1(h)). It is a cheap, syntactic check on
+// one already-bounded token's own text, never a combination of two values.
+//
+// This grammar does not try to compute what a constant ARITHMETIC
+// combination of two or more literals reduces to: an earlier version
+// folded "+", "-", and "*" in float64, which disagrees with Postgres's
+// exact NUMERIC type in both directions — float64 rounds
+// "0.1 + 0.2 - 0.3" to a nonzero residue where Postgres's exact arithmetic
+// gives precisely zero, and it rounds two adjacent 24-digit operands to
+// the same value where their true difference is 1. parseMul's
+// hasColumnRef check replaces that fold instead of correcting its
+// arithmetic: a divisor built from more than one literal, with no column
+// reference anywhere in it, is rejected outright regardless of what it
+// would compute to.
+func (v literalValue) isZero() bool {
+	n, err := strconv.ParseFloat(v.text, 64)
+	return err == nil && n == 0
+}
+
+// parseOr := parseAnd (OR parseAnd)*
+func (p *checkParser) parseOr() (literalValue, error) {
+	v, err := p.parseAnd()
+	if err != nil {
+		return literalValue{}, err
+	}
+	for p.isKeyword("OR") {
+		p.next()
+		if _, err := p.parseAnd(); err != nil {
+			return literalValue{}, err
+		}
+		v = literalValue{}
+	}
+	return v, nil
+}
+
+// parseAnd := parseNot (AND parseNot)*
+func (p *checkParser) parseAnd() (literalValue, error) {
+	v, err := p.parseNot()
+	if err != nil {
+		return literalValue{}, err
+	}
+	for p.isKeyword("AND") {
+		p.next()
+		if _, err := p.parseNot(); err != nil {
+			return literalValue{}, err
+		}
+		v = literalValue{}
+	}
+	return v, nil
+}
+
+// parseNot := NOT parseNot | parseComparison
+//
+// A chain of NOT recurses into itself, so it is bounded by enterDepth just
+// like a parenthesized group: "NOT NOT NOT … x" is the same unbounded-
+// recursion shape as nested parentheses, without needing any parenthesis at
+// all (client-destination-trust.md CT-1(c)).
+func (p *checkParser) parseNot() (literalValue, error) {
+	if p.isKeyword("NOT") {
+		if err := p.enterDepth(); err != nil {
+			return literalValue{}, err
+		}
+		defer p.exitDepth()
+		p.next()
+		_, err := p.parseNot()
+		return literalValue{}, err
+	}
+	return p.parseComparison()
+}
+
+// parseComparison := parseAdd ( predicate | likeOp parseAdd | comparisonOp
+// parseAdd )?
+//
+// predicate is IS [NOT] NULL, IS [NOT] DISTINCT FROM parseAdd, [NOT] IN
+// (…), [NOT] BETWEEN … AND …, or [NOT] LIKE/ILIKE …; likeOp is one of the
+// deparsed LIKE-family operators (~~, ~~*, !~~, !~~*); comparisonOp
+// specially recognizes "= ANY (ARRAY[…])" and "<> ALL (ARRAY[…])" ahead of a
+// plain right-hand AddExpr. This parses at most one predicate or comparison
+// suffix per operand: a CHECK that needs more than one joins them with AND
+// or OR, which parseAnd and parseOr already handle, so parseComparison
+// itself never chains. The left operand's value forwards only when no
+// suffix follows it.
+func (p *checkParser) parseComparison() (literalValue, error) {
+	v, err := p.parseAdd()
+	if err != nil {
+		return literalValue{}, err
+	}
+	switch {
+	case p.isKeyword("IS"):
+		return literalValue{}, p.parseIsPredicate()
+	case p.isKeyword("NOT"):
+		p.next()
+		return literalValue{}, p.parsePredicateKeyword()
+	case p.isKeyword("IN"), p.isKeyword("BETWEEN"), p.isKeyword("LIKE"), p.isKeyword("ILIKE"):
+		return literalValue{}, p.parsePredicateKeyword()
+	case p.isOp("~~", "~~*", "!~~", "!~~*"):
+		p.next()
+		_, err := p.parseAdd()
+		return literalValue{}, err
+	case p.isOp("=", "<>", "!=", "<", "<=", ">", ">="):
+		op := p.next()
+		if op.text == "=" && p.isKeyword("ANY") {
+			p.next()
+			return literalValue{}, p.parseArrayArgument("ANY")
+		}
+		if (op.text == "<>" || op.text == "!=") && p.isKeyword("ALL") {
+			p.next()
+			return literalValue{}, p.parseArrayArgument("ALL")
+		}
+		_, err := p.parseAdd()
+		return literalValue{}, err
+	default:
+		return v, nil
+	}
+}
+
+// parseIsPredicate consumes "IS [NOT] NULL", "IS [NOT] TRUE/FALSE/UNKNOWN"
+// (a BooleanTest — no function dispatch at all, client-destination-trust.md
+// CT-1), or "IS [NOT] DISTINCT FROM parseAdd", the IS keyword confirmed
+// present but not yet consumed at the current position.
+func (p *checkParser) parseIsPredicate() error {
+	p.next()
+	if p.isKeyword("NOT") {
+		p.next()
+	}
+	switch {
+	case p.isKeyword("NULL"), p.isKeyword("TRUE"), p.isKeyword("FALSE"), p.isKeyword("UNKNOWN"):
+		p.next()
+		return nil
+	case p.isKeyword("DISTINCT"):
+		p.next()
+		if !p.isKeyword("FROM") {
+			return p.unsupported("IS DISTINCT", "IS [NOT] DISTINCT must be followed by FROM")
+		}
+		p.next()
+		_, err := p.parseAdd()
+		return err
+	default:
+		return p.unsupported("IS", "IS must be followed by [NOT] NULL, [NOT] TRUE/FALSE/UNKNOWN, or [NOT] DISTINCT FROM")
+	}
+}
+
+// parsePredicateKeyword consumes IN (…), BETWEEN … AND …, or LIKE/ILIKE …
+// starting at the current token, used both bare and after a leading NOT.
+func (p *checkParser) parsePredicateKeyword() error {
+	switch {
+	case p.isKeyword("IN"):
+		p.next()
+		return p.parseLiteralList()
+	case p.isKeyword("BETWEEN"):
+		p.next()
+		if _, err := p.parseAdd(); err != nil {
+			return err
+		}
+		if !p.isKeyword("AND") {
+			return p.unsupported("BETWEEN", "BETWEEN must be followed by a low value, AND, and a high value")
+		}
+		p.next()
+		_, err := p.parseAdd()
+		return err
+	case p.isKeyword("LIKE"), p.isKeyword("ILIKE"):
+		p.next()
+		_, err := p.parseAdd()
+		return err
+	default:
+		return p.unsupported("NOT", "NOT here must precede IN, BETWEEN, LIKE, or ILIKE")
+	}
+}
+
+// parseAdd := parseMul ( (+|-) parseMul )*
+//
+// Combining two values across "+" or "-" clears the threaded literal text
+// (this grammar does not compute a sum or difference), but carries
+// hasColumnRef forward as the OR of both sides: a column reference on
+// either side of "+"/"-" must stay visible to parseMul's division-by-zero
+// check, the same way it is for every other combinator
+// (client-destination-trust.md CT-1(h)).
+func (p *checkParser) parseAdd() (literalValue, error) {
+	v, err := p.parseMul()
+	if err != nil {
+		return literalValue{}, err
+	}
+	for p.isOp("+", "-") {
+		p.next()
+		rhs, err := p.parseMul()
+		if err != nil {
+			return literalValue{}, err
+		}
+		v = literalValue{hasColumnRef: v.hasColumnRef || rhs.hasColumnRef}
+	}
+	return v, nil
+}
+
+// parseMul := parseUnary ( (*|/|%) parseUnary )*
+//
+// A division or modulo's divisor takes one of two paths
+// (client-destination-trust.md CT-1(h)):
+//
+//   - a SINGLE literal (rhs.isLiteral) — "0", "(0)", "+(0)", "0::numeric",
+//     "'0'::numeric" — errors when its own text spells zero (isZero).
+//   - anything else — a column reference, or a combination of more than
+//     one value — errors unless a column reference appears somewhere in
+//     it (rhs.hasColumnRef). This grammar does not evaluate what a
+//     constant combination of literals reduces to (isZero's own doc
+//     comment explains why); a divisor built from more than one literal,
+//     with no column reference anywhere in it, is rejected outright
+//     instead, the same fail-closed default this grammar already applies
+//     to every construct it does not model.
+//
+// Combining two values across "*" or "/" clears the threaded literal text
+// but carries hasColumnRef forward as the OR of both sides, the same way
+// parseAdd does: a chain like "a / (b * 1) > 0" must still see the column
+// reference inside "(b * 1)" once it reaches an outer divisor position.
+func (p *checkParser) parseMul() (literalValue, error) {
+	v, err := p.parseUnary()
+	if err != nil {
+		return literalValue{}, err
+	}
+	for p.isOp("*", "/", "%") {
+		op := p.next()
+		rhs, err := p.parseUnary()
+		if err != nil {
+			return literalValue{}, err
+		}
+		if op.text == "/" || op.text == "%" {
+			switch {
+			case rhs.isLiteral:
+				if rhs.isZero() {
+					return literalValue{}, p.divisionByZeroError(op.text)
+				}
+			case !rhs.hasColumnRef:
+				return literalValue{}, p.divisionByZeroError(op.text)
+			}
+		}
+		v = literalValue{hasColumnRef: v.hasColumnRef || rhs.hasColumnRef}
+	}
+	return v, nil
+}
+
+// divisionByZeroError builds the rejection parseMul returns for a "/" or
+// "%" whose divisor is a literal zero, or a constant combination of
+// literals this grammar cannot confirm is nonzero (client-destination-
+// trust.md CT-1(h)). Either one always errors at evaluation, or, combined
+// with OR, turns a CHECK into a per-row error oracle.
+func (p *checkParser) divisionByZeroError(opText string) error {
+	return p.unsupported("division by zero", fmt.Sprintf("%s by a literal zero, or by a constant expression this grammar cannot confirm is nonzero, always errors at evaluation, or, combined with OR, turns a CHECK into a per-row error oracle", opText))
+}
+
+// parseUnary := (+|-)* parseCast
+//
+// A leading sign does not clear the forwarded literalValue: it does not
+// change whether the underlying literal is zero, or which special string it
+// spells, and any cast that follows the sign's operand already checked
+// itself before the sign is even considered.
+func (p *checkParser) parseUnary() (literalValue, error) {
+	for p.isOp("+", "-") {
+		p.next()
+	}
+	return p.parseCast()
+}
+
+// temporalTypeNames lists every allowlisted cast target whose Postgres
+// input function accepts one of Postgres's special date/time input strings
+// (specialTemporalLiterals) in place of an ordinary literal. Names are the
+// canonical form parseTypeName returns: a multi-word type joined by single
+// spaces, a single-word type lowercased, and an array type with a "[]"
+// suffix per dimension.
+var temporalTypeNames = map[string]bool{
+	"date":                        true,
+	"time":                        true,
+	"timestamp":                   true,
+	"timestamptz":                 true,
+	"time with time zone":         true,
+	"time without time zone":      true,
+	"timestamp with time zone":    true,
+	"timestamp without time zone": true,
+	"interval":                    true,
+}
+
+func isTemporalTypeName(name string) bool { return temporalTypeNames[name] }
+
+// numericTypeNames lists every allowlisted cast target whose Postgres
+// input function accepts scientific notation the same way a bare NUMBER
+// token does. "numeric" and "decimal" are the same Postgres type under two
+// names.
+var numericTypeNames = map[string]bool{
+	"numeric": true,
+	"decimal": true,
+}
+
+func isNumericTypeName(name string) bool { return numericTypeNames[name] }
+
+// baseTypeName strips every trailing "[]" array-dimension suffix
+// parseTypeName appends, leaving the element type name alone. Both
+// isTemporalTypeName and isNumericTypeName classify a type by its element,
+// never by its spelling with the array suffix still attached
+// (client-destination-trust.md CT-1(h)): a cast to "timestamp[]" is exactly
+// as dangerous as a cast to "timestamp".
+func baseTypeName(name string) string {
+	for strings.HasSuffix(name, "[]") {
+		name = strings.TrimSuffix(name, "[]")
+	}
+	return name
+}
+
+// specialTemporalLiterals are Postgres's special date/time input strings.
+// Postgres evaluates each one immediately, at parse analysis time, and
+// freezes the resulting wall-clock value into the stored constant — the
+// mirror's own clock, at microsecond resolution, the same class of leak
+// CT-1(e) already closes for CURRENT_TIMESTAMP and its kin
+// (client-destination-trust.md CT-1). A cast reopens that channel: Postgres
+// deparses the frozen value back out in full, so 'now'::timestamp becomes
+// something like '2026-08-04 08:06:04.340876'::timestamp — strictly more
+// information than CURRENT_TIMESTAMP alone would leak, and a value that can
+// never match a fresh introspection, so it also breaks fidelity comparison.
+var specialTemporalLiterals = map[string]bool{
+	"now": true, "today": true, "tomorrow": true, "yesterday": true,
+	"epoch": true, "infinity": true, "-infinity": true, "allballs": true,
+}
+
+// dateTimeFieldDelimiters lists every character Postgres's own date/time
+// input parser (ParseDateTime) treats as a field delimiter, exactly like
+// whitespace, when it tokenizes a date/time string: '{', '}', '(', ')',
+// '[', ']', ',', and ':'. isSpecialTemporalLiteral must strip them before
+// comparing against specialTemporalLiterals, or a value like "{now}" reads
+// as the literal text "{now}" instead of the special value "now" Postgres's
+// own parser actually sees once it installs the constraint
+// (client-destination-trust.md CT-1(h)). A character OUTSIDE this set —
+// '.', a non-leading '-', '+', or '/' — is never stripped: Postgres's
+// parser does not treat it as a delimiter, so "now." or "-now" is not this
+// special value at all, and Postgres itself rejects it as a malformed
+// date/time string once the CHECK installs, a separate, non-security
+// failure this grammar does not need to predict.
+const dateTimeFieldDelimiters = "{}()[],:"
+
+// isSpecialTemporalLiteral reports whether value, trimmed of surrounding
+// whitespace, stripped of every dateTimeFieldDelimiters character, trimmed
+// again, and compared case-insensitively, is one of Postgres's special
+// date/time input strings. A delimiter can appear anywhere in the text —
+// "{now}", "(now)", "[now]", "now,", and "now:" are all exactly the
+// special value "now" to Postgres, not the literal text they are spelled
+// with — so this strips the whole set rather than matching one fixed
+// shape.
+func isSpecialTemporalLiteral(value string) bool {
+	value = strings.TrimSpace(value)
+	value = strings.Map(func(r rune) rune {
+		if strings.ContainsRune(dateTimeFieldDelimiters, r) {
+			return -1
+		}
+		return r
+	}, value)
+	return specialTemporalLiterals[strings.ToLower(strings.TrimSpace(value))]
+}
+
+// temporalLiteralError builds the rejection for a special date/time input
+// string cast to a temporal type.
+func (p *checkParser) temporalLiteralError(value string) error {
+	return p.unsupported("temporal literal", fmt.Sprintf("%q is one of Postgres's special date/time input values and cannot be cast to a temporal type", value))
+}
+
+// numericMagnitudeError builds the rejection for a string literal cast to
+// a numeric type whose text spells an exponent beyond maxNumericExponent
+// (client-destination-trust.md CT-1(h)).
+func (p *checkParser) numericMagnitudeError(value string) error {
+	return p.unsupported("numeric magnitude", fmt.Sprintf("%q, cast to a numeric type, spells an exponent beyond the %d-magnitude limit CT-1 allows", value, maxNumericExponent))
+}
+
+// stringLiteralExceedsNumericExponent reports whether s, a string literal
+// being cast to a numeric type, spells an exponent ('e' or 'E' followed by
+// an optional sign and digits, digits allowing an underscore digit
+// separator the same way scanNumber's exponent digits do) whose magnitude
+// exceeds maxNumericExponent anywhere in its text. scanNumber (checklex.go)
+// already bounds a bare NUMBER token's exponent this way; a numeric
+// magnitude spelled inside a STRING literal reaches Postgres's same
+// expansion once the string is cast to numeric, so this bounds the same
+// VALUE reached through a second spelling (client-destination-trust.md
+// CT-1(h)). It scans every occurrence, not only the first, so an early
+// small exponent cannot mask a later oversized one.
+func stringLiteralExceedsNumericExponent(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != 'e' && s[i] != 'E' {
+			continue
+		}
+		j := i + 1
+		if j < len(s) && (s[j] == '+' || s[j] == '-') {
+			j++
+		}
+		digitsStart := j
+		for j < len(s) && (isDigit(s[j]) || s[j] == '_') {
+			j++
+		}
+		if j == digitsStart {
+			continue
+		}
+		magnitude, err := strconv.Atoi(strings.ReplaceAll(s[digitsStart:j], "_", ""))
+		if err != nil || magnitude > maxNumericExponent {
+			return true
+		}
+	}
+	return false
+}
+
+// checkCastSafety is the ONE choke point every '::' cast reaching a single,
+// already-identified literal value passes through (client-destination-trust.md
+// CT-1(h)). A bare literal, a parenthesized literal, an IN/ARRAY list
+// item, and a scalar cast to an array type all call it with v, the SAME
+// literalValue the grammar has threaded from parsePrimary, and typeName,
+// the cast's own target.
+//
+// parseArrayCastSuffix is the one exception. It checks the cast
+// pg_get_expr pushes OUTSIDE an ARRAY[...] constructor, applying to every
+// element pg_get_expr already split out individually. CT-1(g) requires
+// that site's own cost stay linear in the expression's length, so it does
+// not call this function once per element per cast. It applies these SAME
+// checks (isTemporalTypeName, isSpecialTemporalLiteral, isNumericTypeName,
+// stringLiteralExceedsNumericExponent) in a batched order instead; its own
+// doc comment explains why that is still one checked property, not a
+// second, divergent copy of it.
+//
+// checkCastSafety bounds the VALUE a string literal can carry into a
+// dangerous cast, not the one syntactic shape a reviewer happened to
+// demonstrate:
+//
+//   - a special date/time input string (isSpecialTemporalLiteral) must
+//     never reach a temporal cast target. Postgres freezes the mirror's own
+//     wall clock into the stored constant, the CT-1(e) clock-leak channel
+//     reopened by a cast.
+//   - a numeric magnitude spelled inside the string must never exceed
+//     maxNumericExponent once cast to a numeric type. A bare NUMBER token
+//     is already bounded this way (scanNumber); a STRING literal reaches
+//     the same amplification once Postgres installs and deparses it.
+//
+// typeName may carry a trailing "[]" from an array cast; this function
+// always strips it before classifying (baseTypeName). v.isArrayLiteral,
+// or this specific cast's own "[]" suffix, means the literal's text is
+// (or, after this cast, becomes) a Postgres array-literal STRING
+// ("{now}"), not a single scalar value. This grammar cannot parse inside
+// that syntax. A temporal array cast rejects outright regardless of
+// content; a numeric array cast still scans the whole string for an
+// oversized exponent. The cheap type-name lookups (isTemporalTypeName,
+// isNumericTypeName) run before the more expensive content checks
+// (isSpecialTemporalLiteral, stringLiteralExceedsNumericExponent), so a
+// cast to a harmless type never pays for a check its own target could
+// never fail (client-destination-trust.md CT-1(g)).
+//
+// It returns v, carrying isArrayLiteral forward once this cast's own
+// target carried "[]", so a caller can thread the result into a further
+// chained cast.
+func (p *checkParser) checkCastSafety(v literalValue, typeName string) (literalValue, error) {
+	if !v.isString {
+		return v, nil
+	}
+	base := baseTypeName(typeName)
+	castTargetsArray := base != typeName
+	opaqueArrayText := v.isArrayLiteral || castTargetsArray
+	if isTemporalTypeName(base) {
+		if opaqueArrayText {
+			return v, p.unsupported("ARRAY", "a string-literal cast to a temporal array type cannot be validated element by element")
+		}
+		if isSpecialTemporalLiteral(v.text) {
+			return v, p.temporalLiteralError(v.text)
+		}
+	}
+	if isNumericTypeName(base) && stringLiteralExceedsNumericExponent(v.text) {
+		return v, p.numericMagnitudeError(v.text)
+	}
+	if castTargetsArray {
+		v.isArrayLiteral = true
+	}
+	return v, nil
+}
+
+// parseCast := parsePrimary ( '::' typeName | COLLATE collationName )*
+//
+// Every cast in the chain runs through checkCastSafety, checked against the
+// SAME original literal parsePrimary returned — client-destination-trust.md
+// CT-1(h): a chain like 'now'::text::timestamp is checked at its second
+// cast too, not only its first, and a parenthesized primary already
+// forwarded whatever literal it found inside its parentheses.
+func (p *checkParser) parseCast() (literalValue, error) {
+	v, err := p.parsePrimary()
+	if err != nil {
+		return literalValue{}, err
+	}
+	for {
+		switch {
+		case p.peek().kind == tokDoubleColon:
+			p.next()
+			typeName, err := p.parseTypeName()
+			if err != nil {
+				return literalValue{}, err
+			}
+			v, err = p.checkCastSafety(v, typeName)
+			if err != nil {
+				return literalValue{}, err
+			}
+		case p.isKeyword("COLLATE"):
+			p.next()
+			if err := p.parseCollationName(); err != nil {
+				return literalValue{}, err
+			}
+		default:
+			return v, nil
+		}
+	}
+}
+
+// parseCollationName consumes a COLLATE clause's collation name: a
+// double-quoted identifier, and only that. pg_get_expr always quotes a
+// collation name (client-destination-trust.md CT-1), so requiring a quote
+// keeps this exact instead of guessing which bare words are safe; it also
+// needs no new relaxation of the existing quoted-identifier rule, which
+// already accepts a quoted token as an opaque name carrying no dispatch.
+func (p *checkParser) parseCollationName() error {
+	tok := p.peek()
+	if tok.kind != tokIdent || !tok.quoted {
+		return p.unsupported("COLLATE", "COLLATE must be followed by a double-quoted collation name")
+	}
+	p.next()
+	return nil
+}
+
+// reservedWords are the keyword-position identifiers parsePrimary refuses
+// to treat as a bare column reference: each one already has its own
+// production earlier in the grammar (parseOr/parseAnd/parseNot,
+// parseComparison's predicates, parseArrayArgument), so meeting one here
+// means it was used somewhere the grammar does not place it. A
+// double-quoted identifier never counts: quoting is how Postgres itself
+// spells "this word is a name, not syntax" (isKeyword and isReservedWord
+// both honor token.quoted).
+// reservedWords also lists Postgres's parenthesis-less SQL value
+// functions (CURRENT_USER and its kin) and the bulk of Postgres 16's
+// "reserved" and "type_func_name" keyword classes, so a bare use of one
+// rejects rather than being read as a column reference.
+//
+// The SQL value functions matter for a reason beyond keyword hygiene: an
+// "identifier immediately followed by '('" rule for detecting a function
+// call misses every one of them, because each takes no parentheses at
+// all — CURRENT_USER, not CURRENT_USER(). Each evaluates per row, and
+// each leaks one bit of the mirror's own role, database, schema, or
+// clock into the CHECK's pass/fail outcome. CT-2's REVOKE cannot back
+// this class up: Postgres evaluates a SQLValueFunction node inline,
+// without ever dispatching through pg_proc (client-destination-trust.md
+// CT-1(e)).
+//
+// The remaining entries close a smaller gap (client-destination-trust.md
+// CT-1, NIT 5): Postgres rejects a CHECK expression that misuses one of
+// its own reserved words with a syntax error, but this grammar, absent
+// this list, read a bare `AS`, `SELECT`, or `TABLE` as an ordinary column
+// name. That turns a should-be-dropped CHECK into a failed
+// "ADD CONSTRAINT" instead — fail-closed either way, but the constraint
+// drop CT-6 expects never happens. Deliberately left out: the many
+// Postgres keywords that stay "unreserved" (a real column may be named
+// after one, e.g. `value`, `type`, `role`), and TRUE/FALSE/NULL, which
+// isLiteralKeyword already covers on its own path.
+var reservedWords = []string{
+	"AND", "OR", "NOT", "IS", "IN", "BETWEEN", "LIKE", "ILIKE",
+	"ANY", "ALL", "ARRAY", "DISTINCT", "FROM",
+
+	// Parenthesis-less SQL value functions (CT-1(e)).
+	"CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP",
+	"LOCALTIME", "LOCALTIMESTAMP",
+	"CURRENT_ROLE", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER",
+	"CURRENT_CATALOG", "CURRENT_SCHEMA",
+
+	// Postgres 16's "reserved" keyword class (NIT 5).
+	"ANALYSE", "ANALYZE", "AS", "ASC", "ASYMMETRIC", "BOTH", "CASE",
+	"CAST", "CHECK", "COLLATE", "COLUMN", "CONSTRAINT", "CREATE",
+	"DEFAULT", "DEFERRABLE", "DESC", "DO", "ELSE", "END", "EXCEPT",
+	"FETCH", "FOR", "FOREIGN", "GRANT", "GROUP", "HAVING", "INITIALLY",
+	"INTERSECT", "INTO", "LATERAL", "LEADING", "LIMIT", "OFFSET", "ON",
+	"ONLY", "ORDER", "PLACING", "PRIMARY", "REFERENCES", "RETURNING",
+	"SELECT", "SOME", "SYMMETRIC", "TABLE", "THEN", "TO", "TRAILING",
+	"UNION", "UNIQUE", "USING", "VARIADIC", "WHEN", "WHERE", "WINDOW",
+	"WITH",
+
+	// Postgres 16's "type_func_name" keyword class (NIT 5).
+	"AUTHORIZATION", "BINARY", "COLLATION", "CONCURRENTLY",
+	"CROSS", "FREEZE", "FULL", "INNER", "ISNULL", "JOIN", "LEFT",
+	"NATURAL", "NOTNULL", "OUTER", "OVERLAPS", "RIGHT", "SIMILAR",
+	"TABLESAMPLE", "VERBOSE",
+}
+
+func isReservedWord(t token) bool {
+	if t.quoted {
+		return false
+	}
+	for _, w := range reservedWords {
+		if strings.EqualFold(t.text, w) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLiteralKeyword(t token) bool {
+	if t.quoted {
+		return false
+	}
+	return strings.EqualFold(t.text, "TRUE") || strings.EqualFold(t.text, "FALSE") || strings.EqualFold(t.text, "NULL")
+}
+
+// parsePrimary := NUMBER | STRING | TRUE | FALSE | NULL | column-ref |
+// '(' parseOr ')'
+//
+// It returns the primary's literal text and whether that literal was a
+// string. Both are zero-valued for anything that is not a single
+// trackable literal, such as a column reference. A parenthesized primary
+// forwards whatever literalValue it finds inside its parentheses
+// unchanged (client-destination-trust.md CT-1(h)): the value must stay
+// visible at any '::' cast that follows, no matter how many parentheses
+// wrap it.
+//
+// An identifier immediately followed by '(' is a function call: CT-1
+// rejects it outright, without ever checking which function it names. A
+// double-quoted identifier followed by '(' is rejected the same way —
+// Postgres allows a quoted function name in a call just as it allows a
+// quoted column name, so quoting is never a way around this check.
+func (p *checkParser) parsePrimary() (literalValue, error) {
+	tok := p.peek()
+	switch tok.kind {
+	case tokEOF:
+		return literalValue{}, p.unsupported("expression", "expected an expression, found end of input")
+	case tokNumber:
+		p.next()
+		return literalValue{text: tok.text, isLiteral: true}, nil
+	case tokString:
+		p.next()
+		return literalValue{text: tok.text, isString: true, isLiteral: true}, nil
+	case tokIdent:
+		return p.parseIdentPrimary(tok)
+	case tokLParen:
+		if err := p.enterDepth(); err != nil {
+			return literalValue{}, err
+		}
+		defer p.exitDepth()
+		p.next()
+		v, err := p.parseOr()
+		if err != nil {
+			return literalValue{}, err
+		}
+		if p.peek().kind != tokRParen {
+			return literalValue{}, p.unsupported("parenthesis", "opening '(' is never closed")
+		}
+		p.next()
+		return v, nil
+	default:
+		return literalValue{}, p.unsupported("token", fmt.Sprintf("unexpected %s where an expression was expected", tok.describe()))
+	}
+}
+
+// parseIdentPrimary handles the four things an identifier can be at a
+// primary position: a TRUE/FALSE/NULL literal, a function call (rejected),
+// a reserved word used where the grammar does not place it (rejected), or
+// a plain column reference. None of the first three carry a trackable
+// literal value forward; only the column-reference case sets
+// hasColumnRef, the signal parseMul's division-by-zero check threads
+// upward (client-destination-trust.md CT-1(h)).
+func (p *checkParser) parseIdentPrimary(tok token) (literalValue, error) {
+	if isLiteralKeyword(tok) {
+		p.next()
+		return literalValue{}, nil
+	}
+	if p.tokens[p.pos+1].kind == tokLParen {
+		p.next()
+		return literalValue{}, p.functionCall(tok.text)
+	}
+	if isReservedWord(tok) {
+		return literalValue{}, p.unsupported(tok.text, fmt.Sprintf("%q is not usable as a column reference here", tok.text))
+	}
+	p.next()
+	return literalValue{hasColumnRef: true}, nil
+}
+
+// multiWordTypeNames lists every accepted multi-word built-in type name,
+// each as its words in order. consumeTypeName tries each of these before
+// falling back to a single-word name: no other sequence of bare words is
+// ever a type name, however many follow '::'. A type name is one of these
+// exact, finite spellings, or it is not a type name at all. A stray word
+// after a cast — a keyword, a typo, an unrelated identifier — always falls
+// through to a clear rejection instead of being silently absorbed.
+var multiWordTypeNames = [][]string{
+	{"double", "precision"},
+	{"character", "varying"},
+	{"timestamp", "with", "time", "zone"},
+	{"timestamp", "without", "time", "zone"},
+	{"time", "with", "time", "zone"},
+	{"time", "without", "time", "zone"},
+}
+
+// singleWordTypeNames holds every accepted single-word built-in type name,
+// lowercased, including the short alias Postgres also accepts alongside its
+// canonical deparsed form (for example "int8" alongside "bigint", for an
+// operator who hand-edits the YAML). A reg* type is deliberately absent: it
+// looks like an ordinary type name but resolves through a catalog lookup
+// that runs its own code, which is exactly the execution path CT-1 exists
+// to close (client-destination-trust.md CT-1(b)). A domain or an extension
+// type is absent for the same reason: each invokes its own input, cast, or
+// CHECK code, which this classifier has no way to vet.
+var singleWordTypeNames = map[string]bool{
+	"text":        true,
+	"varchar":     true,
+	"char":        true,
+	"character":   true,
+	"bpchar":      true,
+	"smallint":    true,
+	"int2":        true,
+	"integer":     true,
+	"int4":        true,
+	"bigint":      true,
+	"int8":        true,
+	"numeric":     true,
+	"decimal":     true,
+	"real":        true,
+	"float4":      true,
+	"float8":      true,
+	"boolean":     true,
+	"bool":        true,
+	"date":        true,
+	"time":        true,
+	"timestamp":   true,
+	"timestamptz": true,
+	"interval":    true,
+	"uuid":        true,
+	"bytea":       true,
+	"json":        true,
+	"jsonb":       true,
+}
+
+// parseTypeName consumes a built-in type name after '::' from CT-1's
+// explicit allowlist (multiWordTypeNames and singleWordTypeNames), followed
+// by an optional (precision[, scale]) and optional trailing "[]" array
+// markers. Every identifier not on the allowlist rejects — a reg* type, a
+// domain, an extension type, or a name the classifier does not recognize —
+// because each of those runs its own code when Postgres processes the cast
+// (client-destination-trust.md CT-1(b)).
+//
+// It returns the type's canonical name on success: the matched words
+// joined by single spaces, or the single word lowercased, with one "[]"
+// appended per array-bracket pair consumed. A caller uses this to check
+// isTemporalTypeName or isNumericTypeName without re-deriving it from the
+// token stream.
+func (p *checkParser) parseTypeName() (string, error) {
+	name, ok := p.consumeTypeName()
+	if !ok {
+		return "", p.unsupported("cast", fmt.Sprintf("%s is not an allowlisted built-in type name", p.peek().describe()))
+	}
+	if p.peek().kind == tokLParen {
+		p.next()
+		if err := p.parseTypePrecision(name); err != nil {
+			return "", err
+		}
+	}
+	for p.peek().kind == tokLBracket {
+		p.next()
+		if p.peek().kind != tokRBracket {
+			return "", p.unsupported("cast", "'[' in a type name must be immediately followed by ']'")
+		}
+		p.next()
+		name += "[]"
+	}
+	return name, nil
+}
+
+// consumeTypeName matches the allowlisted type name starting at the current
+// token — trying each multiWordTypeNames entry, longest forms first as the
+// slice lists them, then a single singleWordTypeNames word — and consumes
+// it, returning the matched canonical name. A quoted identifier never
+// matches: pg_get_expr never quotes a built-in type name, so requiring an
+// unquoted word keeps the allowlist exact.
+func (p *checkParser) consumeTypeName() (string, bool) {
+	for _, words := range multiWordTypeNames {
+		if p.matchesWords(words) {
+			for range words {
+				p.next()
+			}
+			return strings.Join(words, " "), true
+		}
+	}
+	tok := p.peek()
+	if tok.kind == tokIdent && !tok.quoted && singleWordTypeNames[strings.ToLower(tok.text)] {
+		p.next()
+		return strings.ToLower(tok.text), true
+	}
+	return "", false
+}
+
+// matchesWords reports whether the unquoted identifiers starting at the
+// current position spell out words, case-insensitively, without consuming
+// them. It never indexes past the token slice: the final token is always
+// tokEOF (tokenizeCheckExpression's own invariant, the same one next()
+// relies on), and tokEOF never matches a word, so the loop always returns
+// false at or before that index rather than reading beyond it.
+func (p *checkParser) matchesWords(words []string) bool {
+	for i, w := range words {
+		t := p.tokens[p.pos+i]
+		if t.kind != tokIdent || t.quoted || !strings.EqualFold(t.text, w) {
+			return false
+		}
+	}
+	return true
+}
+
+// maxTypeModifier bounds a cast's precision, scale, or length argument for
+// every type EXCEPT numeric/decimal (maxNumericModifier bounds those
+// instead). This is a type's "(N)" or "(N, N)" typmod. Postgres accepts a
+// char/varchar length up to 10,485,760. bpchar blank-pads a fixed-length
+// value out to its full typmod. An accepted cast is a memory-amplification
+// primitive, not merely a large one. The reviewer measured 4 KB of
+// accepted CHECK text: 157 constraints, each `a = ”::char(10485760)`,
+// joined by OR. Postgres const-folds them on the first INSERT. That drove
+// a mirror backend from 18 MB to 1.6 GB of RSS in about seven seconds. An
+// OOM kill of that backend restarts every connection in the mirror
+// (client-destination-trust.md CT-1(f)). No real CHECK constraint needs
+// anywhere near a five- or six-digit typmod. The widest column in the
+// CarbonCloud trial schema is nowhere close to four digits. 10,000 sits
+// comfortably above every ordinary varchar/char length and keeps the
+// resulting allocation bounded and cheap.
+const maxTypeModifier = 10000
+
+// maxNumericModifier bounds a numeric/decimal cast's precision or scale
+// specifically, tighter than maxTypeModifier: Postgres's own NUMERIC
+// precision cap is 1,000, so a numeric(N) with N above it is not merely a
+// large accepted value, it is a value Postgres itself will always reject
+// at ADD CONSTRAINT — a real constraint never needs it, and a dropped CHECK
+// is cheaper than a failed ADD CONSTRAINT (client-destination-trust.md
+// CT-1(f)).
+const maxNumericModifier = 1000
+
+// maxModifierFor returns the precision/scale/length bound
+// parseTypeModifierNumber enforces for a cast to typeName: maxNumericModifier
+// for numeric or decimal, maxTypeModifier for every other type that takes
+// one (client-destination-trust.md CT-1(f)).
+func maxModifierFor(typeName string) int {
+	if isNumericTypeName(typeName) {
+		return maxNumericModifier
+	}
+	return maxTypeModifier
+}
+
+// parseTypePrecision consumes "N)" or "N, N)" after a type name's opening
+// '(', for a precision/scale/length type like numeric(10, 2) or
+// char(10). typeName is the type this precision belongs to: each number is
+// bounded by maxModifierFor(typeName) (client-destination-trust.md
+// CT-1(f)).
+func (p *checkParser) parseTypePrecision(typeName string) error {
+	bound := maxModifierFor(typeName)
+	if err := p.parseTypeModifierNumber(bound); err != nil {
+		return err
+	}
+	if p.peek().kind == tokComma {
+		p.next()
+		if err := p.parseTypeModifierNumber(bound); err != nil {
+			return err
+		}
+	}
+	if p.peek().kind != tokRParen {
+		return p.unsupported("cast", "a type's precision is never closed with ')'")
+	}
+	p.next()
+	return nil
+}
+
+// parseTypeModifierNumber consumes one NUMBER token as a type modifier — a
+// precision, scale, or length inside a cast's "(...)" — rejecting a value
+// that is not a plain non-negative integer, or that exceeds bound
+// (client-destination-trust.md CT-1(f)).
+func (p *checkParser) parseTypeModifierNumber(bound int) error {
+	tok := p.peek()
+	if tok.kind != tokNumber {
+		return p.unsupported("cast", "a type's precision, scale, or length must be a plain integer")
+	}
+	n, err := strconv.Atoi(tok.text)
+	if err != nil || n > bound {
+		return p.unsupported("cast", fmt.Sprintf("a type's precision, scale, or length %q exceeds the %d limit CT-1 allows", tok.text, bound))
+	}
+	p.next()
+	return nil
+}
+
+// parseArrayArgument consumes "(ARRAY[…])" or "('{…}'::type[])" — the
+// parenthesized argument of "= ANY" or "<> ALL" — the comparison operator
+// and its ANY/ALL keyword already consumed by the caller. keyword names
+// which one, for the rejection message only.
+func (p *checkParser) parseArrayArgument(keyword string) error {
+	if p.peek().kind != tokLParen {
+		return p.unsupported(keyword, keyword+" must be followed by (ARRAY[...])")
+	}
+	p.next()
+	if err := p.parseArrayOperand(); err != nil {
+		return err
+	}
+	if p.peek().kind != tokRParen {
+		return p.unsupported(keyword, keyword+"(...) is never closed with ')'")
+	}
+	p.next()
+	return nil
+}
+
+// parseArrayOperand consumes what "= ANY (…)" or "<> ALL (…)" wraps: either
+// an ARRAY[...] literal (parseArrayLiteral) or a single string literal cast
+// to an array type — "'{a,b}'::text[]" — the form pg_get_expr emits when
+// the source wrote ANY/ALL over a Postgres array-literal string rather than
+// an ARRAY[...] constructor. The string itself is not parsed further: it is
+// a single opaque literal, checked at checkCastSafety, the same choke point
+// a scalar cast uses (client-destination-trust.md CT-1(h)). Every cast
+// chained after the first — "'{now}'::text[]::timestamp[]" — is checked
+// too, against the SAME original string.
+func (p *checkParser) parseArrayOperand() error {
+	if p.peek().kind == tokString && p.tokens[p.pos+1].kind == tokDoubleColon {
+		strTok := p.next() // the string literal
+		v := literalValue{text: strTok.text, isString: true}
+		firstCast := true
+		for p.peek().kind == tokDoubleColon {
+			p.next()
+			typeName, err := p.parseTypeName()
+			if err != nil {
+				return err
+			}
+			if firstCast && !strings.HasSuffix(typeName, "[]") {
+				return p.unsupported("ARRAY", "a string-literal ANY/ALL argument must be cast to an array type")
+			}
+			firstCast = false
+			v, err = p.checkCastSafety(v, typeName)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	_, err := p.parseArrayLiteral()
+	return err
+}
+
+// parseArrayLiteral := '(' parseArrayLiteral ')' castSuffix* |
+// ARRAY '[' (parseLiteralItemValue (',' parseLiteralItemValue)*)? ']' castSuffix*
+//
+// The leading recursive parenthesis form matches how pg_get_expr renders a
+// whole-array cast pushed outside the ARRAY constructor:
+// "(ARRAY['a'::text])::text[]". Each recursion into that form is bounded by
+// enterDepth, the same guard a parenthesized boolean expression uses.
+//
+// It returns each element's literal text and whether that literal was a
+// string, so parseArrayCastSuffix can check a cast pushed outside the
+// constructor against every element (client-destination-trust.md CT-1(h)):
+// without this, a cast reaching the whole array instead of each element
+// individually had no element to check at all.
+func (p *checkParser) parseArrayLiteral() ([]literalValue, error) {
+	var elems []literalValue
+	if p.peek().kind == tokLParen {
+		if err := p.enterDepth(); err != nil {
+			return nil, err
+		}
+		defer p.exitDepth()
+		p.next()
+		var err error
+		elems, err = p.parseArrayLiteral()
+		if err != nil {
+			return nil, err
+		}
+		if p.peek().kind != tokRParen {
+			return nil, p.unsupported("ARRAY", "unbalanced parenthesis in an ARRAY literal")
+		}
+		p.next()
+	} else {
+		if !p.isKeyword("ARRAY") {
+			return nil, p.unsupported("ARRAY", "expected an ARRAY[...] literal")
+		}
+		p.next()
+		if p.peek().kind != tokLBracket {
+			return nil, p.unsupported("ARRAY", "ARRAY must be followed by '['")
+		}
+		p.next()
+		if p.peek().kind != tokRBracket {
+			var err error
+			elems, err = p.parseLiteralItemList()
+			if err != nil {
+				return nil, err
+			}
+		}
+		if p.peek().kind != tokRBracket {
+			return nil, p.unsupported("ARRAY", "ARRAY literal is never closed with ']'")
+		}
+		p.next()
+	}
+	if err := p.parseArrayCastSuffix(elems); err != nil {
+		return nil, err
+	}
+	return elems, nil
+}
+
+// parseArrayCastSuffix consumes zero or more "::type" or "::type[]" casts
+// trailing an ARRAY literal (or its parenthesized wrapper): the cast
+// pg_get_expr pushes OUTSIDE the ARRAY constructor instead of onto each
+// element. It checks every element against the chain
+// (client-destination-trust.md CT-1(h)).
+//
+// A prior version called checkCastSafety once per (element, cast) pair: an
+// O(elements × casts) cost. checkCastSafety's own allocation ran on every
+// pair, regardless of whether the cast's target type could ever be
+// dangerous. A 4 KB accepted expression built to maximize that product —
+// many short elements, a long harmless cast chain — measured 4.56 ms.
+// That is superlinear, and invisible on the accept side, where nothing
+// fails and no drop is recorded (client-destination-trust.md CT-1(g)).
+//
+// That same version also carried a bug. It passed checkCastSafety this
+// cast's ALREADY-STRIPPED base type name, where the function expects the
+// FULL type name so it can tell an array-suffixed cast from a scalar one
+// itself. Stripped before the call, the function could never see the
+// suffix, so its array guard could never fire from this site. An element
+// that already carries curly-brace array-literal text — a prior
+// "::type[]" cast applied directly to a STRING inside the item, tracked
+// by literalValue.isArrayLiteral — reaching a further array cast here
+// went unchecked (finding: `(ts = ANY (ARRAY['{now}'::text[]]::timestamp[]))`).
+//
+// This version fixes both at once. Correctness first: order does not
+// matter for the property this checks. A special date/time string or an
+// oversized numeric exponent is exactly as dangerous whichever position in
+// the chain reaches a temporal or numeric target. So whether ANY cast in
+// the chain targets a temporal or a numeric base type is a property of the
+// CHAIN alone, computed once with cheap map lookups, no element text
+// touched. Each element is then inspected against that answer AT MOST
+// once, never once per cast:
+//
+//   - an element already carrying isArrayLiteral is opaque curly-brace
+//     array-literal text pg_get_expr wrote directly. It is never set by
+//     THIS function pushing a cast onto an ARRAY[...] element (per
+//     literalValue.isArrayLiteral's own doc comment). A temporal cast
+//     anywhere in the chain rejects it unconditionally, content unseen,
+//     the same as checkCastSafety's own opaque branch.
+//   - an ordinary element's own text is checked directly against
+//     isSpecialTemporalLiteral (temporal) and
+//     stringLiteralExceedsNumericExponent (numeric): the same content
+//     checks checkCastSafety runs. This applies here because
+//     pg_get_expr's own "ARRAY[...]::type[]" form casts each element as a
+//     plain scalar to the element type, never re-parsing the element's
+//     text as a fresh array literal.
+func (p *checkParser) parseArrayCastSuffix(elems []literalValue) error {
+	var chainHasTemporal, chainHasNumeric bool
+	for p.peek().kind == tokDoubleColon {
+		p.next()
+		typeName, err := p.parseTypeName()
+		if err != nil {
+			return err
+		}
+		base := baseTypeName(typeName)
+		if isTemporalTypeName(base) {
+			chainHasTemporal = true
+		}
+		if isNumericTypeName(base) {
+			chainHasNumeric = true
+		}
+	}
+	if !chainHasTemporal && !chainHasNumeric {
+		return nil
+	}
+	for _, e := range elems {
+		if !e.isString {
+			continue
+		}
+		if chainHasTemporal {
+			if e.isArrayLiteral {
+				return p.unsupported("ARRAY", "a string-literal cast to a temporal array type cannot be validated element by element")
+			}
+			if isSpecialTemporalLiteral(e.text) {
+				return p.temporalLiteralError(e.text)
+			}
+		}
+		if chainHasNumeric && stringLiteralExceedsNumericExponent(e.text) {
+			return p.numericMagnitudeError(e.text)
+		}
+	}
+	return nil
+}
+
+// parseLiteralItemList := parseLiteralItemValue (',' parseLiteralItemValue)*
+func (p *checkParser) parseLiteralItemList() ([]literalValue, error) {
+	var elems []literalValue
+	for {
+		v, err := p.parseLiteralItemValue()
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, v)
+		if p.peek().kind != tokComma {
+			return elems, nil
+		}
+		p.next()
+	}
+}
+
+// parseLiteralItemValue := literal ('::' typeName)* | '(' parseLiteralItemValue ')'
+// ('::' typeName)*, where literal is ('+' | '-')? (NUMBER | STRING | TRUE
+// | FALSE | NULL).
+//
+// An ARRAY or IN list holds only literals: a column reference, an
+// arithmetic expression, or anything else here fails the whole CHECK
+// closed rather than guess at the set's members.
+//
+// The parenthesized form matches pg_get_expr's own deparse of an IN list
+// or an ARRAY literal on any non-integer numeric column: each element
+// comes back as "(1)::numeric", and a whole-array cast pushed down per
+// element nests one further, "('x'::character varying)::text". Without
+// this production, that ordinary deparsed shape had no path through the
+// grammar and rejected outright, so a real IN-list CHECK on a numeric,
+// bigint, or double precision column never round-tripped
+// (client-destination-trust.md CT-1). Recursing into the parenthesized
+// form is bounded by enterDepth, the same guard every other nested
+// construct uses.
+//
+// Every cast is checked at checkCastSafety against the item's ORIGINAL
+// literal, carried unchanged through any number of wrapping parentheses
+// and prior casts in the chain (client-destination-trust.md CT-1(h)).
+func (p *checkParser) parseLiteralItemValue() (literalValue, error) {
+	var v literalValue
+	if p.peek().kind == tokLParen {
+		if err := p.enterDepth(); err != nil {
+			return literalValue{}, err
+		}
+		defer p.exitDepth()
+		p.next()
+		inner, err := p.parseLiteralItemValue()
+		if err != nil {
+			return literalValue{}, err
+		}
+		if p.peek().kind != tokRParen {
+			return literalValue{}, p.unsupported("list item", "unbalanced parenthesis in an IN/ARRAY literal item")
+		}
+		p.next()
+		v = inner
+	} else {
+		if p.isOp("+", "-") {
+			p.next()
+		}
+		tok := p.peek()
+		switch {
+		case tok.kind == tokNumber:
+			p.next()
+			v = literalValue{text: tok.text}
+		case tok.kind == tokString:
+			p.next()
+			v = literalValue{text: tok.text, isString: true}
+		case tok.kind == tokIdent && isLiteralKeyword(tok):
+			p.next()
+			v = literalValue{}
+		default:
+			return literalValue{}, p.unsupported("list item", fmt.Sprintf("IN/ARRAY items must be literals, not %s", tok.describe()))
+		}
+	}
+	for p.peek().kind == tokDoubleColon {
+		p.next()
+		typeName, err := p.parseTypeName()
+		if err != nil {
+			return literalValue{}, err
+		}
+		v, err = p.checkCastSafety(v, typeName)
+		if err != nil {
+			return literalValue{}, err
+		}
+	}
+	return v, nil
+}
+
+// parseLiteralList := '(' parseLiteralItemValue (',' parseLiteralItemValue)* ')',
+// the argument list of IN.
+func (p *checkParser) parseLiteralList() error {
+	if p.peek().kind != tokLParen {
+		return p.unsupported("IN", "IN must be followed by a parenthesized literal list")
+	}
+	p.next()
+	if _, err := p.parseLiteralItemList(); err != nil {
+		return err
+	}
+	if p.peek().kind != tokRParen {
+		return p.unsupported("IN", "IN's literal list is never closed with ')'")
+	}
+	p.next()
+	return nil
+}

--- a/pgcheck/safe_expression_test.go
+++ b/pgcheck/safe_expression_test.go
@@ -1,0 +1,1783 @@
+package pgcheck_test
+
+// Pins CT-1's safe-grammar classifier (client-destination-trust.md §3):
+// every construct SafeCheckExpression must accept, every construct it must
+// reject, the six real CarbonCloud trial CHECK expressions verbatim, and
+// the fail-closed behavior on text the parser cannot fully read.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JacobJNilsson/data-contract-generator/pgcheck"
+)
+
+// The six real, safe CHECK expressions from the CarbonCloud trial
+// destination (client-destination-trust.md CT-1), captured verbatim.
+const (
+	trialBatchSizeDensity     = `((batch_size_density IS NULL) OR (batch_size_density > (0)::double precision))`
+	trialBatchSizeDensityUnit = `((batch_size_density_unit IS NULL) OR (batch_size_density_unit = ANY (ARRAY['kg/l'::text, 'kg/m3'::text, 'g/l'::text, 'g/ml'::text, 'g/cm3'::text, 'lb/us_gal'::text, 'lb/uk_gal'::text])))`
+	trialPackagingNetContent  = `(packaging_net_content > (0)::numeric)`
+	trialSecondaryUnitCount   = `(packaging_secondary_unit_count > 0)`
+	trialRecyclingRate        = `(((0)::double precision <= recycling_rate) AND (recycling_rate <= (1.0)::double precision))`
+	trialVariantRoute         = `((variant = 'route'::text) = (route_id IS NOT NULL))`
+)
+
+// Real, benign CHECK expressions that call a function. CT-1 rejects every
+// one of these too: the platform cannot mechanically tell a benign call
+// from a malicious one, so the grammar excludes all function calls
+// (client-destination-trust.md §3, CT-1 rationale).
+const (
+	rejectPgSleep     = `(pg_sleep((1e9)::double precision) IS NOT NULL)`
+	rejectLoImport    = `(lo_import('/etc/passwd'::text) > 0)`
+	rejectJSONBTypeof = `((metadata IS NULL) OR (jsonb_typeof(metadata) = 'object'::text))`
+	rejectLength      = `(length(name) < 100)`
+)
+
+func TestSafeCheckExpression_AcceptsTrialExpressions(t *testing.T) {
+	cases := []string{
+		trialBatchSizeDensity,
+		trialBatchSizeDensityUnit,
+		trialPackagingNetContent,
+		trialSecondaryUnitCount,
+		trialRecyclingRate,
+		trialVariantRoute,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil (real, safe trial constraint)", expr, err)
+			}
+		})
+	}
+}
+
+func TestSafeCheckExpression_AcceptsEachConstruct(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{"bare column reference", `is_active`},
+		{"string literal", `(name = 'a'::text)`},
+		{"number literal", `(amount = 1)`},
+		{"decimal literal", `(rate = 1.5)`},
+		{"exponent literal", `(rate > 1e-5)`},
+		{"boolean literal true", `(is_active = true)`},
+		{"boolean literal false", `(is_active = false)`},
+		{"NULL literal", `(deleted_at = NULL)`},
+		{"equals", `(a = 1)`},
+		{"not-equals angle-bracket", `(a <> 1)`},
+		{"not-equals bang", `(a != 1)`},
+		{"less than", `(a < 1)`},
+		{"less or equal", `(a <= 1)`},
+		{"greater than", `(a > 1)`},
+		{"greater or equal", `(a >= 1)`},
+		{"AND", `(a > 0) AND (b > 0)`},
+		{"OR", `(a > 0) OR (b > 0)`},
+		{"NOT", `NOT (a > 0)`},
+		{"addition", `(a + b > 0)`},
+		{"subtraction", `(a - b > 0)`},
+		{"multiplication", `(a * b > 0)`},
+		{"division", `(a / b > 0)`},
+		{"modulo", `(a % b = 0)`},
+		{"unary minus", `(a > -1)`},
+		{"unary plus", `(a = +1)`},
+		{"double unary minus separated by a space, not a comment", `(a - -1 > 0)`},
+		{"IS NULL", `(a IS NULL)`},
+		{"IS NOT NULL", `(a IS NOT NULL)`},
+		{"IS TRUE", `(flag IS TRUE)`},
+		{"IS NOT FALSE", `(flag IS NOT FALSE)`},
+		{"IS NOT UNKNOWN", `(flag IS NOT UNKNOWN)`},
+		{"IS UNKNOWN", `(flag IS UNKNOWN)`},
+		{"IS DISTINCT FROM", `(a IS DISTINCT FROM 5)`},
+		{"IS NOT DISTINCT FROM", `(a IS NOT DISTINCT FROM 5)`},
+		{"COLLATE with a comparison", `((t COLLATE "C") > 'a'::text)`},
+		{"ANY over an array-string literal", `(t = ANY ('{a,b}'::text[]))`},
+		{"IN", `(a IN (1, 2, 3))`},
+		{"NOT IN", `(a NOT IN (1, 2, 3))`},
+		{"IN over strings", `(a IN ('x', 'y'))`},
+		{"BETWEEN", `(a BETWEEN 1 AND 10)`},
+		{"NOT BETWEEN", `(a NOT BETWEEN 1 AND 10)`},
+		{"LIKE", `(name LIKE 'a%')`},
+		{"NOT LIKE", `(name NOT LIKE 'a%')`},
+		{"ILIKE", `(name ILIKE 'a%')`},
+		{"deparsed LIKE operator", `(name ~~ 'a%')`},
+		{"deparsed ILIKE operator", `(name ~~* 'a%')`},
+		{"deparsed NOT LIKE operator", `(name !~~ 'a%')`},
+		{"deparsed NOT ILIKE operator", `(name !~~* 'a%')`},
+		{"= ANY ARRAY", `(a = ANY (ARRAY[1, 2, 3]))`},
+		{"= ANY ARRAY over cast strings", `(a = ANY (ARRAY['x'::text, 'y'::text]))`},
+		{"= ANY ARRAY with whole-array cast", `(a = ANY ((ARRAY['x'::character varying, 'y'::character varying])::text[]))`},
+		{"<> ALL ARRAY", `(a <> ALL (ARRAY[1, 2]))`},
+		{"!= ALL ARRAY (hand-spelled synonym)", `(a != ALL (ARRAY[1, 2]))`},
+		{"parentheses", `((a > 0))`},
+		{"cast of a literal", `(a = (0)::numeric)`},
+		{"cast of a column", `((a)::text = 'x'::text)`},
+		{"multi-word type name", `(a = (0)::double precision)`},
+		{"type with precision and scale", `(a = (0)::numeric(10, 2))`},
+		{"type with precision only", `(a = (0)::varchar(255))`},
+		{"short alias type name", `(a = (0)::int8)`},
+		{"timestamp type name", `(a = (0)::timestamp)`},
+		{"nested boolean comparison", `((a = 1) = (b IS NOT NULL))`},
+		{"string literal with an escaped quote", `(name = 'it''s')`},
+		{"IN with a negative numeric literal", `(a IN (-1, 2))`},
+		{"IN with boolean and NULL literals", `(a IN (TRUE, FALSE, NULL))`},
+		{"double-quoted identifier", `("Order" > 0)`},
+		{"double-quoted identifier with an escaped quote", `("Ord""er" > 0)`},
+		{"double-quoted reserved word used as a column name", `("AND" > 0)`},
+		{"non-ASCII unquoted identifier", `(årsmängd > 0)`},
+		{"non-ASCII double-quoted identifier", `("årsmängd" > 0)`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(tc.expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", tc.expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_AcceptsModerateNesting pins that an ordinary,
+// realistic amount of parenthesis nesting still parses: the depth bound
+// (client-destination-trust.md CT-1(c)) exists to reject a pathological
+// input, not to squeeze out a real constraint. 50 levels is far beyond
+// anything the CarbonCloud trial's constraints use.
+func TestSafeCheckExpression_AcceptsModerateNesting(t *testing.T) {
+	expr := strings.Repeat("(", 50) + "a > 0" + strings.Repeat(")", 50)
+	if err := pgcheck.SafeCheckExpression(expr); err != nil {
+		t.Errorf("SafeCheckExpression(50 nested parens) = %v, want nil", err)
+	}
+}
+
+// wantUnsupported fails t unless err is a non-nil *UnsafeExpressionError
+// wrapping pgcheck.ErrUnsupportedConstruct, the shared assertion every
+// rejection test below other than a function-call rejection needs.
+func wantUnsupported(t *testing.T, expr string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("SafeCheckExpression(%q) = nil, want a rejection (fail closed)", expr)
+	}
+	if !errors.Is(err, pgcheck.ErrUnsupportedConstruct) {
+		t.Errorf("SafeCheckExpression(%q): errors.Is(err, ErrUnsupportedConstruct) = false, want true (err = %v)", expr, err)
+	}
+	var unsafeErr *pgcheck.UnsafeExpressionError
+	if !errors.As(err, &unsafeErr) {
+		t.Fatalf("SafeCheckExpression(%q): errors.As(err, *UnsafeExpressionError) = false", expr)
+	}
+	if unsafeErr.Reason == "" {
+		t.Error("UnsafeExpressionError.Reason is empty, want a human-readable explanation")
+	}
+}
+
+func TestSafeCheckExpression_RejectsFunctionCalls(t *testing.T) {
+	cases := []struct {
+		name         string
+		expr         string
+		wantFunction string
+	}{
+		{"pg_sleep (DoS)", rejectPgSleep, "pg_sleep"},
+		{"lo_import (file read)", rejectLoImport, "lo_import"},
+		{"jsonb_typeof (real, benign trial constraint, still rejected)", rejectJSONBTypeof, "jsonb_typeof"},
+		{"length (real, benign trial constraint, still rejected)", rejectLength, "length"},
+		{"function call as a comparison operand", `(a = upper('x'))`, "upper"},
+		{"function call inside an argument", `(a = coalesce(b, 0))`, "coalesce"},
+		{"function call in AND's right operand", `(a > 0) AND (pg_sleep(1) IS NOT NULL)`, "pg_sleep"},
+		{"function call in addition's right operand", `(a + pg_sleep(1) > 0)`, "pg_sleep"},
+		{"function call in multiplication's right operand", `(a * pg_sleep(1) > 0)`, "pg_sleep"},
+		{"function call in BETWEEN's low value", `(a BETWEEN pg_sleep(1) AND 10)`, "pg_sleep"},
+		{"double-quoted function name", `("upper"('x') = 'X')`, "upper"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := pgcheck.SafeCheckExpression(tc.expr)
+			if err == nil {
+				t.Fatalf("SafeCheckExpression(%q) = nil, want a function-call refusal", tc.expr)
+			}
+			if !errors.Is(err, pgcheck.ErrFunctionCall) {
+				t.Errorf("SafeCheckExpression(%q): errors.Is(err, ErrFunctionCall) = false, want true (err = %v)", tc.expr, err)
+			}
+			if errors.Is(err, pgcheck.ErrUnsupportedConstruct) {
+				t.Errorf("SafeCheckExpression(%q): errors.Is(err, ErrUnsupportedConstruct) = true, want false (function calls are the other sentinel)", tc.expr)
+			}
+			var unsafeErr *pgcheck.UnsafeExpressionError
+			if !errors.As(err, &unsafeErr) {
+				t.Fatalf("SafeCheckExpression(%q): errors.As(err, *UnsafeExpressionError) = false", tc.expr)
+			}
+			if unsafeErr.Construct != tc.wantFunction {
+				t.Errorf("UnsafeExpressionError.Construct = %q, want %q", unsafeErr.Construct, tc.wantFunction)
+			}
+			if unsafeErr.Expression != tc.expr {
+				t.Errorf("UnsafeExpressionError.Expression = %q, want %q", unsafeErr.Expression, tc.expr)
+			}
+		})
+	}
+}
+
+func TestSafeCheckExpression_RejectsUnsupportedConstructs(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{"empty expression", ``},
+		{"whitespace-only expression", `   `},
+		{"unterminated string literal", `(a = 'x)`},
+		{"malformed exponent, no digits", `(a = 1e)`},
+		{"malformed exponent, sign only", `(a = 1e+)`},
+		{"unrecognized character", `(a @> b)`},
+		{"lone bang operator", `(a ! 1)`},
+		{"lone colon", `(a:b)`},
+		{"unbalanced opening parenthesis", `(a > 1`},
+		{"unbalanced closing parenthesis (trailing input)", `(a > 1))`},
+		{"IS without NULL, TRUE/FALSE/UNKNOWN, or DISTINCT FROM", `(a IS 5)`},
+		{"IS NOT without NULL, TRUE/FALSE/UNKNOWN, or DISTINCT FROM", `(a IS NOT 5)`},
+		{"IS DISTINCT without FROM", `(a IS DISTINCT 5)`},
+		{"IS NOT DISTINCT without FROM", `(a IS NOT DISTINCT 5)`},
+		{"NOT without a following predicate", `(a NOT 1)`},
+		{"BETWEEN without AND", `(a BETWEEN 1 2)`},
+		{"IN without a parenthesised list", `(a IN 1)`},
+		{"IN with a non-literal item", `(a IN (b))`},
+		{"IN with an empty list", `(a IN ())`},
+		{"ANY without ARRAY", `(a = ANY (b))`},
+		{"ANY without a parenthesised argument", `(a = ANY b)`},
+		{"ANY(...) missing its closing parenthesis", `(a = ANY (ARRAY[1] 2))`},
+		{"ALL without a parenthesised argument", `(a <> ALL b)`},
+		{"ARRAY without a bracket", `(a = ANY (ARRAY(1, 2)))`},
+		{"ARRAY with a non-literal item", `(a = ANY (ARRAY[b]))`},
+		{"ARRAY never closed", `(a = ANY (ARRAY[1, 2))`},
+		{"wrapped ARRAY literal, inner failure", `(a = ANY ((ARRAY[b])::text[]))`},
+		{"wrapped ARRAY literal, unbalanced parenthesis", `(a = ANY ((ARRAY[1] 2)::text[]))`},
+		{"ARRAY cast to a reserved word", `(a = ANY (ARRAY[1]::AND))`},
+		{"cast with no type name", `(a::)`},
+		{"cast to a reserved word", `(a::AND)`},
+		{"cast to a regclass type", `(a::regclass)`},
+		{"cast to a regproc type", `(a::regproc)`},
+		{"cast to a regprocedure type", `(a::regprocedure)`},
+		{"cast to a regconfig type", `(a::regconfig)`},
+		{"cast to a regnamespace type", `(a::regnamespace)`},
+		{"cast to an unknown/extension type", `(a::evil_type)`},
+		{"cast to an unknown/extension array type", `(a::evil_type[])`},
+		{"cast to a parenthesised literal, regclass", `(('pg_class'::regclass) IS NOT NULL)`},
+		{"function name used as a type name with a fake typmod", `((a)::pg_sleep(1))`},
+		{"cast precision with no number", `(a::numeric())`},
+		{"cast precision never closed", `(a::numeric(10 2))`},
+		{"cast scale not a number", `(a::numeric(10, x))`},
+		{"cast array marker never closed", `(a::text[)`},
+		{"bare reserved word as a primary", `(AND)`},
+		{"unexpected punctuation where an expression was expected", `(a + )`},
+		{"IN list missing a comma, never closed", `(a IN (1 2))`},
+		{"IN list truncated at end of input", `(a IN (`},
+		{"trailing input after a complete expression", `(a > 1) extra`},
+		{"a word after a valid cast is trailing input, not part of the type", `((a)::text NULL)`},
+		{"a run of words after a valid cast is trailing input", `((a)::text b c)`},
+		{"a run of nonsense words after a valid cast is trailing input", `((a)::i am a banana)`},
+		{"qualified column name", `(t.a > 0)`},
+		{"array subscript on a column", `(a[1] > 0)`},
+		{"field selection on a parenthesised column", `((a).f > 0)`},
+		{"bare tilde operator", `(a ~ 'x%')`},
+		{"tilde at the very end of input", `a ~`},
+		{"bang-tilde with no following tilde", `(a !~ 'x')`},
+		{"unterminated double-quoted identifier", `("Order > 0)`},
+		{"empty double-quoted identifier", `("" > 0)`},
+		{"invalid UTF-8 byte", "(a > \xff)"},
+		{"invalid UTF-8 byte immediately after an identifier character", "(a\xff > 0)"},
+		{"non-letter Unicode symbol", "(€ > 0)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := pgcheck.SafeCheckExpression(tc.expr)
+			wantUnsupported(t, tc.expr, err)
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsCommentSmuggling pins CT-1(a)
+// (client-destination-trust.md): a SQL comment introducer anywhere in the
+// text rejects the whole expression, closing the gap where a '--' or '/*'
+// between a function name and its opening parenthesis let the classifier
+// read one function call as two separate, harmless-looking tokens while
+// Postgres reunites them at execution time.
+func TestSafeCheckExpression_RejectsCommentSmuggling(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{
+			"line comment splits a function name from its call, file read",
+			"(pg_read_file--\n('/etc/passwd') IS NOT NULL)",
+		},
+		{
+			"line comment splits a function name from its call, sleep",
+			"(pg_sleep--\n(1) IS NOT NULL)",
+		},
+		{
+			"line comment splits a function name from its call, large object import",
+			"(lo_import--\n('/etc/passwd') > 0)",
+		},
+		{
+			"nested comment-split calls",
+			"(length--\n(pg_read_file--\n('/etc/passwd')) > 0)",
+		},
+		{
+			"comment body looks like whitespace and arithmetic",
+			"(pg_sleep--    1 + 2 * 3\n(1) IS NOT NULL)",
+		},
+		{
+			"CRLF line ending after the comment introducer",
+			"(pg_read_file--\r\n('/etc/passwd') IS NOT NULL)",
+		},
+		{
+			"comment-smuggled call inside a larger boolean expression",
+			"(a > 0) AND (pg_sleep--\n(1) IS NOT NULL)",
+		},
+		{
+			"block comment splits a function name from its call, leading position",
+			"(/* x */pg_sleep(1) IS NOT NULL)",
+		},
+		{
+			"block comment splits a function name from its call, middle position",
+			"(pg_sleep/* x */(1) IS NOT NULL)",
+		},
+		{
+			"block comment splits a function name from its call, trailing position",
+			"(pg_sleep(1)/* x */ IS NOT NULL)",
+		},
+		{
+			"block comment spanning several lines",
+			"(pg_sleep/*\nmulti\nline\n*/(1) IS NOT NULL)",
+		},
+		{
+			"bare line comment introducer with no following text",
+			"(a > 0) --",
+		},
+		{
+			"bare block comment introducer with no following text",
+			"(a > 0) /*",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := pgcheck.SafeCheckExpression(tc.expr)
+			wantUnsupported(t, tc.expr, err)
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsExcessiveNesting pins CT-1(c)
+// (client-destination-trust.md): the parser tracks recursion depth
+// explicitly and rejects once it passes the documented bound, rather than
+// exhausting the Go stack. Neither case here reaches anywhere near the
+// ~560,000-level input the reviewer used to trigger a real, fatal
+// overflow — the point of the bound is to refuse long before that, with an
+// ordinary error.
+func TestSafeCheckExpression_RejectsExcessiveNesting(t *testing.T) {
+	t.Run("deeply nested parentheses", func(t *testing.T) {
+		expr := strings.Repeat("(", 250)
+		err := pgcheck.SafeCheckExpression(expr)
+		wantUnsupported(t, expr, err)
+	})
+	t.Run("a long chain of NOT", func(t *testing.T) {
+		expr := strings.Repeat("NOT ", 250) + "a"
+		err := pgcheck.SafeCheckExpression(expr)
+		wantUnsupported(t, expr, err)
+	})
+	t.Run("deeply nested ARRAY-literal parenthesis wrapper", func(t *testing.T) {
+		expr := "(a = ANY (" + strings.Repeat("(", 250)
+		err := pgcheck.SafeCheckExpression(expr)
+		wantUnsupported(t, expr, err)
+	})
+}
+
+// TestSafeCheckExpression_RejectsOversizeExpression pins CT-1(c): an
+// expression longer than the documented byte limit rejects before the
+// parser ever runs on it.
+func TestSafeCheckExpression_RejectsOversizeExpression(t *testing.T) {
+	expr := "(a = " + strings.Repeat("1", 4100) + ")"
+	err := pgcheck.SafeCheckExpression(expr)
+	wantUnsupported(t, expr, err)
+	var unsafeErr *pgcheck.UnsafeExpressionError
+	if errors.As(err, &unsafeErr) && unsafeErr.Construct != "length" {
+		t.Errorf("UnsafeExpressionError.Construct = %q, want %q", unsafeErr.Construct, "length")
+	}
+}
+
+// TestSafeCheckExpression_ErrorSatisfiesErrorInterface pins that the
+// returned error's Error() method matches Reason verbatim, the documented
+// contract a caller that only logs the message relies on.
+func TestSafeCheckExpression_ErrorSatisfiesErrorInterface(t *testing.T) {
+	err := pgcheck.SafeCheckExpression(rejectPgSleep)
+	var unsafeErr *pgcheck.UnsafeExpressionError
+	if !errors.As(err, &unsafeErr) {
+		t.Fatalf("errors.As(err, *UnsafeExpressionError) = false")
+	}
+	if err.Error() != unsafeErr.Reason {
+		t.Errorf("err.Error() = %q, want Reason %q", err.Error(), unsafeErr.Reason)
+	}
+}
+
+// TestSafeCheckExpression_RejectsBareSQLValueFunctions pins CT-1(e)
+// (client-destination-trust.md): Postgres's parenthesis-less SQL value
+// functions evaluate per row and leak the mirror's own role, database,
+// schema, or clock into a CHECK's pass/fail outcome, and CT-2's REVOKE
+// cannot back them up — Postgres evaluates each one inline, without ever
+// dispatching through pg_proc. An "identifier immediately followed by '('"
+// rule for detecting a function call misses every one of them, so each
+// must reject on its own; a genuine column sharing the reserved word's
+// spelling still works when quoted.
+func TestSafeCheckExpression_RejectsBareSQLValueFunctions(t *testing.T) {
+	names := []string{
+		"CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP",
+		"LOCALTIME", "LOCALTIMESTAMP",
+		"CURRENT_ROLE", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER",
+		"CURRENT_CATALOG", "CURRENT_SCHEMA",
+	}
+	for _, name := range names {
+		t.Run("rejects bare "+name, func(t *testing.T) {
+			expr := fmt.Sprintf("(name <> %s)", name)
+			err := pgcheck.SafeCheckExpression(expr)
+			wantUnsupported(t, expr, err)
+		})
+		t.Run("accepts quoted "+name+" as a column", func(t *testing.T) {
+			expr := fmt.Sprintf(`(name <> "%s")`, name)
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil (quoted, a genuine column name)", expr, err)
+			}
+		})
+	}
+
+	// The four members that also take an optional precision already
+	// reject as an ordinary function call when parenthesized; pinned here
+	// so a future change to reservedWords cannot silently stop covering
+	// them.
+	parenthesized := []string{
+		"CURRENT_TIME(3)", "CURRENT_TIMESTAMP(3)", "LOCALTIME(3)", "LOCALTIMESTAMP(3)",
+	}
+	for _, name := range parenthesized {
+		t.Run("rejects parenthesized "+name, func(t *testing.T) {
+			expr := fmt.Sprintf("(a > %s)", name)
+			err := pgcheck.SafeCheckExpression(expr)
+			if !errors.Is(err, pgcheck.ErrFunctionCall) {
+				t.Errorf("SafeCheckExpression(%q): errors.Is(err, ErrFunctionCall) = false, want true (err = %v)", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_BoundsTypeModifier pins CT-1(f)
+// (client-destination-trust.md): bpchar blank-pads a fixed-length value
+// out to its full typmod, so an unbounded precision, scale, or length is a
+// memory-amplification primitive, not merely a large accepted number. An
+// ordinary, real-world typmod still accepts, on every type that takes one.
+func TestSafeCheckExpression_BoundsTypeModifier(t *testing.T) {
+	oversize := []string{
+		`(a = ''::char(10485760))`,
+		`(a = ''::character(10485760))`,
+		`(a = ''::bpchar(10485760))`,
+		`(a = ''::varchar(10485760))`,
+		`(a = (0)::numeric(10485760, 2))`,
+		`(a = (0)::numeric(10, 10485760))`,
+		`(a = ''::varchar(10001))`,
+	}
+	for _, expr := range oversize {
+		t.Run(expr, func(t *testing.T) {
+			err := pgcheck.SafeCheckExpression(expr)
+			wantUnsupported(t, expr, err)
+		})
+	}
+	ordinary := []string{
+		`(a = ''::char(10))`,
+		`(a = ''::varchar(255))`,
+		`(a = (0)::numeric(10, 2))`,
+		`(a = ''::character(4000))`,
+		`(a = ''::varchar(10000))`, // exactly at the bound
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_AcceptsParenthesizedListItems pins CONCERN 3
+// (the second adversarial review): pg_get_expr deparses an IN list or an
+// ARRAY literal on any non-integer numeric column with each element
+// wrapped and cast, "(1)::numeric", and a whole-array cast pushed down per
+// element nests one further, "('x'::character varying)::text". Without a
+// parenthesized-element production the grammar rejected its own platform's
+// common, real deparsed shape.
+func TestSafeCheckExpression_AcceptsParenthesizedListItems(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{"numeric IN list, deparsed", `(n = ANY (ARRAY[(1)::numeric, (2)::numeric]))`},
+		{"double precision IN list, deparsed", `(n = ANY (ARRAY[(1)::double precision, (2)::double precision]))`},
+		{"bigint IN list, deparsed", `(n = ANY (ARRAY[(1)::bigint, (2)::bigint]))`},
+		{"whole-array cast, per-element cast-down", `(a = ANY (ARRAY[('x'::character varying)::text]))`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(tc.expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", tc.expr, err)
+			}
+		})
+	}
+	t.Run("a non-literal inside the parenthesized form still rejects", func(t *testing.T) {
+		expr := `(n = ANY (ARRAY[(b)::numeric]))`
+		err := pgcheck.SafeCheckExpression(expr)
+		wantUnsupported(t, expr, err)
+	})
+	t.Run("unbalanced parenthesis inside a literal item rejects", func(t *testing.T) {
+		expr := `(n = ANY (ARRAY[(1 2]))`
+		err := pgcheck.SafeCheckExpression(expr)
+		wantUnsupported(t, expr, err)
+	})
+	t.Run("a literal item cast to an unrecognized type rejects", func(t *testing.T) {
+		expr := `(a = ANY (ARRAY[1::evil_type]))`
+		err := pgcheck.SafeCheckExpression(expr)
+		wantUnsupported(t, expr, err)
+	})
+	t.Run("excessive nesting inside a literal item rejects, not panics", func(t *testing.T) {
+		expr := "(a = ANY (ARRAY[" + strings.Repeat("(", 250)
+		err := pgcheck.SafeCheckExpression(expr)
+		wantUnsupported(t, expr, err)
+	})
+}
+
+// TestSafeCheckExpression_PinsAllowlistedTypeNames pins every entry in
+// CT-1's cast-target allowlist (client-destination-trust.md CT-1(b)) as an
+// accepted cast target. CONCERN 4 (the second adversarial review): mutating
+// the source to delete several allowlist entries — all four multi-word
+// entries, or eight of the single-word ones — passed the whole suite
+// unchanged, because nothing exercised those specific type names as an
+// accept case.
+func TestSafeCheckExpression_PinsAllowlistedTypeNames(t *testing.T) {
+	singleWord := []string{
+		"text", "varchar", "char", "character", "bpchar",
+		"smallint", "int2", "integer", "int4", "bigint", "int8",
+		"numeric", "decimal", "real", "float4", "float8",
+		"boolean", "bool", "date", "time", "timestamp", "timestamptz",
+		"interval", "uuid", "bytea", "json", "jsonb",
+	}
+	multiWord := []string{
+		"double precision",
+		"character varying",
+		"timestamp with time zone",
+		"timestamp without time zone",
+		"time with time zone",
+		"time without time zone",
+	}
+	for _, name := range append(append([]string{}, singleWord...), multiWord...) {
+		t.Run("accepts "+name, func(t *testing.T) {
+			expr := fmt.Sprintf("(a = (0)::%s)", name)
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+
+	// Representative near-misses: a type deliberately left off the
+	// allowlist (CT-1(b): a reg* type resolves through a catalog lookup
+	// that runs its own code, and money/oid/xml/inet are simply not on
+	// it), and the lone first word of a multi-word type name that is not
+	// itself a valid single-word type.
+	rejects := []string{"money", "regclass", "double", "oid", "xml", "inet"}
+	for _, name := range rejects {
+		t.Run("rejects "+name, func(t *testing.T) {
+			expr := fmt.Sprintf("(a = (0)::%s)", name)
+			err := pgcheck.SafeCheckExpression(expr)
+			wantUnsupported(t, expr, err)
+		})
+	}
+}
+
+// TestSafeCheckExpression_PinsParserLoops pins three constructs whose
+// grammar production is a loop, not a single optional occurrence.
+// CONCERN 4 (the second adversarial review): mutating parseCast's cast
+// loop, parseUnary's sign loop, and parseTypeName's '[]' loop to each run
+// at most once passed the whole suite unchanged, because nothing needed a
+// SECOND iteration to parse.
+func TestSafeCheckExpression_PinsParserLoops(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{"chained cast, parseCast's loop", `(a::text::text = 'x'::text)`},
+		{"chained unary minus, parseUnary's loop", `(a = - -1)`},
+		{"doubly nested array cast, parseTypeName's '[]' loop", `((a)::text[][] IS NOT NULL)`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(tc.expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", tc.expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_QuotedLiteralKeywordIsAnIdentifier pins that
+// isLiteralKeyword's exemption for a quoted token (CONCERN 4, the second
+// adversarial review) is load-bearing, not redundant with the plain-
+// identifier fallback further down parseIdentPrimary: a quoted "true"
+// immediately followed by '(' must be read as a function call — Postgres
+// allows a quoted function name exactly as it allows a quoted column name
+// — not silently consumed as the TRUE literal, stranding "('x')" as
+// trailing input and reporting the wrong error kind.
+func TestSafeCheckExpression_QuotedLiteralKeywordIsAnIdentifier(t *testing.T) {
+	expr := `("true"('x') = 'X')`
+	err := pgcheck.SafeCheckExpression(expr)
+	if !errors.Is(err, pgcheck.ErrFunctionCall) {
+		t.Fatalf("SafeCheckExpression(%q): errors.Is(err, ErrFunctionCall) = false, want true (err = %v)", expr, err)
+	}
+	var unsafeErr *pgcheck.UnsafeExpressionError
+	if !errors.As(err, &unsafeErr) {
+		t.Fatalf("SafeCheckExpression(%q): errors.As(err, *UnsafeExpressionError) = false", expr)
+	}
+	if unsafeErr.Construct != "true" {
+		t.Errorf("UnsafeExpressionError.Construct = %q, want %q", unsafeErr.Construct, "true")
+	}
+
+	// The non-function form: a quoted TRUE/FALSE/NULL spelling is a plain
+	// column reference, comparable like any other column.
+	quoted := `("true" > 0)`
+	if err := pgcheck.SafeCheckExpression(quoted); err != nil {
+		t.Errorf("SafeCheckExpression(%q) = %v, want nil (a quoted column, not the TRUE literal)", quoted, err)
+	}
+}
+
+// TestSafeCheckExpression_RejectsMoreReservedWords pins NIT 5
+// (client-destination-trust.md): a hand-edited YAML CHECK expression that
+// misuses one of Postgres's reserved words as a bare column reference
+// fails closed here instead of failing loudly downstream, when the
+// mirror's own ADD CONSTRAINT hits a genuine Postgres syntax error. A
+// genuine column sharing the word's spelling still works when quoted.
+func TestSafeCheckExpression_RejectsMoreReservedWords(t *testing.T) {
+	words := []string{"AS", "SELECT", "TABLE"}
+	for _, w := range words {
+		t.Run("rejects bare "+w, func(t *testing.T) {
+			expr := fmt.Sprintf("(%s > 0)", w)
+			err := pgcheck.SafeCheckExpression(expr)
+			wantUnsupported(t, expr, err)
+		})
+		t.Run("accepts quoted "+w, func(t *testing.T) {
+			expr := fmt.Sprintf(`("%s" > 0)`, w)
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsMaximalMunchOperator pins NIT 6
+// (client-destination-trust.md): Postgres reads a run of operator
+// characters as one token, trimming a trailing '+'/'-' only when the
+// remaining characters carry none of Postgres's "special" operator
+// characters. "~~-" keeps its trailing '-' (the prefix "~~" contains
+// '~'), so Postgres reads it as one unrecognized operator and errors —
+// the classifier must reject it too, rather than read the deparsed
+// LIKE-operator "~~" and strand the '-' as if it were a separate,
+// harmless token.
+func TestSafeCheckExpression_RejectsMaximalMunchOperator(t *testing.T) {
+	expr := `(name ~~- 'x')`
+	err := pgcheck.SafeCheckExpression(expr)
+	wantUnsupported(t, expr, err)
+}
+
+// TestSafeCheckExpression_TrimsPlainTrailingMinus pins the other side of
+// NIT 6's rule: "=-" does NOT keep its trailing '-' ("=" alone carries
+// none of Postgres's special operator characters), so Postgres reads it
+// as two tokens, "=" then "-", and this classifier must keep doing the
+// same — accepting "(name =- 'x')" as "name" compared to the unary minus
+// of a string literal, not rejecting the whole expression as one
+// unrecognized operator the way "~~-" correctly does.
+func TestSafeCheckExpression_TrimsPlainTrailingMinus(t *testing.T) {
+	expr := `(name =- 'x')`
+	if err := pgcheck.SafeCheckExpression(expr); err != nil {
+		t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+	}
+}
+
+// TestSafeCheckExpression_OperatorScanIsLinear pins CT-1(g)
+// (client-destination-trust.md): the classifier's OWN cost must stay
+// bounded, not only the input length. A prior version of the operator
+// scanner cost the CUBE of the run's length — this exact 4093-byte input (a
+// long run of alternating '+' and '-', the reviewer's worst case) cost 4.22
+// CPU-seconds under it. It must now classify in well under a second, even
+// on a slow CI machine: the run is far longer than the grammar allows for
+// any real operator, so it rejects, but the rejection itself must be fast.
+func TestSafeCheckExpression_OperatorScanIsLinear(t *testing.T) {
+	expr := "(a = " + strings.Repeat("+-", 2043) + "1)"
+	if len(expr) != 4093 {
+		t.Fatalf("test setup: built %d bytes, want 4093", len(expr))
+	}
+	start := time.Now()
+	err := pgcheck.SafeCheckExpression(expr)
+	elapsed := time.Since(start)
+	if elapsed > time.Second {
+		t.Errorf("SafeCheckExpression took %s for a 4 KB adversarial operator run, want well under 1s", elapsed)
+	}
+	wantUnsupported(t, expr, err)
+}
+
+// TestSafeCheckExpression_OperatorScanScalesLinearly pins the same
+// property at several run lengths: growth must stay roughly proportional
+// to length, not explode. Each length only needs to stay fast in absolute
+// terms; this is not a precise curve-fit, which would flake on a loaded CI
+// machine.
+func TestSafeCheckExpression_OperatorScanScalesLinearly(t *testing.T) {
+	for _, n := range []int{250, 500, 1000, 2000, 4000} {
+		t.Run(fmt.Sprintf("run length %d", n), func(t *testing.T) {
+			expr := "(a = " + strings.Repeat("+-", n/2) + "1)"
+			start := time.Now()
+			_ = pgcheck.SafeCheckExpression(expr)
+			if elapsed := time.Since(start); elapsed > time.Second {
+				t.Errorf("SafeCheckExpression took %s for a %d-byte operator run, want well under 1s", elapsed, n)
+			}
+		})
+	}
+}
+
+// buildArrayCastAmplificationInput builds an accepted CHECK expression
+// shaped to maximize parseArrayCastSuffix's old O(elements × casts) cost at
+// roughly totalBytes total length: half the byte budget spent on many
+// short string elements, the other half on a long chain of harmless
+// (non-temporal, non-numeric) casts pushed outside the ARRAY constructor.
+// Neither dimension alone reaches the byte cap; the PRODUCT of the two did,
+// under the implementation this pins against regressing to.
+func buildArrayCastAmplificationInput(totalBytes int) string {
+	const prefix, midpoint, suffix = "(a = ANY (ARRAY[", "]", "))"
+	budget := totalBytes - len(prefix) - len(midpoint) - len(suffix)
+	elemBudget := budget / 2
+	castBudget := budget - elemBudget
+
+	const elemUnit, castUnit = "'a',", "::text[]"
+	n := elemBudget / len(elemUnit)
+	elems := strings.TrimSuffix(strings.Repeat(elemUnit, n), ",")
+	casts := strings.Repeat(castUnit, castBudget/len(castUnit))
+
+	return prefix + elems + midpoint + casts + suffix
+}
+
+// TestSafeCheckExpression_ArrayCastThreadingIsLinear pins CONCERN 4 (the
+// fifth adversarial review, client-destination-trust.md CT-1(g)): the
+// threading between parseArrayLiteral and parseArrayCastSuffix must cost
+// time proportional to the expression's length, never the PRODUCT of its
+// element count and its cast-chain length. A prior version cost the two
+// multiplied together: 4 KB of accepted text, shaped to maximize that
+// product, measured 4.56 ms — not a repeat of CT-1(g)'s earlier
+// 4.22-CPU-second finding, but a real superlinear cost on the ACCEPT side,
+// where nothing fails and no drop is recorded.
+func TestSafeCheckExpression_ArrayCastThreadingIsLinear(t *testing.T) {
+	const documentedLimit = 4096
+	expr := buildArrayCastAmplificationInput(documentedLimit - 1)
+	if len(expr) > documentedLimit {
+		t.Fatalf("test setup: built %d bytes, want at most %d", len(expr), documentedLimit)
+	}
+	start := time.Now()
+	err := pgcheck.SafeCheckExpression(expr)
+	elapsed := time.Since(start)
+	if elapsed > time.Second {
+		t.Errorf("SafeCheckExpression took %s for a %d-byte array-cast amplification input, want well under 1s", elapsed, len(expr))
+	}
+	if err != nil {
+		t.Errorf("SafeCheckExpression(...) = %v, want nil (every element and every cast in the chain is harmless)", err)
+	}
+}
+
+// TestSafeCheckExpression_ArrayCastThreadingScalesLinearly pins the same
+// property at several lengths: growth must stay roughly proportional to
+// length, not explode. Each length only needs to stay fast in absolute
+// terms; this is not a precise curve-fit, which would flake on a loaded CI
+// machine — the same rationale
+// TestSafeCheckExpression_OperatorScanScalesLinearly documents for the
+// analogous operator-scan property.
+func TestSafeCheckExpression_ArrayCastThreadingScalesLinearly(t *testing.T) {
+	for _, n := range []int{500, 1000, 2000, 4000} {
+		t.Run(fmt.Sprintf("length %d", n), func(t *testing.T) {
+			expr := buildArrayCastAmplificationInput(n)
+			start := time.Now()
+			_ = pgcheck.SafeCheckExpression(expr)
+			if elapsed := time.Since(start); elapsed > time.Second {
+				t.Errorf("SafeCheckExpression took %s for a %d-byte array-cast amplification input, want well under 1s", elapsed, n)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsPercentSignOperators pins CONCERN 2's fix
+// (client-destination-trust.md CT-1): specialOperatorChars must include
+// '%', Postgres's own qualifying set, so "%-" and its kin tokenize as ONE
+// unrecognized operator, the same way Postgres reads them, instead of
+// being silently trimmed down to the recognized "%" (modulo) operator.
+func TestSafeCheckExpression_RejectsPercentSignOperators(t *testing.T) {
+	cases := []string{
+		`(a %- 1 = 0)`,
+		`(a %+ 1 = 0)`,
+		`(a %++ 1 = 0)`,
+		`(a %+- 1 = 0)`,
+		`(a %-+ 1 = 0)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// The plain modulo operator, and a modulo directly followed by a
+	// SEPARATE trailing minus with no other special character between them,
+	// still work: this rule must not reject ordinary arithmetic.
+	if err := pgcheck.SafeCheckExpression(`(a % b = 0)`); err != nil {
+		t.Errorf("SafeCheckExpression(%q) = %v, want nil", `(a % b = 0)`, err)
+	}
+}
+
+// TestSafeCheckExpression_BoundsNumericExponent pins CONCERN 3
+// (client-destination-trust.md CT-1): a numeric literal's exponent must be
+// bounded, or a tiny literal like "1e131071" expands to tens of megabytes
+// once Postgres installs the constraint and the platform reads the deparse
+// back. Every realistic constraint literal — plain scientific notation, a
+// long-but-sane decimal with no exponent at all — must still accept.
+func TestSafeCheckExpression_BoundsNumericExponent(t *testing.T) {
+	oversize := []string{
+		`(a = 1e1001)`,
+		`(a = 1e131071)`,
+		`(a = 1e-1001)`,
+		`(a = ANY (ARRAY[1e131071]))`,
+	}
+	for _, expr := range oversize {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	ordinary := []string{
+		`(a = 1e6)`,
+		`(rate > 1.5e-3)`,
+		`(a = 1e1000)`,                    // exactly at the bound
+		`(a = 1e-1000)`,                   // exactly at the bound, negative
+		`(a = 123456789012345.123456789)`, // long, but a plain decimal, no exponent
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_BoundsNumericExponentWithDigitSeparators pins
+// client-destination-trust.md CT-1(h): Postgres 16 accepts '_' as a digit
+// separator inside a numeric literal's exponent. "1e1_31071" is the
+// exponent 131071 to Postgres, not 1 — scanning the exponent's digits
+// without skipping '_' read the wrong, far smaller magnitude and let the
+// same amplification through under a second spelling. This bounds a bare
+// NUMBER token (scanNumber), a STRING literal cast to numeric
+// (stringLiteralExceedsNumericExponent), and both through the ANY/ARRAY
+// paths that reuse the same check.
+func TestSafeCheckExpression_BoundsNumericExponentWithDigitSeparators(t *testing.T) {
+	cases := []string{
+		`(b = 1e1_31071)`, // a bare NUMBER token: scanNumber's own bound
+		`(b = '1e1_31071'::numeric)`,
+		`(b = ANY (ARRAY['1e1_31071']::numeric[]))`,
+		`(b = ANY ('{1e1_31071}'::numeric[]))`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	ordinary := []string{
+		`(b = 1e1_000)`,            // exponent 1000, at the bound, digit-separated
+		`(b = '1e1_000'::numeric)`, // the same bound through a string cast
+		`(b = ANY (ARRAY[1e1_000]))`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsSpecialTemporalLiterals pins CONCERN 4
+// (client-destination-trust.md CT-1): Postgres evaluates a special
+// date/time input string (now, today, tomorrow, yesterday, epoch,
+// infinity, -infinity, allballs) at parse analysis time and freezes the
+// mirror's own wall clock into the stored constant — the same class of
+// leak CT-1(e) already closes for CURRENT_TIMESTAMP, reopened by a cast.
+// An ordinary date/timestamp literal must still accept.
+func TestSafeCheckExpression_RejectsSpecialTemporalLiterals(t *testing.T) {
+	cases := []string{
+		`(ts < 'now'::timestamp)`,
+		`(ts < 'now'::timestamp with time zone)`,
+		`(d = 'today'::date)`,
+		`(d = 'tomorrow'::date)`,
+		`(d = 'yesterday'::date)`,
+		`(d = 'epoch'::date)`,
+		`(ts = 'infinity'::timestamp)`,
+		`(ts = '-infinity'::timestamp)`,
+		`(t = 'allballs'::time)`,
+		`(d = 'NOW'::date)`,   // case-insensitive
+		`(d = ' now '::date)`, // whitespace-trimmed
+		`(a = ANY (ARRAY['now'::timestamp]))`,
+		`(a IN ('today'::date))`,
+		`(ts = 'now'::text::timestamp)`, // still frozen on the SECOND cast
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	ordinary := []string{
+		`(d = '2024-01-15'::date)`,
+		`(ts = '2024-01-15 10:00:00'::timestamp)`,
+		`(name = 'now')`,       // no cast at all: an ordinary string comparison
+		`(name = 'now'::text)`, // cast to a NON-temporal type: not the frozen-clock channel
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsDivisionByLiteralZero pins CONCERN 5
+// (client-destination-trust.md CT-1): a division or modulo whose divisor
+// is a literal zero always errors at evaluation, and combined with OR
+// turns a CHECK into a per-row error oracle (ERROR vs. violation). Ordinary
+// division, including by a column this parser cannot evaluate statically,
+// still accepts: SafeCheckExpression does not try to predict every way an
+// expression might fail, only a divisor whose value it can see directly.
+// A single pair of parentheses used to defeat this check (CT-1(h));
+// TestSafeCheckExpression_RejectsDisguisedZeroDivisor pins the fix.
+func TestSafeCheckExpression_RejectsDivisionByLiteralZero(t *testing.T) {
+	cases := []string{
+		`(a = 1/0)`,
+		`(a / 0 > 1)`,
+		`(a % 0 = 0)`,
+		`((a > 100) OR (1/0 = 1))`,
+		`(a / -0 > 1)`,
+		`(a / 0.0 > 1)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	ordinary := []string{
+		`(a / 2 > 0)`,
+		`(a / b > 0)`,
+		`(a % 3 = 0)`,
+		`(a * 0 = 0)`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsDisguisedZeroDivisor pins
+// client-destination-trust.md CT-1(h): the division-by-zero check's own comment named
+// "(a > 100) OR (1/(0) = 1)" as the attack it catches, but a single pair of
+// parentheses, a unary plus, or a cast defeated the original purely
+// syntactic check. The check now bounds the VALUE a divisor reduces to,
+// through the same parentheses-and-casts choke point every other
+// cast-reaching check uses, not the one bare "a / 0" shape a prior version
+// matched.
+func TestSafeCheckExpression_RejectsDisguisedZeroDivisor(t *testing.T) {
+	cases := []string{
+		`((a > 100) OR (1/(0) = 1))`,
+		`(a / (0) > 1)`,
+		`(a / +(0) > 1)`,
+		`(a % (0) = 0)`,
+		`(a / 0::numeric > 1)`,
+		`(a / '0'::numeric > 1)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// A non-zero value reached the same way must still accept: the fix
+	// bounds the VALUE, not every parenthesized or cast divisor.
+	ordinary := []string{
+		`(a / (2) > 0)`,
+		`(a / +(2) > 0)`,
+		`(a / 2::numeric > 0)`,
+		`(a / '2'::numeric > 0)`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsNonIntegerTypeModifier pins a mutation
+// survivor from the second adversarial review (client-destination-trust.md
+// CT-1(f)): parseTypeModifierNumber's "err != nil ||" guard is
+// load-bearing on its own. strconv.Atoi returns n=0 on a parse failure, so
+// a mutant that drops the err check would let a non-integer typmod like
+// "1e9" — a valid NUMBER token, but not a plain integer — through as if it
+// were 0, bypassing the bound entirely.
+func TestSafeCheckExpression_RejectsNonIntegerTypeModifier(t *testing.T) {
+	expr := `(a = (0)::char(1e9))`
+	wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+}
+
+// TestSafeCheckExpression_ChainedArrayCastLoops pins a mutation survivor
+// (client-destination-trust.md CT-1): parseArrayCastSuffix's "for" must run
+// more than once. A SECOND "::type" cast chained after an ARRAY literal
+// only parses if the loop keeps going past its first iteration.
+func TestSafeCheckExpression_ChainedArrayCastLoops(t *testing.T) {
+	expr := `(a = ANY ((ARRAY[1, 2])::integer[]::integer[]))`
+	if err := pgcheck.SafeCheckExpression(expr); err != nil {
+		t.Errorf("SafeCheckExpression(%q) = %v, want nil (a second chained array cast)", expr, err)
+	}
+}
+
+// TestSafeCheckExpression_AcceptsNumberElementsUnderDangerousChain pins
+// parseArrayCastSuffix's per-element isString guard: a NUMBER element (not
+// a STRING) never carries the temporal or numeric-magnitude danger
+// checkCastSafety exists to catch, even when the outer cast chain itself
+// targets a numeric or temporal type, so it must be skipped rather than
+// inspected.
+func TestSafeCheckExpression_AcceptsNumberElementsUnderDangerousChain(t *testing.T) {
+	cases := []string{
+		`(a = ANY (ARRAY[1, 2]::numeric[]))`,
+		`(a = ANY (ARRAY[1, 2]::timestamp[]))`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsQuotedCastType pins a mutation survivor
+// (client-destination-trust.md CT-1(b)): consumeTypeName's "!tok.quoted"
+// check is load-bearing on its own. pg_get_expr never quotes a built-in
+// type name, so a double-quoted "text" after '::' must reject even though
+// "text" unquoted is on the allowlist.
+func TestSafeCheckExpression_RejectsQuotedCastType(t *testing.T) {
+	expr := `(a::"text" = 'x')`
+	wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+}
+
+// TestSafeCheckExpression_RejectsCommentInsideStringLiteral pins
+// rejectCommentIntroducer's block-comment branch in isolation
+// (client-destination-trust.md CT-1(a)): every existing block-comment test
+// case is ALSO caught by the ordinary operator allowlist, because '/' and
+// '*' are both operator characters and "/*" is never a recognized
+// operator. Placed inside a STRING LITERAL instead, "/*" and "--" never
+// reach the operator scanner at all — scanStringLiteral just copies the
+// bytes — so only the dedicated pre-tokenizing check catches them there.
+func TestSafeCheckExpression_RejectsCommentInsideStringLiteral(t *testing.T) {
+	cases := []string{
+		`(name = 'a/*b')`,
+		`(name = 'a--b')`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsMalformedExponent pins scanNumber's
+// malformed-exponent return in isolation (a mutation survivor): the
+// rejection's Construct must be "number", not merely SOME rejection from a
+// different code path (like trailing input), so a mutant that lets a
+// malformed exponent through to be misread elsewhere still fails this
+// test.
+func TestSafeCheckExpression_RejectsMalformedExponent(t *testing.T) {
+	cases := []string{`(a = 1e)`, `(a = 1e+)`, `(a = 1e-)`}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			err := pgcheck.SafeCheckExpression(expr)
+			wantUnsupported(t, expr, err)
+			var unsafeErr *pgcheck.UnsafeExpressionError
+			if errors.As(err, &unsafeErr) && unsafeErr.Construct != "number" {
+				t.Errorf("UnsafeExpressionError.Construct = %q, want %q", unsafeErr.Construct, "number")
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_AcceptsBooleanTest pins NIT 7
+// (client-destination-trust.md): IS [NOT] TRUE/FALSE/UNKNOWN is a
+// BooleanTest node — no function dispatch at all — so it belongs in the
+// safe grammar the same way IS [NOT] NULL already does.
+func TestSafeCheckExpression_AcceptsBooleanTest(t *testing.T) {
+	cases := []string{
+		`(flag IS TRUE)`,
+		`(flag IS NOT TRUE)`,
+		`(flag IS FALSE)`,
+		`(flag IS NOT FALSE)`,
+		`(flag IS UNKNOWN)`,
+		`(flag IS NOT UNKNOWN)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_AcceptsArrayStringLiteral pins NIT 7
+// (client-destination-trust.md): pg_get_expr renders "ANY(<array literal>)"
+// as a single string literal cast to an array type, not always as an
+// ARRAY[...] constructor. A temporal array type rejects instead: this
+// grammar cannot see inside the array-literal string to check each element
+// against Postgres's special date/time input strings.
+func TestSafeCheckExpression_AcceptsArrayStringLiteral(t *testing.T) {
+	if err := pgcheck.SafeCheckExpression(`(t = ANY ('{a,b}'::text[]))`); err != nil {
+		t.Errorf("SafeCheckExpression(%q) = %v, want nil", `(t = ANY ('{a,b}'::text[]))`, err)
+	}
+	rejects := []string{
+		`(t = ANY ('{a,b}'::text))`,   // not an array type
+		`(t = ANY ('{now}'::date[]))`, // a temporal array: cannot verify its contents
+		`(t = ANY ('{now}'::timestamp[]))`,
+		`(t = ANY ('{a,b}'::evil_type[]))`, // not an allowlisted type at all
+	}
+	for _, expr := range rejects {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+}
+
+// TestSafeCheckExpression_AcceptsCollate pins NIT 7
+// (client-destination-trust.md): COLLATE followed by a double-quoted
+// collation name is safe (no function dispatch) and is the form pg_get_expr
+// emits. An unquoted collation name rejects: pg_get_expr always quotes one,
+// so this grammar requires the quote rather than guessing which bare words
+// are safe.
+func TestSafeCheckExpression_AcceptsCollate(t *testing.T) {
+	if err := pgcheck.SafeCheckExpression(`((t COLLATE "C") > 'a'::text)`); err != nil {
+		t.Errorf("SafeCheckExpression(%q) = %v, want nil", `((t COLLATE "C") > 'a'::text)`, err)
+	}
+	expr := `((t COLLATE C) > 'a'::text)`
+	wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+}
+
+// TestSafeCheckExpression_AcceptDoesNotPromiseInstallability pins CONCERN 5
+// (client-destination-trust.md CT-1): ACCEPT means "inside the safe
+// grammar", not "Postgres will install and evaluate it". These both lie
+// inside the grammar and accept, even though each one fails at
+// installation (an input function rejecting its argument) rather than at
+// classification. A caller that installs an accepted expression must treat
+// that installation's own outcome as its own recorded result. (A numeric
+// literal large enough to overflow at ADD CONSTRAINT, like 1e1000000, is no
+// longer an example of this: maxNumericExponent now rejects it at
+// classification time instead, before it ever reaches the mirror.)
+func TestSafeCheckExpression_AcceptDoesNotPromiseInstallability(t *testing.T) {
+	cases := []string{
+		`(a = 'x'::uuid)`,         // input function rejects at ADD CONSTRAINT
+		`(a = ''::char(10000)[])`, // input function rejects at ADD CONSTRAINT
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil (inside the grammar; installability is a separate, later outcome)", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsTemporalLiteralThroughParentheses pins
+// client-destination-trust.md CT-1(h): parseCast used to snapshot the
+// literal at its OWN entry position, so a special date/time string
+// wrapped in one or more
+// parentheses before reaching a temporal cast slipped past — a single pair
+// of parentheses defeated the same check
+// TestSafeCheckExpression_RejectsSpecialTemporalLiterals already pinned for
+// the bare, unparenthesized form. checkCastSafety now sees the literal
+// through any depth of wrapping parentheses and any number of prior casts.
+func TestSafeCheckExpression_RejectsTemporalLiteralThroughParentheses(t *testing.T) {
+	cases := []string{
+		`(ts < ('now'::text)::timestamp without time zone)`, // pg_get_expr's own real form
+		`(('now')::timestamp IS NOT NULL)`,
+		`(a = (('now'))::date)`, // double-wrapped
+		`(ts = ('infinity')::timestamp)`,
+		`(ts = 'now'::timestamptz)`, // the one-word alias, also on the cast allowlist
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// The paren-wrapped literal must still accept when the cast target is
+	// not temporal: the fix bounds the VALUE reaching a DANGEROUS cast, not
+	// every parenthesized literal.
+	ordinary := []string{
+		`(('now')::text = 'x'::text)`,
+		`((('now'))::text = 'x'::text)`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsTemporalArrayCastPaths pins
+// client-destination-trust.md CT-1(h): an earlier fix blocked a string
+// cast to a temporal array type only inside the ANY/ALL argument position
+// (parseArrayOperand). A special
+// date/time string reaches the identical frozen-clock danger through a
+// whole-array cast pushed OUTSIDE the ARRAY constructor
+// (parseArrayCastSuffix, which never inspected the elements it parsed),
+// and through a plain scalar comparison to a string cast to an array type
+// with no ANY/ALL at all. checkCastSafety is now the one choke point every
+// one of these paths runs through.
+func TestSafeCheckExpression_RejectsTemporalArrayCastPaths(t *testing.T) {
+	cases := []string{
+		`(ts = ANY (ARRAY['now']::timestamp[]))`,
+		`(ts = ANY ((ARRAY['now'])::timestamp[]))`,
+		`(ts_arr = '{now}'::timestamp[])`,
+		`('{now}'::timestamp[] IS NOT NULL)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// A non-special element reached the same way must still accept. A
+	// STRING literal cast to a temporal array type rejects unconditionally
+	// regardless of content (this grammar cannot see inside the array
+	// syntax to check each element), so only the ARRAY[...] constructor
+	// form — which parses each element — can accept a temporal element.
+	ordinary := []string{
+		`(ts = ANY (ARRAY['2024-01-15']::date[]))`,
+		`(ts_arr = '{2024-01-15}'::text[])`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsDelimitedSpecialTemporalLiterals pins
+// client-destination-trust.md CT-1(h): Postgres's own date/time parser
+// treats '{', '}', '(', ')', '[', ']', ',', and ':' as field delimiters,
+// exactly like whitespace, when it reads a date/time input string. An
+// exact string match against "now" missed every one of these — Postgres
+// installs '{now}'::timestamp, 'now,'::timestamp, and 'now:'::timestamp as
+// the SAME frozen wall-clock value 'now' alone would freeze. A character
+// outside that delimiter set does not reduce to the special value and
+// Postgres genuinely rejects it, so those forms are ordinary, accepted
+// text as far as this grammar is concerned.
+func TestSafeCheckExpression_RejectsDelimitedSpecialTemporalLiterals(t *testing.T) {
+	cases := []string{
+		`(c = '{now}'::timestamp)`,
+		`(c = '(now)'::timestamp)`,
+		`(c = '[now]'::timestamp)`,
+		`(c = 'now,'::timestamp)`,
+		`(c = 'now:'::timestamp)`,
+		`(d = '{today}'::date)`,
+		`(tz = '{now}'::timestamptz)`,
+		`(c = '{yesterday}'::timestamp)`,
+		`(c = ANY (ARRAY['{now}']::timestamp[]))`,
+		`(c = ANY (ARRAY['{now}'::timestamp]))`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// Postgres's date/time parser does not treat '.', a non-leading '-',
+	// '+', or '/' as a field delimiter, so these do not reduce to the
+	// special value "now" at all; Postgres itself rejects each one as a
+	// malformed date/time string once the CHECK installs, a separate,
+	// non-security failure this grammar does not need to predict.
+	ordinary := []string{
+		`(c = 'now.'::timestamp)`,
+		`(c = '-now'::timestamp)`,
+		`(c = '+now'::timestamp)`,
+		`(c = 'now/'::timestamp)`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_BoundsNumericExponentInStringLiterals pins
+// client-destination-trust.md CT-1(h): maxNumericExponent bounds a NUMBER
+// token's exponent (TestSafeCheckExpression_BoundsNumericExponent), but a
+// magnitude spelled inside a STRING literal was never scanned, and a
+// string cast to numeric is an allowlisted cast. This bounds the same
+// amplification through a second spelling of the value scanNumber already
+// bounds.
+func TestSafeCheckExpression_BoundsNumericExponentInStringLiterals(t *testing.T) {
+	cases := []string{
+		`(a = '1e131071'::numeric)`,
+		`(a = '1e131071'::decimal)`,
+		`(a = ANY ('{1e131071,1e131071}'::numeric[]))`,
+		`(a = ANY (ARRAY['1e131071']::numeric[]))`,
+		`(a = ('1e131071'::text)::numeric)`,       // through an intervening safe cast
+		`(a = '1e99999999999999999999'::numeric)`, // exponent digit run overflows a plain int
+		`(a = '1e-131071'::numeric)`,              // a signed exponent
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	ordinary := []string{
+		`(a = '1e6'::numeric)`,
+		`(a = '1e1000'::numeric)`, // exactly at the bound
+		`(a = ANY ('{1,2,3}'::numeric[]))`,
+		`(a = ANY (ARRAY['5']::numeric[]))`,
+		`(a = '1e+x'::numeric)`, // an 'e' with no digits after its sign is not an exponent at all
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsNulByteInStringLiteral pins
+// client-destination-trust.md CT-1: Postgres refuses a whole statement
+// containing a NUL byte in a string literal ("invalid byte sequence"), so
+// an accepted CHECK carrying one would fail the mirror's ADD CONSTRAINT
+// outright instead of being recorded as a CT-6 drop. Rejecting it here
+// keeps that outcome a recorded drop, not a failed statement.
+func TestSafeCheckExpression_RejectsNulByteInStringLiteral(t *testing.T) {
+	expr := "(a = 'x\x00y')"
+	wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+}
+
+// TestSafeCheckExpression_RejectsQuotedANDAsKeyword pins
+// client-destination-trust.md CT-1: isKeyword's "!t.quoted" guard is
+// load-bearing on its own. A double-quoted "AND"
+// between two parenthesized comparisons is a name, not the AND keyword —
+// Postgres itself reads a quoted word as a plain identifier — so the
+// expression must reject as trailing input, not silently accept as if the
+// two comparisons were joined.
+func TestSafeCheckExpression_RejectsQuotedANDAsKeyword(t *testing.T) {
+	expr := `(a > 0) "AND" (b > 0)`
+	wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+}
+
+// TestSafeCheckExpression_RejectsExcessiveNestingInArrayParenWrapper pins
+// client-destination-trust.md CT-1(c). The OTHER existing depth test for
+// this wrapper
+// (TestSafeCheckExpression_RejectsExcessiveNesting's "deeply nested
+// ARRAY-literal parenthesis wrapper" case) never closes its parentheses, so
+// it always rejects at end of input ("expected an ARRAY[...] literal")
+// without ever exercising enterDepth/exitDepth in parseArrayLiteral's own
+// parenthesis branch. This case closes every parenthesis around a genuine
+// ARRAY[1], so a mutant that deletes that enterDepth/exitDepth pair would
+// let it through instead of rejecting for nesting.
+func TestSafeCheckExpression_RejectsExcessiveNestingInArrayParenWrapper(t *testing.T) {
+	expr := "(a = ANY (" + strings.Repeat("(", 250) + "ARRAY[1]" + strings.Repeat(")", 250) + "))"
+	err := pgcheck.SafeCheckExpression(expr)
+	wantUnsupported(t, expr, err)
+	var unsafeErr *pgcheck.UnsafeExpressionError
+	if errors.As(err, &unsafeErr) && unsafeErr.Construct != "nesting" {
+		t.Errorf("UnsafeExpressionError.Construct = %q, want %q (must reject for DEPTH, not end of input or an unbalanced parenthesis)", unsafeErr.Construct, "nesting")
+	}
+
+	moderate := "(a = ANY (" + strings.Repeat("(", 50) + "ARRAY[1]" + strings.Repeat(")", 50) + "))"
+	if err := pgcheck.SafeCheckExpression(moderate); err != nil {
+		t.Errorf("SafeCheckExpression(50 nested parens around an ARRAY literal) = %v, want nil", err)
+	}
+}
+
+// TestSafeCheckExpression_TrimsMultipleTrailingSigns pins
+// client-destination-trust.md CT-1: scanOperatorRun's trim loop must run
+// more than once. "=+-" needs TWO trim steps to reach
+// the recognized "=" operator (Postgres reads the run as "=", "+", "-" in
+// sequence): a mutant that reduces the loop to a single step would trim
+// only the trailing '-', leaving the unrecognized two-character run "=+".
+func TestSafeCheckExpression_TrimsMultipleTrailingSigns(t *testing.T) {
+	expr := `(a =+- 1)`
+	if err := pgcheck.SafeCheckExpression(expr); err != nil {
+		t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+	}
+}
+
+// TestSafeCheckExpression_RejectsArrayCastOfAlreadyArrayElement pins the
+// CRITICAL finding from the fifth adversarial review
+// (client-destination-trust.md CT-1(h)): parseArrayCastSuffix used to call
+// checkCastSafety with its OWN cast's type name already stripped of "[]",
+// so checkCastSafety could never detect that cast as array-suffixed. An
+// element that is itself already array-shaped — its own text cast to an
+// array type inside the ARRAY[...] item, tracked by
+// literalValue.isArrayLiteral — reaching a further array cast pushed
+// outside the constructor went unchecked: accepted, verified on live
+// Postgres 17.10, and evaluated PER ROW against the mirror clock.
+func TestSafeCheckExpression_RejectsArrayCastOfAlreadyArrayElement(t *testing.T) {
+	cases := []string{
+		`(ts = ANY (ARRAY['{now}'::text[]]::timestamp[]))`,
+		`(ts <> ALL (ARRAY['{now}'::text[]]::timestamp[]))`,
+		`(ts = ANY (ARRAY['{now}'::text[]]::timestamp without time zone[]))`,
+		`(ts = ANY (ARRAY['{now}'::text[]]::timestamptz[]))`,
+		`(d = ANY (ARRAY['{today}'::text[]]::date[]))`,
+		`(t = ANY (ARRAY['{allballs}'::text[]]::time[]))`,
+		`(ts = ANY (ARRAY['{infinity}'::text[]]::timestamp[]))`,
+		`(ts = ANY ((ARRAY['{now}'::text[]])::timestamp[]))`,                   // paren-wrapped
+		`(ts = ANY (ARRAY['{now}'::text[]]::date[][]))`,                        // double suffix
+		`(ts = ANY (ARRAY[('{now}'::text[])::timestamp without time zone[]]))`, // pgintrospect.NormalizeCheckExpression's own deparse of the first case
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// The fix bounds the VALUE, not every element that went through an
+	// inner array cast: a non-temporal, non-numeric target still accepts.
+	ordinary := []string{
+		`(ts = ANY (ARRAY['{now}'::text[]]::text[]))`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsDisguisedZeroDivisorByArithmetic pins
+// client-destination-trust.md CT-1(h): a divisor spelled as a constant
+// arithmetic combination — not a single bare "0" — must still reject.
+// Postgres const-folds the divisor before OR can short-circuit around it,
+// so ONE accepted CHECK like this fails EVERY rehearsal INSERT on its
+// table with "division by zero", an availability loss CT-6 never records
+// because CT-1 accepted the constraint.
+//
+// An earlier version of this check evaluated the combination itself, in
+// float64, to decide whether it reduced to zero. float64 disagrees with
+// Postgres's exact NUMERIC type in both directions: it rounds
+// "0.1 + 0.2 - 0.3" to a nonzero residue where Postgres's exact arithmetic
+// gives precisely zero (a real zero divisor the float64 fold missed), and
+// it rounds two adjacent large operands to the same value where their true
+// difference is a harmless 1 (a safe divisor the float64 fold rejected).
+// This grammar no longer tries to evaluate a constant divisor at all: a
+// divisor built from more than one literal is rejected outright unless a
+// column reference appears somewhere in it (parseMul,
+// literalValue.hasColumnRef). That rule can never mis-round a value it
+// never computes, at the cost of also rejecting an arithmetic combination
+// that is provably nonzero, such as "1e308 * 10 - 1e308 * 10" read
+// literally as two IDENTICAL sub-expressions, or the tiny-but-nonzero
+// "1e-320 * 1e-320" — both fall on the DROP side, which CT-6 already
+// treats as a normal, recorded outcome, never a broken run.
+func TestSafeCheckExpression_RejectsDisguisedZeroDivisorByArithmetic(t *testing.T) {
+	cases := []string{
+		`((a > 100) OR (1/(1-1) = 1))`,
+		`(a / (0+0) > 1)`,
+		`(a / (0*1) > 1)`,
+		`(a % (1-1) = 0)`,
+		`(a / (0::numeric+0) > 1)`,
+		`(a / (1+1) > 0)`,
+		`(a / (3-1) > 0)`,
+		`(a / (1*2) > 0)`,
+		// The exact-numeric-vs-float64 divergence a prior fold used to
+		// evaluate in float64: every one of these is a constant
+		// combination with no column reference, so the structural rule
+		// rejects it regardless of what it would compute to.
+		`(a / ('0'::numeric + 0) > 1)`,
+		`(a / (0 * 1e1000) > 1)`,
+		`(a / (1e1000 - 1e1000) > 1)`,
+		`(a / (1e308 * 10 - 1e308 * 10) > 1)`,
+		`(a / (0.1 + 0.2 - 0.3) > 1)`,
+		`(a / (1/1 - 1) > 1)`,
+		`(a / (99999999999999999999999 - 99999999999999999999998) > 1)`,
+		`(a / (1e-320 * 1e-320) > 1)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// A single literal, whatever its own text, and a column-based divisor
+	// this grammar never tries to fold at all, must still accept.
+	ordinary := []string{
+		`(a / (b-1) > 0)`,
+		`(a / 2 > 0)`,
+		`(a / other_col > 0)`,
+		`(a / (b + 1) > 0)`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsNulByteInQuotedIdentifier pins CONCERN 3
+// (the fifth adversarial review, client-destination-trust.md CT-1):
+// scanQuotedIdent copied any byte between its quotes, including a NUL,
+// while scanStringLiteral's identical scan was already checked. Via pgx
+// (this repo's driver) a NUL byte fails the whole statement closed; via
+// libpq the statement truncates at the NUL and the remaining SQL is
+// swallowed into the identifier — neither is a recorded CT-6 drop.
+func TestSafeCheckExpression_RejectsNulByteInQuotedIdentifier(t *testing.T) {
+	expr := "(\"a\x00b\" = 1)"
+	wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+}
+
+// TestSafeCheckExpression_BoundsNumericModifierTighterThanTypeModifier
+// pins NIT 6 (the fifth adversarial review, client-destination-trust.md
+// CT-1(f)): maxTypeModifier (10,000) exceeds Postgres's own NUMERIC
+// precision cap (1,000), so an accepted numeric(N) with N between the two
+// bounds always fails ADD CONSTRAINT — a drop would have been cheaper.
+// maxModifierFor now bounds a numeric/decimal cast tighter than every
+// other type that takes a modifier.
+func TestSafeCheckExpression_BoundsNumericModifierTighterThanTypeModifier(t *testing.T) {
+	rejects := []string{
+		`(a = (0)::numeric(1001))`,
+		`(a = (0)::decimal(1001))`,
+		`(a = (0)::numeric(10, 1001))`,
+	}
+	for _, expr := range rejects {
+		t.Run(expr, func(t *testing.T) {
+			wantUnsupported(t, expr, pgcheck.SafeCheckExpression(expr))
+		})
+	}
+	// Exactly at the tighter bound still accepts; a non-numeric type is
+	// still governed by the wider maxTypeModifier bound, unaffected by
+	// numeric's own tighter one.
+	ordinary := []string{
+		`(a = (0)::numeric(1000))`,
+		`(a = ''::varchar(10000))`,
+	}
+	for _, expr := range ordinary {
+		t.Run(expr, func(t *testing.T) {
+			if err := pgcheck.SafeCheckExpression(expr); err != nil {
+				t.Errorf("SafeCheckExpression(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_ThreadingSurvivesEveryPassOrClearSite pins
+// CONCERN 5 (the fifth adversarial review, client-destination-trust.md
+// CT-1(h) and §4.2): four sites where the literalValue thread is passed or
+// cleared, enumerated independently of the source rather than found by
+// iterating it, each pinned by an input that is a real Postgres expression
+// reading the mirror clock. The equivalent SCALAR-path mutation for the
+// first two was already caught before this review; these are the sites
+// that were not.
+func TestSafeCheckExpression_ThreadingSurvivesEveryPassOrClearSite(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{"COLLATE branch must not clear the thread (parseCast)", `(ts = 'now' COLLATE "C"::timestamp)`},
+		{"parenthesized list-item branch must forward the thread (parseLiteralItemValue)", `(ts = ANY (ARRAY[('now')::date]))`},
+		{"baseTypeName must strip every '[]' suffix, not only one", `(ts = '{now}'::timestamp[][])`},
+		{"parseArrayCastSuffix must check every cast in a chain, not only the first", `(ts = ANY (ARRAY['now']::text[]::timestamp[]))`},
+		{"parseArrayOperand must check every cast in a chain, not only the first", `(ts = ANY ('{now}'::text[]::timestamp[]))`},
+		{"stringLiteralExceedsNumericExponent must scan every occurrence, not only the first", `(b = ANY ('{1e2,1e131071}'::numeric[]))`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wantUnsupported(t, tc.expr, pgcheck.SafeCheckExpression(tc.expr))
+		})
+	}
+}
+
+// TestSafeCheckExpression_RejectsEveryReservedWord pins the COMPLETE
+// reserved-word list at a hardcoded copy, independent of the reservedWords
+// slice the source defines. A test that instead ITERATES the source slice
+// cannot catch a word deleted from it — the loop simply stops offering
+// that word as a sub-test — which is exactly how deleting 82 of roughly 90
+// entries once left the suite green. This list is written down here on
+// purpose, kept in sync with reservedWords by hand: a real deletion from
+// the source now leaves a word this test still tries, and still expects
+// rejected.
+func TestSafeCheckExpression_RejectsEveryReservedWord(t *testing.T) {
+	words := []string{
+		"AND", "OR", "NOT", "IS", "IN", "BETWEEN", "LIKE", "ILIKE",
+		"ANY", "ALL", "ARRAY", "DISTINCT", "FROM",
+		"CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP",
+		"LOCALTIME", "LOCALTIMESTAMP",
+		"CURRENT_ROLE", "CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER",
+		"CURRENT_CATALOG", "CURRENT_SCHEMA",
+		"ANALYSE", "ANALYZE", "AS", "ASC", "ASYMMETRIC", "BOTH", "CASE",
+		"CAST", "CHECK", "COLLATE", "COLUMN", "CONSTRAINT", "CREATE",
+		"DEFAULT", "DEFERRABLE", "DESC", "DO", "ELSE", "END", "EXCEPT",
+		"FETCH", "FOR", "FOREIGN", "GRANT", "GROUP", "HAVING", "INITIALLY",
+		"INTERSECT", "INTO", "LATERAL", "LEADING", "LIMIT", "OFFSET", "ON",
+		"ONLY", "ORDER", "PLACING", "PRIMARY", "REFERENCES", "RETURNING",
+		"SELECT", "SOME", "SYMMETRIC", "TABLE", "THEN", "TO", "TRAILING",
+		"UNION", "UNIQUE", "USING", "VARIADIC", "WHEN", "WHERE", "WINDOW",
+		"WITH",
+		"AUTHORIZATION", "BINARY", "COLLATION", "CONCURRENTLY",
+		"CROSS", "FREEZE", "FULL", "INNER", "ISNULL", "JOIN", "LEFT",
+		"NATURAL", "NOTNULL", "OUTER", "OVERLAPS", "RIGHT", "SIMILAR",
+		"TABLESAMPLE", "VERBOSE",
+	}
+	for _, w := range words {
+		t.Run(w, func(t *testing.T) {
+			expr := "(" + w + " > 0)"
+			if err := pgcheck.SafeCheckExpression(expr); err == nil {
+				t.Errorf("SafeCheckExpression(%q) = nil, want a rejection: %q is a reserved word", expr, w)
+			}
+		})
+	}
+}
+
+// TestSafeCheckExpression_MaxExpressionLengthBoundary pins the exact byte
+// count client-destination-trust.md CT-1(c) documents, 4096, HARDCODED
+// rather than read from maxExpressionLength: a test built from the same
+// constant it is checking cannot catch that constant's own value shifting
+// (a mutation from 4096 to 4105 is exactly the kind this closes), only a
+// change to the comparison around it.
+func TestSafeCheckExpression_MaxExpressionLengthBoundary(t *testing.T) {
+	const documentedLimit = 4096
+	build := func(total int) string {
+		const prefix, suffix = "(a = ", ")"
+		return prefix + strings.Repeat("1", total-len(prefix)-len(suffix)) + suffix
+	}
+
+	atLimit := build(documentedLimit)
+	if len(atLimit) != documentedLimit {
+		t.Fatalf("test setup: built %d bytes, want exactly %d", len(atLimit), documentedLimit)
+	}
+	if err := pgcheck.SafeCheckExpression(atLimit); err != nil {
+		t.Errorf("SafeCheckExpression(%d bytes) = %v, want nil: exactly at the documented limit must still accept", len(atLimit), err)
+	}
+
+	overLimit := build(documentedLimit + 1)
+	if err := pgcheck.SafeCheckExpression(overLimit); err == nil {
+		t.Errorf("SafeCheckExpression(%d bytes) = nil, want a rejection: one byte over the documented limit must reject", len(overLimit))
+	}
+}
+
+// TestSafeCheckExpression_MaxParseDepthBoundary pins the exact nesting
+// level client-destination-trust.md CT-1(c) documents, 200, hardcoded for
+// the same reason TestSafeCheckExpression_MaxExpressionLengthBoundary is.
+func TestSafeCheckExpression_MaxParseDepthBoundary(t *testing.T) {
+	const documentedDepth = 200
+
+	atLimit := strings.Repeat("(", documentedDepth) + "a > 0" + strings.Repeat(")", documentedDepth)
+	if err := pgcheck.SafeCheckExpression(atLimit); err != nil {
+		t.Errorf("SafeCheckExpression(%d nested parens) = %v, want nil: exactly at the documented depth must still accept", documentedDepth, err)
+	}
+
+	overLimit := strings.Repeat("(", documentedDepth+1) + "a > 0" + strings.Repeat(")", documentedDepth+1)
+	if err := pgcheck.SafeCheckExpression(overLimit); err == nil {
+		t.Errorf("SafeCheckExpression(%d nested parens) = nil, want a rejection: one level over the documented depth must reject", documentedDepth+1)
+	}
+}
+
+// TestSafeCheckExpression_AcceptsHugeNonZeroDivisor pins the "number too
+// large for float64" edge of the division-by-literal-zero check
+// (client-destination-trust.md CT-1): a divisor with far more digits than
+// float64 can represent must not be misread as zero, and must not panic.
+func TestSafeCheckExpression_AcceptsHugeNonZeroDivisor(t *testing.T) {
+	expr := "(a / " + strings.Repeat("9", 320) + " > 0)"
+	if err := pgcheck.SafeCheckExpression(expr); err != nil {
+		t.Errorf("SafeCheckExpression(huge non-zero divisor) = %v, want nil", err)
+	}
+}
+
+// FuzzSafeCheckExpression checks the one property a table of named cases
+// cannot: that SafeCheckExpression never panics, for any input at all. A
+// panic here is the same class of fault CT-1(c) exists to close
+// (client-destination-trust.md) — the classifier must return an ordinary
+// error for hostile input, never crash the process running it. The return
+// value itself is not asserted: this fuzz target explores byte sequences no
+// named case would think to write.
+func FuzzSafeCheckExpression(f *testing.F) {
+	seeds := []string{
+		trialBatchSizeDensity,
+		trialBatchSizeDensityUnit,
+		trialPackagingNetContent,
+		trialSecondaryUnitCount,
+		trialRecyclingRate,
+		trialVariantRoute,
+		rejectPgSleep,
+		rejectLoImport,
+		rejectJSONBTypeof,
+		rejectLength,
+		"(pg_read_file--\n('/etc/passwd') IS NOT NULL)",
+		"(pg_sleep/*\nmulti\nline\n*/(1) IS NOT NULL)",
+		"((a)::regclass IS NOT NULL)",
+		"(name ~~ 'a%')",
+		"(name !~~* 'a%')",
+		`("Order" > 0)`,
+		`("Ord""er" > 0)`,
+		"(årsmängd > 0)",
+		"(a IS DISTINCT FROM 5)",
+		"(a <> ALL (ARRAY[1, 2]))",
+		strings.Repeat("(", 600),
+		strings.Repeat("NOT ", 600) + "a",
+		"",
+		"   ",
+		"(a > 1",
+		"(a::numeric(10, 2) > 0)",
+		"(a > \xff)",
+		"(€ > 0)",
+		"(name <> CURRENT_USER)",
+		`(a = ''::char(10485760))`,
+		`(n = ANY (ARRAY[(1)::numeric, (2)::numeric]))`,
+		`(name ~~- 'x')`,
+		`("true"('x') = 'X')`,
+		// The CT-1(g) adversarial shape: a long run of alternating '+' and
+		// '-' with no spaces used to cost the CUBE of its length in the
+		// operator scanner (4.22 CPU-seconds at 4093 bytes). Seeding it
+		// keeps fuzzing from rediscovering the same regression by chance.
+		"(a = " + strings.Repeat("+-", 2043) + "1)",
+		`(a %- 1 = 0)`,
+		`(a = 1e131071)`,
+		`(ts < 'now'::timestamp)`,
+		`(a / 0 > 1)`,
+		`(flag IS NOT UNKNOWN)`,
+		`(t = ANY ('{a,b}'::text[]))`,
+		`((t COLLATE "C") > 'a'::text)`,
+		// client-destination-trust.md CT-1(h): each of these is a bypass of an
+		// earlier fix, defeated by a single pair of parentheses, a whole-array
+		// cast, or a string cast to numeric. Seeding them keeps fuzzing from
+		// rediscovering the same regressions by chance.
+		`(ts < ('now'::text)::timestamp without time zone)`,
+		`(a = (('now'))::date)`,
+		`(ts = ANY (ARRAY['now']::timestamp[]))`,
+		`(ts_arr = '{now}'::timestamp[])`,
+		`(a = '1e131071'::numeric)`,
+		`(a = ANY ('{1e131071,1e131071}'::numeric[]))`,
+		`((a > 100) OR (1/(0) = 1))`,
+		`(a / '0'::numeric > 1)`,
+		"(a = 'x\x00y')",
+		`(a > 0) "AND" (b > 0)`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, expr string) {
+		_ = pgcheck.SafeCheckExpression(expr)
+	})
+}


### PR DESCRIPTION
## Why

A destination contract carries each table's CHECK constraints as raw SQL expression text. The platform identifier-quotes every other part of the mirror's DDL, but a SQL expression allows no quoting. It renders verbatim into `CREATE TABLE`. The platform installs it on the mirror via `ADD CONSTRAINT ... NOT VALID`, and rehearsal INSERTs then evaluate it as a privileged role. When the destination is not one we own, that text is input we did not write.

Spec: `knyta-documentation/product/client-destination-trust.md`, decision CT-1.

## What

`pgcheck.SafeCheckExpression` classifies an expression against a conservative safe grammar. The grammar allows column references, literals, and comparison, boolean, and arithmetic operators. It allows `IS [NOT] NULL`, `IS [NOT] DISTINCT FROM`, the deparsed LIKE-family operators, `= ANY (ARRAY[...])`, and `<> ALL (...)`. It allows casts to an allowlist of built-in types. Any function call rejects, as does any construct the grammar does not name. It returns a typed error with sentinels so a consumer can tell a refusal from a fault.

The grammar targets `pg_get_expr` output, the form the platform actually receives. It carries explicit bounds on input length, parser depth, type modifiers, numeric magnitude, and operator-run length. Both the expression and the classifier's own cost stay bounded.

## Read this before relying on it

Section 2.1 of the spec records the posture: **this is defense in depth, not a complete boundary.** Six adversarial reviews found thirteen critical bypasses. The last three were pure semantic divergence from Postgres: braces are datetime field delimiters, an underscore is a digit separator, and float arithmetic disagrees with exact numeric. The classifier reached full coverage, 52M clean fuzz executions, most mutations killed, and linear cost. It still carried those bypasses, because it must model the database's own semantics, and every approximation is a gap.

The platform's real trust assumption is therefore the destination OWNER. Point it at our own destinations or a trusted customer's. Before an untrusted owner, the spec names the two alternatives to build instead.

An independent review ran a 40-case differential test against a real Postgres 16: no false accepts, and cost at 4 KB adversarial input measured 8-96 microseconds per call.

## Status

No production callers exist yet. The drop-and-record consumer is CT-6, in the orchestrator. Downstream impact on the orchestrator today is zero: only `pgcheck.MembershipSet` is consumed, and this PR changes no existing file.
